### PR TITLE
Add 2.3.0 changed-contract + 2.3.4 boundary-assumption sweeps to /implement

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ lib/                     # retrospective-loop helpers (*.sh, *.jq), preflight.sh
                          #   intervention-surfaces.md, test/
 .github/                 # optional cloud tier: workflows + composite actions
                          #   + project-config.example.yml
-docs/                    # cloud-setup.md
+docs/                    # cloud-setup.md, implement-skill.md
 install.sh               # one-command cloud-tier install/update for consumer repos
 ```
 

--- a/docs/implement-skill.md
+++ b/docs/implement-skill.md
@@ -1,0 +1,60 @@
+# `/implement` skill — Phase 2.3 sweep discipline
+
+**Skill:** `skills/implement/SKILL.md` (Phase 2.3, *Implement*)
+
+The `/implement` orchestrator runs a set of mandatory **sweeps** in Phase 2.3, after writing the
+code and before running tests. Each sweep closes a class of blast-radius bug that survives `git diff`
+review because nothing is *syntactically* broken — the affected lines still compile, parse, or run;
+they are only *semantically* stale. This doc is the internal-docs counterpart of that section: it
+records *why* each sweep exists so the skill text can stay terse.
+
+## The sweeps
+
+| Sweep | Triggers on | Closes |
+|---|---|---|
+| 2.3.0 Changed-contract | a change that **modifies** a signature, renames/moves a symbol, tightens a validator, or alters a classifying predicate | dependent sites left on the *old* contract (other predicate branches, sibling callers, fixtures/assertions) |
+| 2.3.1 Orphaned-setup | a **deletion** of code | setup lines (a dependency fetch, lookup, computed local, import) whose only consumer was the deleted code |
+| 2.3.2 Stranded-dependents | a **deletion** of a method, file, route, or page | references *outside* the diff the deletion stripped of purpose (callerless public methods, dead args, surviving inbound links) |
+| 2.3.3 Convention-compliance | any code the diff **added or modified** | `CLAUDE.md` convention violations in touched code |
+| 2.3.4 Boundary-assumption | any diff that **depends on** a fact about something it does not own | claims about a dependency version, the supported runtime, a sibling producer's output, or the real host that were asserted from memory instead of verified |
+
+2.3.1–2.3.3 trigger on *deletion* or *addition*. **2.3.0** fills the gap for *modification*: changing a
+contract is just as blast-radius-prone as deleting one, but it is harder to catch because every
+dependent site still compiles. The common failure mode is fixing the originating site but not its
+siblings — a predicate corrected in one branch but not the others, one caller that plumbs a new
+per-request input while its sibling sharing the same object does not, or a fixture/assertion left
+encoding the old contract. **2.3.4** is orthogonal to all of the above: it is not about the diff's own
+consistency but about facts the diff *relies on* across a boundary it does not control.
+
+## Changed-contract sweep (2.3.0) and the post-merge re-sweep
+
+The skill spells out the three checks (predicate variants, sibling call sites, fixtures/assertions).
+The *why*: the common failure mode is fixing the originating site but not its siblings — and those
+siblings still compile, so `git diff` review misses them.
+
+The sweep must also be **re-run after any merge or rebase of `main`** — the skill's Error Handling
+conflict-recovery path (`git pull --rebase origin {branch}`) and anywhere else the run pulls in
+`main`. A clean textual merge is not a clean semantic merge: `main` can arrive with a fixture, call
+site, or assertion (often from a concurrently-merged PR) that the change's new contract now rejects,
+merged cleanly with no conflict. A newly-arrived violating site is a defect in *this* PR, not a
+follow-up.
+
+## Boundary-assumption sweep (2.3.4)
+
+The four boundary kinds and how to verify each are in the skill (and summarized in the table above).
+The *why*: these bugs ship clean and pass the author's own tests — because the tests encode the same
+wrong assumption — so a green run is not confirmation, and a test assertion *about* a boundary is
+itself an unverified claim. A boundary that genuinely cannot be verified in-environment is never
+asserted as true: it is recorded with a `--reflection` note and, only when a specific acceptance
+criterion's verification depends on it, retagged `(post-merge)`.
+
+## Scope boundary between Phase 2.3.2 and Phase 4.1
+
+The 2.3.2 stranded-dependents sweep covers references in **code, config, and routing tables** — things
+that break behavior at runtime if left dangling (a surviving `href` to a deleted page, a call site
+still passing dead arguments). It does **not** cover prose references to the deleted symbols/paths
+inside `docs/internal/` (descriptions, walkthroughs, install steps). Those are handled by the Phase
+4.1 documentation pass, which spawns the `devflow:docs` subagent after the code is committed. If a
+2.3.2 grep turns up only docs hits, the skill notes them and moves on rather than editing
+`docs/internal/` from Phase 2.3 — the docs pass has the full picture (shipped code, not just the
+plan) and the right mandate to update prose.

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -295,6 +295,18 @@ Now implement the feature yourself. You have full context:
 
 Write the code. Follow the patterns and conventions described in `CLAUDE.md`. As plan steps complete, tick them off: `workpad.py update $ISSUE_NUMBER --tick-plan "{substring of completed step}"`.
 
+#### 2.3.0 Changed-contract sweep (mandatory whenever the change modifies a signature, renames/moves a symbol, tightens a validator, or changes a routing/branch predicate)
+
+2.3.1–2.3.3 below all trigger on *deletion* or *addition*. Modifying a contract is just as blast-radius-prone, but it slips past `git diff` review because every dependent site still compiles — the call resolves, the fixture parses, the assertion runs — and is only *semantically* stale. After any change that modifies a signature, renames or moves a symbol, tightens a validator, or alters a predicate that classifies input, before running tests, grep the whole repo for every dependent site and bring each into line:
+
+1. **All variants of a changed predicate.** If you changed a predicate that classifies input (e.g. a check for one specific status, type, or keyword), enumerate every value the predicate must now accept or reject and confirm every runner/branch routes them identically. A predicate fixed at one site but not its siblings is a defect in *this* PR, not a follow-up.
+2. **Sibling call sites of a shared dependency.** If you wrapped or extended a shared object (e.g. added a per-request guard or a new error branch), grep for every caller that consumes that object and confirm each one plumbs the new inputs and handles the new branch — not just the site that motivated the change.
+3. **Fixtures and assertions matching the old contract.** If you tightened a validator or moved output between streams (e.g. stdout↔stderr), grep tests for every fixture value and assertion that encoded the old contract — both in the files you touched *and* in shared `conftest.py` / helper modules — and update them. A fixture under a newly-stricter validator, or an assertion on a stream you rerouted, is a CI failure waiting for the next merge.
+
+A modify / rename / reroute is not done until grepping for the old symbol, predicate value, stream, or contract returns only the intended sites.
+
+**Re-run this sweep after any merge or rebase of `main`.** A clean *textual* merge is not a clean *semantic* merge: `main` may have added a fixture, call site, or assertion (often from a concurrently-merged PR) that your new contract now rejects, and git merges it cleanly without ever surfacing the conflict. After any `git merge main` / `git pull --rebase` the run performs (including the Error Handling conflict-recovery path), re-run steps 1–3 against the newly-arrived sites and treat any new site that violates the change's contract as a defect in *this* PR. See [`docs/implement-skill.md`](../../docs/implement-skill.md) for why each Phase 2.3 sweep exists.
+
 #### 2.3.1 Orphaned-setup sweep (mandatory whenever the change deletes code)
 
 Removing a call site, a UI block, a branch, or a whole function almost always strands the *setup lines* that fed it — a service-locator/dependency fetch, a query or record lookup, a computed local, an import or `use` clause — whose only consumer was the code you just deleted. These survive `git diff` review because nothing is *syntactically* broken; the line is simply dead. Reviewers keep flagging them as "optional cleanup", which means the PR shipped imperfect.
@@ -339,6 +351,26 @@ After implementing, before running tests, do this sweep:
 4. Do not reformat or rename code the diff didn't otherwise touch — this sweep covers only lines/functions/files your change already modified or introduced, never a repo-wide cleanup.
 
 Treat a known convention violation in touched code as a defect in **this** PR, not a pre-existing-style excuse — if the diff touched it, it leaves `CLAUDE.md`-compliant.
+
+#### 2.3.4 Boundary-assumption verification sweep (mandatory)
+
+2.3.0–2.3.3 keep the diff internally consistent (contract changes propagated, no dead lines, no stranded dependents, no convention drift). This sweep targets a different defect class: a claim your diff *depends on* about something **outside the lines you wrote** that you asserted from memory instead of verifying against the source of truth. These ship clean — the code reads fine in `git diff` review, and they pass your own tests (because the tests encode the same wrong assumption) — so they only surface as a `/devflow:review` REJECT or a human post-merge patch. The cheapest place to catch them is here, before you commit.
+
+A **boundary assumption** is any factual claim the diff relies on about something the diff does not own. The recurring kinds:
+
+- **Dependency-version behavior** — a symbol, export, signature, or runtime behavior of a third-party package. Verify it against the **pinned range's** actual installed source/changelog, not the latest docs (e.g. importing a symbol that is only public in a version newer than your dependency pin permits, so an in-constraint install breaks at import).
+- **Supported-runtime behavior** — a behavior of the language, standard library, or interpreter. Verify it holds across the project's **entire** documented supported-runtime range, not just the version in your hands.
+- **Sibling-producer output** — the shape or content of data produced by another module your code consumes. Verify it by reading the **production producer**, not by assuming a field is populated (e.g. consuming a field that the producer hard-codes empty).
+- **Real host/runtime environment** — a path, base URL, network namespace, or sandbox constraint of where the code actually runs. Verify against the **real host**, not the local dev shell (e.g. relative asset paths that resolve locally but 404 under the deployed base URL).
+
+After implementing, before running tests, do this sweep:
+
+1. From `git diff --staged -U0` (or `git diff -U0`), list every claim the diff depends on that falls into one of the four kinds above. The diff is the *trigger* for finding which boundaries the change now relies on — a boundary's definition site (an unchanged import, a producer module, a version pin) usually sits in context `-U0` doesn't print, so follow each claim to its actual source. Purely-internal claims (a local you just wrote, a function defined in the same diff) are **out of scope** — this sweep is only about boundaries you don't own.
+2. For each claim, verify it against the **actual source of truth** — the pinned version's installed source/changelog, the producer module, the documented supported-runtime range across *all* of it, the real host — never from memory.
+3. **A test assertion about a boundary is itself an unverified claim.** A test that asserts a wrong boundary value still passes — it encodes the bug rather than catching it — so a green run at 2.4 is not confirmation. When the diff adds or changes a test that asserts a boundary value, verify that value against the same source of truth here.
+4. If the code is wrong, fix it. If a boundary genuinely **cannot** be verified in-environment, do **not** assert it as true: always record the gap with `workpad.py update $ISSUE_NUMBER --reflection "unverified boundary: {claim} — needs {live env} to confirm"` so it is visible to review and the merger. If — and only if — a specific acceptance criterion's verification depends on that boundary, additionally retag that criterion `(post-merge)` (per Phase 1.4, via the Phase 3.4 `--rewrite-ac` retag pattern) so the 3.4 gate doesn't block on a live-only check. `(post-merge)` covers code that ships correct but can only be *verified* live — it is never a way to wave through a boundary you suspect is wrong (that is a blocker).
+
+Treat an unverified boundary assumption as a defect in **this** PR, not a review-engine problem to be caught downstream — if the diff depends on it, verify it here or route it to `(post-merge)` with a reflection note.
 
 ### 2.4 Test
 
@@ -576,7 +608,7 @@ Then output the PR URL and a one- or two-line summary of what was accomplished.
 Before reporting completion, verify ALL phases executed:
 
 - Phase 1: Issue fetched, branch exists, workpad initialized with Acceptance Criteria mirrored
-- Phase 2: For `bug`-labelled issues, reproduction signal recorded; if the issue spans multiple PRs, the 2.2.5 scope-adjustment rule was applied and the workpad's Acceptance Criteria section now contains only in-scope items; code committed and pushed
+- Phase 2: For `bug`-labelled issues, reproduction signal recorded; if the issue spans multiple PRs, the 2.2.5 scope-adjustment rule was applied and the workpad's Acceptance Criteria section now contains only in-scope items; the 2.3.0 changed-contract sweep (re-run after any merge/rebase) and the 2.3.4 boundary-assumption sweep both ran over the diff — each cross-boundary claim verified against its source of truth, or routed to `(post-merge)` with a reflection note; code committed and pushed
 - Phase 3: Draft PR created, `/simplify` ran (fixes committed if any), `/review-and-fix` ran, acceptance criteria gate passed (PR still draft)
 - Phase 4: If any criteria were deferred in 2.2.5, follow-up issue(s) filed in 4.0; if /devflow:review-and-fix emitted a deferrals manifest, follow-up issue(s) filed in 4.0.5 and the manifest hydrated; docs updated and "Documented" label applied; PR description generated via `/pr-description`; PR marked ready; workpad finalized with `Status: Complete`
 
@@ -590,7 +622,7 @@ Verify each `Status` PATCH actually landed at the time it was issued (see the Up
 ## Error Handling
 
 - **Empty steps**: If any phase produces no file changes, skip the commit and continue. Do not create empty commits.
-- **Git conflicts**: If a push fails due to conflicts, run `git pull --rebase origin {branch}` and retry once. If it fails again, stop and report the error.
+- **Git conflicts**: If a push fails due to conflicts, run `git pull --rebase origin {branch}` and retry once. If it fails again, stop and report the error. After any successful rebase here, re-run the Phase 2.3.0 changed-contract sweep against the newly-arrived sites — a clean textual rebase can still surface a fixture, call site, or assertion from `main` that the change's contract now rejects.
 - **Subagent failures**: If a subagent fails or produces no useful output, note the failure in the workpad's `Devflow Reflection` and continue to the next step. Do not retry the same subagent more than once.
 - **Permission denials**: If a Bash command is denied, note it in the workpad and continue to the next step. Never skip an entire phase because of a single denied command.
 - **Commit prefixes**: Use `docs:` for documentation, `feat:` for implementation, `fix:` for review fixes and test fixes.


### PR DESCRIPTION
Adopts two retrospective-surfaced `/implement` sweeps (generalized from sqllens PRs #163/#164 for the public plugin):

- **2.3.0 Changed-contract sweep** — 2.3.1–2.3.3 only fire on deletion/addition; this covers *modification* blast radius (signatures, renames, validators, predicates) + a post-merge/rebase re-sweep.
- **2.3.4 Boundary-assumption sweep** — verify claims the diff depends on about things it doesn't own (dependency version, supported runtime, sibling-producer output, real host) before commit.

Wired into the Error Handling rebase path and the Phase 2 Completion Checklist. Adds `docs/implement-skill.md` (why each sweep exists) and updates the README layout. Examples generalized (no sqllens internals); ran the simplify pass; 189 tests pass.