### PR TITLE
feat(create-issue): enforce decision-resolution, ban options in issue body

### DIFF
--- a/skills/create-issue/SKILL.md
+++ b/skills/create-issue/SKILL.md
@@ -7,13 +7,19 @@ argument-hint: <user-story>
 
 If `$ARGUMENTS` is empty, ask the user to describe their user story, bug report, or feature idea before proceeding.
 
+## Core principle
+
+**An issue is the output of resolved decisions — not a place to park unresolved ones.**
+
+Every decision a developer would otherwise have to guess at MUST be resolved by asking the user *before* the issue is written. Whatever the user genuinely will not or cannot resolve goes into one explicit **Blocked** section — never disguised as an "option", a "recommended approach", an "Open Question", a default, or conditional wording scattered through the body. Listing options in the issue body is the failure this skill exists to prevent.
+
 ## Completion checklist (do this first)
 
 This skill is a **pipeline that ends with a created GitHub issue** — not with a documentation report. Before doing anything else, create a TodoWrite todo list with exactly these items:
 
 1. Run `/docs-verify --report-only` and capture its findings report
-2. Clarify the user story (or consciously skip — see Step 2)
-3. Draft and create the GitHub issue (Step 3)
+2. Clarify the user story until the **Definition of Ready** is met (Step 2)
+3. Draft and create the GitHub issue, passing the **no-options gate** (Step 3)
 
 Mark each todo `in_progress` when you start and `completed` only when done. **The skill is not complete until the issue is created** — a finished `/docs-verify` report is only todo 1.
 
@@ -26,36 +32,41 @@ This verifies internal docs against the code and **returns a findings report** �
 
 `/docs-verify` is a standalone workflow, so it announces its own completion when it finishes. That signal ends *its* report (todo 1), not this skill — keep going to Step 2. Carry the findings, including any drift noted, forward into Step 3.
 
-### Step 2: Clarify user story
+### Step 2: Clarify until the Definition of Ready is met
 
-Evaluate whether the user story needs clarification based on the doc findings and the story itself.
+**Clarification is the default, not the exception.** Do not assess "is this clear enough to skip" — assess "which Definition-of-Ready facts are still unknown" and ask about those. The only way to skip a question is to already know its answer from the user story or the Step 1 findings.
 
-**General principle:** Identify gaps, ambiguities, or risks that would produce a weak or incorrect GitHub issue. If the story is clear and the feature is straightforward, skip to Step 3.
+**Definition of Ready — every item below must have a single, decided answer before you draft:**
 
-**Ask when:**
-- User story is missing who benefits or why it's needed
-- No clear scope boundary — could mean several different things
-- Doc review revealed the feature touches multiple modules or has non-obvious dependencies
-- Acceptance criteria are implied but not stated, and there are multiple valid interpretations
-- Tension between what was asked and what the codebase currently supports
+- [ ] **Problem & beneficiary** — who hits this pain and why it matters. (Not "users want export" — *which* users, doing *what*, blocked *how*.)
+- [ ] **Single coherent scope** — the issue is exactly one feature/fix. If the story bundles two or more ("export results *and* notify when ready"), ask the user whether to split; default to one issue per feature.
+- [ ] **One decided behavior per fork** — every place the story could mean different things (format, channel, trigger condition, access model, edge-case handling) has *one* chosen answer. No "or", no "either", no "default for now".
+- [ ] **One implementation approach** — where the codebase admits more than one way to build it, the user has picked one. You surface the fork and its trade-offs *in the question*, not in the issue.
+- [ ] **Concrete acceptance criteria** — you can state each as a single unconditional, testable assertion. If an AC would need a conditional ("if links are public…"), the underlying fork isn't resolved yet — go ask.
 
-**Skip when:**
-- Bug report with clear repro steps
-- Small feature with obvious scope ("add a tooltip to the X button")
-- User story already specifies behavior, scope, and edge cases
+**How to ask:**
 
-**If clarification is needed:**
-- Ask questions **one at a time**
-- Prefer multiple choice when the options are known
-- Bias toward brevity — only ask what genuinely reduces ambiguity
-- If the user says "just create it" or similar, stop and proceed to Step 3
+- Use the **AskUserQuestion** tool. Batch 2–4 related questions per call rather than one long interrogation.
+- For each question, offer concrete multiple-choice options. When the codebase or findings make one choice clearly best, list it **first** and mark it `(Recommended)` with a one-line why.
+- After each round of answers, **re-check the Definition of Ready**. If gaps remain, ask another batch. Keep going until the list is fully satisfied — do not draft with items still open.
+- Cap at ~3 rounds. If facts are still missing after that, treat the remainder as disengagement (below).
+
+**Push back once before accepting total disengagement.** If the user disengages while the issue is still *unbuildable* — no decided scope, or the single core behavior fork is still open (the ticket would be almost entirely Blocked) — do not silently produce a hollow issue. Say so plainly, once: e.g. *"As-is this issue won't be buildable — every decision is still open. Can you answer just two things: (1) is this one feature or several, and (2) <the single most defining behavior fork>? Otherwise I'll file it with everything flagged as blocked."* Ask those via one AskUserQuestion batch. If the user answers, continue clarifying; if they disengage again, proceed below. This push-back happens **at most once** — do not nag. It does not apply when only peripheral forks remain open (e.g. link expiry) — Blocked those without comment.
+
+**When the user disengages** — says "just create it", goes quiet, or answers "I don't know" / "you decide" to a Definition-of-Ready question:
+
+- Stop asking. Draft the issue from what *is* decided.
+- Every still-unresolved Definition-of-Ready item goes into the issue's **`## 🚫 Blocked — resolve before implementation`** section, phrased as a direct question with one line on why it blocks work (see template).
+- Do **not** invent a default and bury it in the body. Do **not** rephrase the open decision as an "option" or "recommended approach" elsewhere. The Blocked section is the *only* place an unresolved decision may appear.
+- "You decide" is not permission to guess silently — it is an unresolved item that belongs in Blocked, unless the choice is genuinely inconsequential to scope (e.g. a variable name).
 
 ### Step 3: Draft and create the GitHub issue
 
-Draft the issue **from the context you already hold** — the documentation findings from Step 1 (relevant files, current behavior, any drift) and the clarifications from Step 2 — doing only targeted verification reads where a specific claim needs confirming. Do not re-explore the whole codebase; the findings are your map.
+Draft the issue **from the context you already hold** — the documentation findings from Step 1 (relevant files, current behavior, any drift) and the decisions from Step 2 — doing only targeted verification reads where a specific claim needs confirming. Do not re-explore the whole codebase; the findings are your map.
 
-Follow `references/issue-template.md` for the required section structure, the quality checklist, autolink hygiene, and the exact `gh issue create` invocation. Key rules:
+Follow `references/issue-template.md` for the required section structure, the **no-options rule**, the quality checklist, autolink hygiene, and the exact `gh issue create` invocation. Key rules:
 
+- **No-options gate (run before posting):** re-read the rendered body. Outside the `## 🚫 Blocked` section it must contain **no** unresolved-decision language — no "or", "either", "alternatively", "could", "we might", "TBD", "option", "approach A vs B", "(optional)"-for-undecided, "e.g. X or Y" where X and Y are competing choices. Each acceptance criterion is one concrete unconditional assertion. If you find any such language, you skipped a decision: either ask the user now, or move it to the Blocked section. Do not post until the body is clean.
 - Create the issue **directly via `gh issue create`** piping the body through stdin — no scratch file, nothing written to the working tree.
 - **Do not add labels** — never pass `--label`.
 - Report the issue URL that `gh` prints on success.

--- a/skills/create-issue/references/issue-template.md
+++ b/skills/create-issue/references/issue-template.md
@@ -1,44 +1,91 @@
 # GitHub Issue Template & Quality Guide
 
 Reference for drafting and posting a well-structured GitHub issue. The calling skill
-(`/create-issue`) has already gathered documentation findings and clarifications — draft
-the issue **from that context**, doing only targeted verification reads where a specific
-claim needs confirming. Do not re-explore the whole codebase; the findings are your map.
+(`/create-issue`) has already gathered documentation findings and **resolved every
+in-scope decision with the user**. Draft the issue **from that context**, doing only
+targeted verification reads where a specific claim needs confirming. Do not re-explore
+the whole codebase; the findings are your map.
+
+## The no-options rule (read first)
+
+The issue describes **one decided behavior built one decided way.** A developer reading
+it must never have to choose between alternatives or fill in a gap to start work.
+
+Outside the `## 🚫 Blocked` section, the body must contain **none** of:
+
+- choice words: "or", "either / or", "alternatively", "vs", "option", "approach A vs B"
+- hedge words: "could", "we might", "we may want to", "consider", "perhaps", "possibly"
+- deferral words: "TBD", "to be decided", "for now", "Open Question(s)", "(optional)" for
+  something that is actually undecided
+- competing examples: "e.g. WeasyPrint or ReportLab" where the two are rival choices the
+  developer would have to pick between
+
+If drafting surfaces any of these, you have an unresolved decision. Resolve it with the
+user, or — only if the user has disengaged — move it verbatim into the Blocked section.
+Never leave it as prose in the body.
 
 ## Issue structure
 
-Every issue includes these sections, in this order:
+Every issue includes these sections, in this order. (`## 🚫 Blocked` appears only if
+unresolved items exist — see below.)
 
 ### Title
-Clear, descriptive, action-oriented (e.g., "Add bulk order status editing with date range filtering").
+Clear, descriptive, action-oriented, and scoped to **one** feature/fix (e.g., "Add PDF
+export for survey results"). If you are tempted to write "and" joining two features, the
+issue should have been split in Step 2 — ask the user to split before drafting.
+
+Exception: if the scope-split decision is itself unresolved because the user disengaged
+(it is the first item in `## 🚫 Blocked`), a neutral multi-feature title is acceptable —
+it honestly reflects the unresolved scope. Do not silently pick one feature to satisfy the
+title rule; that would be inventing a default the skill forbids.
 
 ### Description
-- **Problem Statement** — why is this needed? What pain point does it solve?
+- **Problem Statement** — why is this needed? Which user hits what pain.
 - **Current Behavior** — for a bug, what happens today; for a feature, what's missing.
-- **Desired Behavior** — what should happen after implementation.
+- **Desired Behavior** — the single decided behavior after implementation. State it
+  declaratively ("Owners export results as PDF"), never as a menu.
 - **User Impact** — who benefits and how.
 
 ### Technical Context
 Ground this in the documentation findings passed by the caller:
 - **Relevant Classes/Files** — specific files from the findings (verify before citing).
 - **Architecture Alignment** — how this fits existing patterns.
-- **Dependencies** — other services, modules, or features it depends on.
+- **Dependencies** — the specific service/module/library this depends on. If a library is
+  needed, name the **one** chosen (decided in Step 2), not a shortlist.
 - **Data/Schema Considerations** — schema changes, queries, or data-access patterns.
 - **Cross-layer Impact** — which layers are affected (frontend, backend, API, database).
 
 ### Acceptance Criteria
-Measurable, testable checkbox items (`- [ ]`):
-- Specific, implementable requirements.
-- Edge cases and error-handling scenarios.
+Checkbox items (`- [ ]`), each a **single unconditional, testable assertion**:
+- Specific and implementable — a developer knows exactly when it's met.
+- No conditionals tied to an undecided fork ("if links are public…"). A conditional AC
+  means the fork is unresolved — it belongs in Blocked, not here.
+- Edge cases and error-handling scenarios, stated as concrete expected behavior.
 - Performance/scalability considerations if relevant.
 - Reference project coding standards from `CLAUDE.md` if available.
 
 ### Implementation Notes
-- **Recommended Approach** — architecture patterns or design decisions.
-- **Code Patterns** — patterns already used in this codebase.
+Describe the **one** approach the user chose — not a comparison of candidates.
+- **Approach** — the decided design: the specific files to touch and how the change fits.
+- **Code Patterns** — patterns already used in this codebase to mirror.
 - **Testing Strategy** — how this should be tested.
 - **Documentation Needed** — what doc updates the change requires.
-- **Potential Gotchas** — pitfalls and architectural constraints.
+- **Potential Gotchas** — pitfalls and architectural constraints (these are warnings, not
+  unresolved choices).
+
+### 🚫 Blocked — resolve before implementation (include only if non-empty)
+The **only** place unresolved decisions may appear. Include this section solely when the
+user disengaged in Step 2 leaving Definition-of-Ready items open. Each item is a direct
+question plus one line on why it blocks work:
+
+```markdown
+## 🚫 Blocked — resolve before implementation
+- **Link access model?** Public-with-token or login-required — changes the data model and
+  the security review. Implementation cannot start until this is chosen.
+```
+
+Do not soften these into "options" or attach a default. If this section is empty, omit it
+entirely — do not write "Open Questions: none".
 
 ## Full-stack awareness
 
@@ -50,12 +97,14 @@ incomplete issues.
 
 ## Quality checklist (verify before posting)
 
-- [ ] Title is clear and action-oriented
-- [ ] Problem statement explains the "why"
+- [ ] Title is clear, action-oriented, and scoped to one feature/fix
+- [ ] Problem statement explains the "why" and names who benefits
+- [ ] Desired Behavior is stated as one decided behavior, not a menu
 - [ ] Technical context cites real file paths / class names from this project
-- [ ] Acceptance criteria are measurable and testable
-- [ ] Implementation notes give genuine technical guidance
-- [ ] Recommendations align with existing patterns and conventions
+- [ ] Acceptance criteria are measurable, testable, and unconditional
+- [ ] Implementation notes describe a single chosen approach
+- [ ] **No-options gate passed**: no choice/hedge/deferral language outside `## 🚫 Blocked`
+- [ ] Any unresolved decision is in `## 🚫 Blocked`, phrased as a question — nowhere else
 - [ ] Edge cases and error handling are considered
 - [ ] Architecture constraints are explicitly noted
 - [ ] Documentation references are accurate


### PR DESCRIPTION
## Summary

Reworks the `/create-issue` skill so it produces GitHub issues from **resolved decisions** rather than parking ambiguity in the ticket. Addresses two reported failure modes: agents skipped asking clarifying questions, and they listed implementation options / "Open Questions" inside the issue body.

## Changes

**`skills/create-issue/SKILL.md`**
- Adds a core principle: an issue is the output of resolved decisions.
- Replaces Step 2's skip-bias with a mandatory **Definition of Ready** — a question may only be skipped when its answer is already known from the story or Step 1 findings.
- Clarification now uses batched `AskUserQuestion` (recommended-first), looping until the DoR is met.
- On disengagement, **pushes back once** if the issue is still unbuildable, then routes every unresolved item into a single **`🚫 Blocked`** section as questions — never buried defaults or options.
- Adds a **no-options gate** before posting.

**`skills/create-issue/references/issue-template.md`**
- Adds the no-options rule (banned choice/hedge/deferral language).
- "Recommended Approach" → single decided **Approach**; dependencies name the one chosen library.
- Acceptance criteria must be single unconditional assertions.
- Specs the Blocked section as the only home for open decisions and resolves the one-feature-title vs blocked-scope contradiction.

No plugin version change.

## Verification

Followed the writing-skills RED→GREEN→REFACTOR loop with subagent pressure tests:

| Scenario | Result |
|---|---|
| Vague + "in a rush" (original failure) | Asks batched questions; no silent skip |
| User answers all questions | One decided feature, unconditional ACs, no options, no Blocked section |
| User fully disengages | Pushes back once, then files with all unknowns as Blocked *questions* |
| Trivial well-specified story | Asks nothing, files immediately (no over-interrogation) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
