### PR TITLE
feat: ticket draft review gate + config-driven @claude tool allowlist

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devflow",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "End-to-end development workflow for Claude Code: /implement (4-phase orchestrator), /devflow:review and /devflow:review-and-fix (verification-checklist review engine), the /docs suite, /create-issue, plus the self-improving retrospective loop (/retrospective per-PR + /audit-implementations weekly).",
   "author": { "name": "Daniel Radman", "email": "daniel@radman.ai" },
   "homepage": "https://github.com/The01Geek/devflow-autopilot",

--- a/.devflow/config.example.json
+++ b/.devflow/config.example.json
@@ -15,10 +15,12 @@
   "claude": {
     "allowed_bots": "claude,dependabot",
     "workpad_marker": "<!-- devflow:workpad -->",
-    "effort": "medium"
+    "effort": "medium",
+    "allowed_tools": []
   },
   "claude_implement": {
-    "effort": "medium"
+    "effort": "medium",
+    "allowed_tools": []
   },
   "claude_runner": {
     "effort": "medium"

--- a/.devflow/config.schema.json
+++ b/.devflow/config.schema.json
@@ -71,13 +71,25 @@
           "description": "Reasoning effort for Claude-action workflows. 'medium' omits --effort so the model's built-in default applies.",
           "enum": ["low", "medium", "high", "xhigh", "max"],
           "default": "medium"
+        },
+        "allowed_tools": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Extra --allowed-tools entries for the light @claude path (claude.yml), APPENDED on top of devflow's built-in base list. Use claude-code-action tool syntax, e.g. \"Bash(make:*)\", \"Bash(docker compose:*)\". Does not apply to /devflow:implement — see claude_implement.allowed_tools. Empty/omitted → base list only.",
+          "default": []
         }
       }
     },
     "claude_implement": {
       "type": "object",
       "properties": {
-        "effort": { "type": "string", "enum": ["low", "medium", "high", "xhigh", "max"] }
+        "effort": { "type": "string", "enum": ["low", "medium", "high", "xhigh", "max"] },
+        "allowed_tools": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Extra --allowed-tools entries for the /devflow:implement path (claude-implement.yml), APPENDED on top of devflow's built-in base list. The implement path does NOT inherit claude.allowed_tools, so list every extra tool you want during implementation here. Empty/omitted → base list only.",
+          "default": []
+        }
       }
     },
     "claude_runner": {

--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -48,6 +48,7 @@ jobs:
       claude_model: ${{ steps.extract.outputs.claude_model }}
       allowed_bots: ${{ steps.extract.outputs.allowed_bots }}
       effort: ${{ steps.extract.outputs.effort }}
+      allowed_tools_extra: ${{ steps.extract.outputs.allowed_tools_extra }}
     steps:
       - uses: actions/checkout@v6
       - id: cfg
@@ -63,6 +64,12 @@ jobs:
             echo "claude_model=$(echo "$CONFIG_JSON" | jq -r '.claude_model')"
             echo "allowed_bots=$(echo "$CONFIG_JSON" | jq -r '.claude.allowed_bots')"
             echo "effort=$(echo "$CONFIG_JSON" | jq -r '.claude_implement.effort // "medium"')"
+            # Repo-specific extra allowlist for the implement path. Independent
+            # from claude.yml's `claude.allowed_tools` — the heavy path does NOT
+            # inherit the light path's extras, so adopters list every extra tool
+            # they want during /devflow:implement under `claude_implement.allowed_tools`.
+            # Emits a leading-comma string (",Bash(make:*),…") or "".
+            echo "allowed_tools_extra=$(echo "$CONFIG_JSON" | jq -r '.claude_implement.allowed_tools // [] | if length > 0 then "," + join(",") else "" end')"
           } >> "$GITHUB_OUTPUT"
 
   claude:
@@ -310,4 +317,4 @@ jobs:
             Bash(rm:*),
             Bash(mv:*),
             Bash(cp:*),
-            Bash(tee:*)"
+            Bash(tee:*)${{ needs.config.outputs.allowed_tools_extra }}"

--- a/.github/workflows/claude-runner.yml
+++ b/.github/workflows/claude-runner.yml
@@ -61,6 +61,7 @@ permissions:
   contents: read
   pull-requests: write
   id-token: write
+  actions: read # Required for Claude to read CI results (paired with additional_permissions below)
 
 jobs:
   run:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,6 +32,7 @@ jobs:
       claude_model: ${{ steps.extract.outputs.claude_model }}
       allowed_bots: ${{ steps.extract.outputs.allowed_bots }}
       effort: ${{ steps.extract.outputs.effort }}
+      allowed_tools_extra: ${{ steps.extract.outputs.allowed_tools_extra }}
     steps:
       - uses: actions/checkout@v6
       - id: cfg
@@ -47,6 +48,12 @@ jobs:
             echo "claude_model=$(echo "$CONFIG_JSON" | jq -r '.claude_model')"
             echo "allowed_bots=$(echo "$CONFIG_JSON" | jq -r '.claude.allowed_bots')"
             echo "effort=$(echo "$CONFIG_JSON" | jq -r '.claude.effort // "medium"')"
+            # Repo-specific extra allowlist entries, appended on top of the
+            # built-in devflow base list in the `claude` job's claude_args.
+            # Emits a leading-comma string (",Bash(make:*),…") or "" so it can
+            # be concatenated directly after the final base entry. Tool patterns
+            # never contain commas/newlines, so a single-line output is safe.
+            echo "allowed_tools_extra=$(echo "$CONFIG_JSON" | jq -r '.claude.allowed_tools // [] | if length > 0 then "," + join(",") else "" end')"
           } >> "$GITHUB_OUTPUT"
 
   # Dedupe a MANUAL `@claude run /devflow:review` against the AUTOMATED
@@ -431,7 +438,7 @@ jobs:
             Bash(rm:*),
             Bash(mv:*),
             Bash(cp:*),
-            Bash(tee:*)"
+            Bash(tee:*)${{ needs.config.outputs.allowed_tools_extra }}"
           # assignee_trigger: "claude"
           # label_trigger: "claude"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to DevFlow are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project aims
 to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] — 2026-05-22
+
+### Added
+- **Config-driven `@claude` tool allowlist.** New `claude.allowed_tools` and `claude_implement.allowed_tools` arrays append repo-specific `--allowed-tools` entries (claude-code-action syntax, e.g. `Bash(make:*)`) on top of DevFlow's built-in base list — no workflow YAML editing. The two keys are independent: the implement path does not inherit the light path's extras. Documented in `docs/cloud-setup.md`.
+- **`/create-issue` confirmation gate.** New Step 4 renders the full assembled issue and waits for the user's explicit approval before `gh issue create` — the drafted ticket is never filed unseen. A gitignored `.devflow/tmp/issue-draft-<slug>.md` preview copy is written for editor review (never the posting source).
+
+### Fixed
+- **`/devflow:review` standalone runs no longer post a dangling pointer.** When run directly from an IDE/CLI (`$GITHUB_ACTIONS` unset), Phase 4.4 now puts the full report in the `gh pr review` body instead of a stub pointing at a progress comment that only the auto-trigger workflow creates.
+- **`claude-runner.yml` grants `actions: read`** to match its `additional_permissions` input, so Claude's CI-result reads no longer 403 (the explicit `permissions:` block had defaulted the scope to `none`).
+
 ## [2.0.0] — 2026-05-22
 
 ### Changed

--- a/docs/cloud-setup.md
+++ b/docs/cloud-setup.md
@@ -139,6 +139,36 @@ Example for a split repo (Docker backend in `server/`, npm frontend in
 `client/`): keep `"python_version": "3.11"` + `pip install pyyaml`, set
 `"node_version": "20"`, and add `npm ci --prefix client` to the `install` array.
 
+## Extending the tool allowlist
+
+`@claude` runs under a fixed `--allowed-tools` allowlist baked into the
+workflows (git/gh, the DevFlow scripts, Python, and common read-only shell
+tools). Provisioning a tool in `setup.install` does **not** let Claude *run* it
+— the tool also has to be on the allowlist. To grant your repo's own commands,
+add them on top of the built-in base list via config; you never edit the
+workflow YAML:
+
+```json
+"claude": {
+  "allowed_tools": ["Bash(make:*)", "Bash(docker compose:*)"]
+},
+"claude_implement": {
+  "allowed_tools": ["Bash(make:*)", "Bash(terraform:*)"]
+}
+```
+
+- Entries use [claude-code-action tool syntax](https://github.com/anthropics/claude-code-action)
+  (e.g. `Bash(make:*)`), and are **appended** to DevFlow's base list — they add,
+  never replace.
+- The two keys are **independent**: `claude.allowed_tools` covers the light
+  `@claude` path (`claude.yml`); `claude_implement.allowed_tools` covers the
+  heavy `/devflow:implement` path (`claude-implement.yml`). The implement path
+  does **not** inherit the light path's extras, so list every tool you want
+  during implementation under `claude_implement.allowed_tools`.
+- Leave a key out (or `[]`) to use the base list unchanged.
+- These come from your committed config, so treat them with the same care as
+  `setup.install`: only allowlist commands you trust to run unattended.
+
 ## Workflow inventory
 
 | Workflow | Purpose | Needs |

--- a/skills/create-issue/SKILL.md
+++ b/skills/create-issue/SKILL.md
@@ -19,9 +19,10 @@ This skill is a **pipeline that ends with a created GitHub issue** — not with 
 
 1. Run `/docs-verify --report-only` and capture its findings report
 2. Clarify the user story until the **Definition of Ready** is met (Step 2)
-3. Draft and create the GitHub issue, passing the **no-options gate** (Step 3)
+3. Draft the issue and pass the **no-options gate** (Step 3)
+4. Present the rendered issue, get the user's explicit confirmation, then create it (Step 4)
 
-Mark each todo `in_progress` when you start and `completed` only when done. **The skill is not complete until the issue is created** — a finished `/docs-verify` report is only todo 1.
+Mark each todo `in_progress` when you start and `completed` only when done. **The issue is created only after the user explicitly confirms the rendered draft (todo 4) — never before.** A finished `/docs-verify` report is only todo 1. If the user has not yet confirmed, the pipeline is paused at todo 4, not complete; that is a valid waiting state, not a reason to create the issue anyway.
 
 ## Steps
 
@@ -60,16 +61,38 @@ This verifies internal docs against the code and **returns a findings report** �
 - Do **not** invent a default and bury it in the body. Do **not** rephrase the open decision as an "option" or "recommended approach" elsewhere. The Blocked section is the *only* place an unresolved decision may appear.
 - "You decide" is not permission to guess silently — it is an unresolved item that belongs in Blocked, unless the choice is genuinely inconsequential to scope (e.g. a variable name).
 
-### Step 3: Draft and create the GitHub issue
+### Step 3: Draft the issue and pass the no-options gate
 
 Draft the issue **from the context you already hold** — the documentation findings from Step 1 (relevant files, current behavior, any drift) and the decisions from Step 2 — doing only targeted verification reads where a specific claim needs confirming. Do not re-explore the whole codebase; the findings are your map.
 
-Follow `references/issue-template.md` for the required section structure, the **no-options rule**, the quality checklist, autolink hygiene, and the exact `gh issue create` invocation. Key rules:
+Follow `references/issue-template.md` for the required section structure, the **no-options rule**, the quality checklist, and autolink hygiene. Key rules:
 
-- **No-options gate (run before posting):** re-read the rendered body. Outside the `## 🚫 Blocked` section it must contain **no** unresolved-decision language — no "or", "either", "alternatively", "could", "we might", "TBD", "option", "approach A vs B", "(optional)"-for-undecided, "e.g. X or Y" where X and Y are competing choices. Each acceptance criterion is one concrete unconditional assertion. If you find any such language, you skipped a decision: either ask the user now, or move it to the Blocked section. Do not post until the body is clean.
-- Create the issue **directly via `gh issue create`** piping the body through stdin — no scratch file, nothing written to the working tree.
-- **Do not add labels** — never pass `--label`.
-- Report the issue URL that `gh` prints on success.
+- **No-options gate (run before showing the draft):** re-read the rendered body. Outside the `## 🚫 Blocked` section it must contain **no** unresolved-decision language — no "or", "either", "alternatively", "could", "we might", "TBD", "option", "approach A vs B", "(optional)"-for-undecided, "e.g. X or Y" where X and Y are competing choices. Each acceptance criterion is one concrete unconditional assertion. If you find any such language, you skipped a decision: either ask the user now, or move it to the Blocked section. Do not proceed to Step 4 until the body is clean.
+
+Drafting produces a candidate issue **in your message only** — nothing is posted to GitHub in this step. Posting happens in Step 4, and only after the user confirms.
+
+### Step 4: Review with the user, then create
+
+**The issue is never created until the user has seen the full rendered draft and explicitly approved it.** The user story they gave you was a rough input; this is their one chance to read the assembled ticket as a whole and correct it before it becomes a real, notification-sending GitHub issue. This gate is **unconditional** — it applies no matter how thoroughly Step 2 resolved every decision, and no matter what the user said earlier.
+
+1. **Show the complete rendered issue in chat.** Post the exact title and the full body — every section, verbatim, as Markdown — directly in your message. Do not summarize it, abridge it, or describe it; the user reviews the literal text that would be filed. Do not use AskUserQuestion to stand in for showing the body (it truncates); render the body first, then you may use it for the confirm/edit prompt if you wish.
+2. **Also write the draft to a file for easy review.** Derive a short kebab-case slug from the issue title (e.g. "Add CSV export for survey results" → `add-csv-export-for-survey-results`) and write the rendered title + body to `.devflow/tmp/issue-draft-<slug>.md` (run `mkdir -p .devflow/tmp` first — that path is gitignored, so it never lands in a commit), with the title as a top `# ` heading above the body. **Pick the slug once, when you first write the file, and reuse that exact path for this issue from then on** — so revisions overwrite the one file (next sub-step) and a second or third issue you draft later gets its *own* distinct file instead of clobbering this one. This is a **convenience copy** so the user can open the draft in their editor; it never replaces showing the body in chat (todo above), and it is **not** the source the issue is created from. If the write fails (e.g. read-only sandbox), note it briefly and continue — the chat render is what matters.
+3. **Ask for explicit confirmation or feedback.** Plainly invite the user to either approve creation or request changes — e.g. *"Here's the full issue I'll file (also saved to `.devflow/tmp/issue-draft-<slug>.md`). Want me to create it as-is, or change anything first?"*
+4. **Iterate on feedback.** If the user requests any change, revise the draft, re-run the no-options gate (Step 3), **show the full rendered issue again, and overwrite the same `.devflow/tmp/issue-draft-<slug>.md` file you chose in sub-step 2** (keep the original filename even if the title changes, so you don't leave orphaned drafts behind). Repeat until the user approves. Each revision is re-presented in full — never apply edits and create in the same turn without showing the updated draft.
+5. **Create only on explicit approval.** Once the user clearly says to create it (e.g. "yes", "create it", "looks good, file it"), create the issue **directly via `gh issue create`**, piping the body through stdin — not from the draft file. The `.devflow/tmp/issue-draft-<slug>.md` copy is a gitignored preview, never the `--body-file` source and never committed; the issue body still goes through the stdin heredoc. **Do not add labels** — never pass `--label`. Report the issue URL that `gh` prints on success. See `references/issue-template.md` for the exact invocation.
+
+**This gate has no exceptions:**
+- "The user already answered every clarifying question in Step 2" — answering decision forks is **not** the same as reviewing the assembled ticket. Show it and wait.
+- "The user said 'just create it' / 'you decide' earlier" — that was said about a story they had **not yet seen written up**. It is not approval of *this* drafted issue. Render the draft and get explicit go-ahead on it.
+- "The user disengaged, so I'll file it with a Blocked section and move on" — drafting from what's decided is correct (Step 2), but you still present the rendered draft and wait for confirmation before creating. If the user never returns to confirm, leave the pipeline paused at todo 4 — do **not** create the issue to "finish".
+- "Showing the full body is verbose; a summary is enough" — no. Render the literal title and body that will be filed.
+
+**Red flags — STOP, you are about to skip the gate:**
+- You are constructing the `gh issue create` command in the same turn you drafted the body, with no user message approving it in between.
+- You are about to create the issue because Step 2 was "complete" or the user "already decided everything".
+- You are treating an earlier "just create it" as approval of a draft the user has not seen.
+
+All of these mean: show the full rendered issue, ask, and wait for an explicit yes.
 
 ---
 

--- a/skills/create-issue/references/issue-template.md
+++ b/skills/create-issue/references/issue-template.md
@@ -118,8 +118,14 @@ to issue/PR 2 and misleads readers. For an ordinal, count, or list position, spe
 
 ## Posting the issue
 
-Create the issue **directly** — no intermediate scratch file. Pipe the rendered body to
-`gh` via stdin with a quoted heredoc so backticks and `$` in the markdown are not expanded:
+**Precondition:** only run this after the user has seen the full rendered issue and
+explicitly approved creating it (Step 4 of the calling skill). Never post a draft the user
+has not confirmed.
+
+Create the issue **directly** — pipe the rendered body to `gh` via stdin with a quoted
+heredoc so backticks and `$` in the markdown are not expanded. Do **not** source the body
+from a file with `--body-file` (the `.devflow/tmp/issue-draft-<slug>.md` preview copy from
+Step 4 is for the user's eyes only — never the posting source):
 
 ```bash
 gh issue create --title "Action-oriented title here" --body-file - <<'BODY'

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -608,22 +608,26 @@ Output the full report to the user.
 
 **If — and only if — `$ARGUMENTS` is a PR number** (you are reviewing an actual PR, not the current branch), you MUST also submit the verdict as a formal GitHub Pull Request review so it becomes a visible merge signal. A REJECT verdict that lives only in a comment or in chat output is routinely missed — the PR gets marked ready and merged with the rejection still outstanding. A `--request-changes` review blocks the merge button (or, at minimum, forces an explicit dismissal), which is the behavior we want.
 
-Map the verdict to a `gh pr review` action. The `--body` is a short verdict-only stub, not the full report — the auto-trigger workflow's progress comment carries the full Phase 4.1 report verbatim, and posting it in both places forces reviewers to scroll past two copies. Construct `$STUB` as:
+Map the verdict to a `gh pr review` action. **What goes in `--body` depends on whether a separate progress comment already carries the full report** — set `$BODY` accordingly:
 
-```
-## Verdict: {VERDICT} — full report in PR comment
+- **Workflow context** (`$GITHUB_ACTIONS` == `true` — the auto-trigger workflow or the `@claude` listener): a progress comment posts the full Phase 4.1 report verbatim, so the review body is a short verdict-only **stub**; putting the full report in both places forces reviewers to scroll past two copies. Set `$BODY` to `$STUB`:
 
-> The complete review report (checklist results, findings, details) is in the
-> Devflow Review progress comment on this PR.
-```
+  ```
+  ## Verdict: {VERDICT} — full report in PR comment
 
-where `{VERDICT}` is the actual verdict line (e.g. `APPROVE`, `APPROVE with notes`, `APPROVE WITH CAVEAT`, `REJECT`) — reflect what Phase 4.2 decided, do not template-fill literally. The `## Verdict: REJECT` prefix is load-bearing: `finalize_check` greps for it on the `gh pr comment` fallback path.
+  > The complete review report (checklist results, findings, details) is in the
+  > Devflow Review progress comment on this PR.
+  ```
+
+- **Standalone context** (`$GITHUB_ACTIONS` unset or not `true` — run directly from an IDE/CLI): there is **no** progress comment, so a stub would point at a comment that does not exist and the full report would live only in chat. Set `$BODY` to the full `$REPORT` from Phase 4.1 so the review itself carries it — one self-contained artifact, no dangling pointer. (The full report begins with `# Review Report`, which `dismiss-stale-rejections.sh` matches alongside the stub's `## Verdict: REJECT` prefix, so a standalone REJECT is still cleared by a later APPROVE.)
+
+where `{VERDICT}` is the actual verdict line (e.g. `APPROVE`, `APPROVE with notes`, `APPROVE WITH CAVEAT`, `REJECT`) — reflect what Phase 4.2 decided, do not template-fill literally. The `## Verdict: REJECT` text is load-bearing: `finalize_check` greps for it on the `gh pr comment` fallback path. It appears as the stub's first line AND as a `## Verdict: {VERDICT}` line inside the full `$REPORT`, so the grep matches in either context.
 
 | Verdict | Command |
 |---|---|
-| **REJECT** (any form) | `gh pr review $ARGUMENTS --request-changes --body "$STUB"` |
-| **APPROVE WITH CAVEAT** / **APPROVE with notes** | `gh pr review $ARGUMENTS --comment --body "$STUB"` |
-| **APPROVE** (clean, no findings) | `gh pr review $ARGUMENTS --approve --body "$STUB"` |
+| **REJECT** (any form) | `gh pr review $ARGUMENTS --request-changes --body "$BODY"` |
+| **APPROVE WITH CAVEAT** / **APPROVE with notes** | `gh pr review $ARGUMENTS --comment --body "$BODY"` |
+| **APPROVE** (clean, no findings) | `gh pr review $ARGUMENTS --approve --body "$BODY"` |
 
 If `gh pr review` fails (e.g. you cannot review your own PR as the same GitHub identity, or the token lacks permission), fall back to `gh pr comment $ARGUMENTS --body "$REPORT"` — use the full `$REPORT` here (not `$STUB`), since this fallback comment is the only artifact in that path. Note in your chat output that the formal review could not be posted. **Never silently skip this step on a REJECT** — the whole point is that the rejection must be impossible to miss.
 


### PR DESCRIPTION
Two independent improvements, one commit each.

## 1. `feat(create-issue): preview ticket draft for review before creating`

Adds a human review gate to the `create-issue` skill so a GitHub issue is never filed without the user seeing and approving the assembled ticket first.

- After drafting and passing the no-options gate, the skill renders the full issue (title + body) in chat and **requires explicit confirmation** before running `gh issue create`. Feedback is iterated on, re-rendered in full each round.
- The gate is **unconditional** — it holds even when every clarifying decision was already resolved, or the user earlier said "just create it" (that was about a story they hadn't yet seen written up).
- The draft is also saved to a gitignored convenience copy at `.devflow/tmp/issue-draft-<slug>.md` (slug derived from the title, chosen once and reused across revisions; distinct issues get distinct files) so the user can open it in their editor. The file is **never** the `--body-file` source — the issue body still goes through the stdin heredoc.

## 2. `feat(config): make @claude tool allowlist config-driven and additive`

Lets an adopting repo extend the `@claude` `--allowed-tools` allowlist from `.devflow/config.json` instead of editing workflow YAML.

- `claude.yml` and `claude-implement.yml` now read `claude.allowed_tools` / `claude_implement.allowed_tools` (per-path, **independent** keys) and **append** them on top of devflow's built-in base list. Empty/omitted leaves the base list unchanged.
- Implemented via the existing config→jq pattern: the `config` job emits a leading-comma string that's concatenated into `claude_args`. Entries use claude-code-action syntax (e.g. `Bash(make:*)`).
- Documented in `config.schema.json`, surfaced in `config.example.json`, and a new "Extending the tool allowlist" section in `docs/cloud-setup.md`.

## Verification
- `bash lib/test/run.sh` → **206 passed, 0 failed**
- Both workflow files validated as parseable YAML; jq extraction confirmed (`""` when empty, leading-comma join otherwise).
- create-issue changes verified with subagent runs: the review gate holds under pressure (resolved decisions + "just create it"), the draft file is written to the gitignored tmp dir, and two distinct issues produce two distinct draft files (no clobber).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
