### PR TITLE
feat: /devflow:init + shared config scaffolder

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devflow",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "End-to-end development workflow for Claude Code: /implement (4-phase orchestrator), /devflow:review and /devflow:review-and-fix (verification-checklist review engine), the /docs suite, /create-issue, plus the self-improving retrospective loop (/retrospective per-PR + /audit-implementations weekly).",
   "author": { "name": "Daniel Radman", "email": "daniel@radman.ai" },
   "homepage": "https://github.com/The01Geek/devflow-autopilot",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devflow",
-  "version": "2.2.0",
+  "version": "2.1.1",
   "description": "End-to-end development workflow for Claude Code: /implement (4-phase orchestrator), /devflow:review and /devflow:review-and-fix (verification-checklist review engine), the /docs suite, /create-issue, plus the self-improving retrospective loop (/retrospective per-PR + /audit-implementations weekly).",
   "author": { "name": "Daniel Radman", "email": "daniel@radman.ai" },
   "homepage": "https://github.com/The01Geek/devflow-autopilot",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to DevFlow are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project aims
 to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.2.0] — 2026-05-22
+## [2.1.1] — 2026-05-22
 
 ### Added
 - **`/devflow:init`** — a one-time setup command (hidden from model auto-invocation via `disable-model-invocation`, so it adds zero per-turn context cost) that scaffolds `.devflow/config.json` from the shipped template **only if absent** and refreshes `config.schema.json`. It resolves templates from the installed plugin, so it works on a marketplace install where the templates aren't in the repo — unlike the old `cp .devflow/config.example.json …`, which only worked from the source repo.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to DevFlow are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project aims
 to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] — 2026-05-22
+
+### Added
+- **`/devflow:init`** — a one-time setup command (hidden from model auto-invocation via `disable-model-invocation`, so it adds zero per-turn context cost) that scaffolds `.devflow/config.json` from the shipped template **only if absent** and refreshes `config.schema.json`. It resolves templates from the installed plugin, so it works on a marketplace install where the templates aren't in the repo — unlike the old `cp .devflow/config.example.json …`, which only worked from the source repo.
+- **`scripts/scaffold-config.sh`** — the single shared config scaffolder. Both `/devflow:init` and `install.sh` call it, so local- and cloud-tier scaffolding can never drift; they coexist safely (no-clobber, schema-only refresh on re-run regardless of order).
+
+### Changed
+- `install.sh` step 5 now delegates to `scaffold-config.sh` (behaviour unchanged: never clobbers `config.json`, always refreshes the schema) and vendors the two config templates into the plugin so the vendored `/devflow:init` can find them.
+
 ## [2.1.0] — 2026-05-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -90,13 +90,14 @@ See **[`docs/cloud-setup.md`](docs/cloud-setup.md)** for secrets, the GitHub App
 | `/devflow:docs-bootstrap-internal` | Stand up an internal-docs structure from scratch | interactively |
 | `/devflow:docs-bootstrap-external` | Generate the initial external docs from internal docs | interactively |
 | `/devflow:create-issue` | Rough idea → well-structured GitHub issue | interactively |
+| `/devflow:init` | One-time setup: scaffold `.devflow/config.json` from the template (only if absent) + refresh `config.schema.json` | interactively |
 | `/devflow:devflow-weekly` | The weekly self-improvement loop orchestrator | interactively / headless |
 | `/devflow:retrospective` | Stage A brief — per-PR retrospective analysis | subagent only (dispatched by `/devflow-weekly`) |
 | `/devflow:audit-implementations` | Stage B brief — per-pattern intervention drafting | subagent only (dispatched by `/devflow-weekly`) |
 
 **Agents** (`agents/`): `checklist-generator`, `checklist-deduper`, and `checklist-verifier` (used by `/devflow:review` and `/devflow:review-and-fix` to build, dedupe, and verify the verification checklist).
 
-> The bare slash-command forms (`/implement`, …) resolve to the `devflow:`-namespaced skills when the plugin is enabled and there's no name collision. **Note:** `/devflow:review`, `/init`, and `/security-review` are also built-in Claude Code commands — to reach DevFlow's reviewer unambiguously (especially from GitHub Actions / `@claude` comments), use the namespaced `/devflow:review`.
+> The bare slash-command forms (`/implement`, …) resolve to the `devflow:`-namespaced skills when the plugin is enabled and there's no name collision. **Note:** `/devflow:review`, `/init`, and `/security-review` are also built-in Claude Code commands — to reach DevFlow's reviewer unambiguously (especially from GitHub Actions / `@claude` comments), use the namespaced `/devflow:review`. Likewise use `/devflow:init` for DevFlow's config scaffolder — bare `/init` is Claude Code's built-in CLAUDE.md generator.
 
 ## Companion plugins (auto-installed dependencies)
 
@@ -111,11 +112,13 @@ The three `claude-plugins-official` plugins above are **auto-installed** by `/pl
 
 ## Project configuration
 
-The local tier needs **no config** — every value has a built-in default. To customize, copy the template:
+The local tier needs **no config** — every value has a built-in default. To customize, scaffold the config files:
 
-```bash
-cp .devflow/config.example.json .devflow/config.json
 ```
+/devflow:init
+```
+
+This creates `.devflow/config.json` from DevFlow's shipped template (only if you don't already have one — it never clobbers a config you've filled in) and refreshes `.devflow/config.schema.json`. It pulls the templates from the installed plugin, so it works even though they aren't in your repo — a plain `cp .devflow/config.example.json …` only works from the DevFlow source repo, not a marketplace install. The cloud-tier `install.sh` runs the *same* scaffolder, so the two are interchangeable and safe to run in any order: whichever runs first creates `config.json`; the other leaves it untouched and just refreshes the schema.
 
 (The live `config.json` is gitignored so you don't commit project/board IDs. Your editor reads `config.schema.json` for autocomplete + field descriptions.) Keys the skills read:
 

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,9 @@
 # Installs (or updates) the DevFlow GitHub Actions "cloud tier" into the CURRENT
 # repository. Idempotent — re-run any time to pull the latest from the primary
 # repo. It writes:
-#   - .claude/plugins/devflow/        the VENDORED plugin (scripts/skills/agents/lib)
+#   - .claude/plugins/devflow/        the VENDORED plugin (scripts/skills/agents/lib
+#                                     + .devflow/ templates, so /devflow:init can
+#                                     find them from the vendored copy too)
 #   - .claude-plugin/marketplace.json local marketplace pointing at the above
 #   - .github/workflows/*.yml         the @claude / implement / review / board workflows
 #   - .github/actions/*               the composite actions they use
@@ -58,6 +60,12 @@ log "vendoring plugin → .claude/plugins/devflow/"
 rm -rf .claude/plugins/devflow
 mkdir -p .claude/plugins/devflow
 cp -R "$SRC/.claude-plugin" "$SRC/agents" "$SRC/lib" "$SRC/scripts" "$SRC/skills" .claude/plugins/devflow/
+# Vendor ONLY the two config templates (not the whole .devflow/ tree — that would
+# drag in learnings/ and, from a dirty source, a live config.json). They let the
+# vendored /devflow:init resolve templates at scripts/../.devflow/.
+mkdir -p .claude/plugins/devflow/.devflow
+cp "$SRC/.devflow/config.example.json" "$SRC/.devflow/config.schema.json" \
+   .claude/plugins/devflow/.devflow/
 # The vendored copy is a plugin, not a marketplace — keep only plugin.json.
 rm -f .claude/plugins/devflow/.claude-plugin/marketplace.json
 find .claude/plugins/devflow -name __pycache__ -type d -prune -exec rm -rf {} + 2>/dev/null || true
@@ -101,15 +109,11 @@ for a in dedupe-pr-events get-app-token read-project-config; do
   fi
 done
 
-# 5. config scaffold — never clobber an existing one; always refresh the schema.
-mkdir -p .devflow
-cp "$SRC/.devflow/config.schema.json" .devflow/config.schema.json
-if [ -f "$CONFIG" ]; then
-  log "keeping existing $CONFIG"
-else
-  cp "$SRC/.devflow/config.example.json" "$CONFIG"
-  log "scaffolded $CONFIG — fill in the YOUR_* placeholders before enabling workflows"
-fi
+# 5. config scaffold — delegated to the ONE shared scaffolder so the cloud tier
+#    and the /devflow:init skill can never drift. It never clobbers an existing
+#    config.json and always refreshes config.schema.json. Templates resolve
+#    relative to the script ($SRC/.devflow), and we target the current repo root.
+bash "$SRC/scripts/scaffold-config.sh" "$PWD"
 
 # 6. Apply secret-name mapping from `cloud_secrets` in config.json (idempotent).
 #    Reading a value out of JSON safely needs a real parser. We use jq, else

--- a/lib/test/run.sh
+++ b/lib/test/run.sh
@@ -191,6 +191,52 @@ assert_eq "cg: invalid JSON → exit 2" "2" "$?"
 rm -f "$CG_BAD"
 
 # ────────────────────────────────────────────────────────────────────────────
+echo "scaffold-config.sh"
+# ────────────────────────────────────────────────────────────────────────────
+# Single shared scaffolder used by BOTH install.sh and the /devflow:init skill.
+# Templates resolve relative to the script (../.devflow), so we point it at a
+# throwaway TARGET root and assert against the repo's real template files.
+SC="$LIB/../scripts/scaffold-config.sh"
+TPL_DIR="$LIB/../.devflow"
+
+# 1. Fresh target → scaffolds config.json (from the example) + schema.
+SC_FRESH="$(mktemp -d)"
+bash "$SC" "$SC_FRESH" >/dev/null 2>&1
+assert_eq "scaffold: fresh exit 0" "0" "$?"
+assert_eq "scaffold: config.json created" "yes" \
+  "$([ -f "$SC_FRESH/.devflow/config.json" ] && echo yes || echo no)"
+assert_eq "scaffold: config.json == example template" \
+  "$(cat "$TPL_DIR/config.example.json")" "$(cat "$SC_FRESH/.devflow/config.json")"
+assert_eq "scaffold: schema created" "yes" \
+  "$([ -f "$SC_FRESH/.devflow/config.schema.json" ] && echo yes || echo no)"
+
+# 2. Existing config.json → NEVER clobbered; schema still refreshed over stale.
+SC_KEEP="$(mktemp -d)"
+mkdir -p "$SC_KEEP/.devflow"
+printf '{"sentinel":true}' > "$SC_KEEP/.devflow/config.json"
+printf 'STALE' > "$SC_KEEP/.devflow/config.schema.json"
+bash "$SC" "$SC_KEEP" >/dev/null 2>&1
+assert_eq "scaffold: existing config preserved" \
+  '{"sentinel":true}' "$(cat "$SC_KEEP/.devflow/config.json")"
+assert_eq "scaffold: schema refreshed over stale" \
+  "$(cat "$TPL_DIR/config.schema.json")" "$(cat "$SC_KEEP/.devflow/config.schema.json")"
+
+# 3. Idempotent: a second run leaves the scaffolded config.json unchanged.
+SC_B1="$(cat "$SC_FRESH/.devflow/config.json")"
+bash "$SC" "$SC_FRESH" >/dev/null 2>&1
+assert_eq "scaffold: idempotent re-run keeps config" \
+  "$SC_B1" "$(cat "$SC_FRESH/.devflow/config.json")"
+
+# 4. Templates missing next to the script → fail loudly (exit 2), no guessing.
+SC_NOTPL="$(mktemp -d)"; mkdir -p "$SC_NOTPL/scripts"
+cp "$SC" "$SC_NOTPL/scripts/scaffold-config.sh"
+SC_NOTPL_TGT="$(mktemp -d)"
+bash "$SC_NOTPL/scripts/scaffold-config.sh" "$SC_NOTPL_TGT" >/dev/null 2>&1
+assert_eq "scaffold: missing templates → exit 2" "2" "$?"
+
+rm -rf "$SC_FRESH" "$SC_KEEP" "$SC_NOTPL" "$SC_NOTPL_TGT"
+
+# ────────────────────────────────────────────────────────────────────────────
 echo "conf.sh"
 # ────────────────────────────────────────────────────────────────────────────
 ( export DEVFLOW_CONFIG_FILE="$LIB/test/fixtures/config.json"

--- a/scripts/scaffold-config.sh
+++ b/scripts/scaffold-config.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 Daniel Radman
+# SPDX-License-Identifier: MIT
+# scaffold-config.sh — DevFlow's single config-scaffolding implementation.
+#
+# Drops the DevFlow config files into a repo's .devflow/ directory:
+#   - config.json     scaffolded from config.example.json ONLY when absent
+#                     (never clobbers an existing one — your IDs/secrets stay).
+#   - config.schema.json  refreshed every run (editor autocomplete/validation).
+#
+# This is the ONE scaffolder. Both entry points call it so the behaviour can
+# never drift between them:
+#   - install.sh           (cloud tier — runs from a fresh clone, $SRC)
+#   - the /devflow:init skill (local tier — runs from the plugin cache)
+# Because both call here, the two coexist safely: whichever runs first creates
+# config.json; the other preserves it (no-clobber) and only refreshes the schema.
+#
+# Templates are resolved RELATIVE TO THIS SCRIPT (../.devflow), so the script is
+# self-locating wherever it ships (marketplace cache, vendored plugin, or a
+# clone). The caller never has to tell us where the templates are.
+#
+# Usage: scaffold-config.sh [TARGET_REPO_ROOT]
+#   TARGET_REPO_ROOT  where to write .devflow/ (default: git toplevel, else cwd)
+#
+# Exit codes:
+#   0  config.json scaffolded or kept; schema refreshed
+#   2  bad arguments, or the template files are missing next to the script
+set -euo pipefail
+
+log() { printf 'devflow-scaffold: %s\n' "$1"; }
+die() { printf 'devflow-scaffold: %s\n' "$1" >&2; exit 2; }
+
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TPL_DIR="$SELF_DIR/../.devflow"
+EXAMPLE="$TPL_DIR/config.example.json"
+SCHEMA="$TPL_DIR/config.schema.json"
+
+[ -f "$EXAMPLE" ] || die "template not found: $EXAMPLE (is the plugin install complete?)"
+[ -f "$SCHEMA" ]  || die "template not found: $SCHEMA (is the plugin install complete?)"
+
+TARGET_ROOT="${1:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+DEST="$TARGET_ROOT/.devflow"
+CONFIG="$DEST/config.json"
+
+mkdir -p "$DEST"
+
+# Schema is generated, never hand-edited — safe to overwrite every run so
+# editors always validate against the current field set.
+cp "$SCHEMA" "$DEST/config.schema.json"
+
+if [ -f "$CONFIG" ]; then
+  log "keeping existing $CONFIG"
+else
+  cp "$EXAMPLE" "$CONFIG"
+  log "scaffolded $CONFIG — fill in the YOUR_* placeholders before enabling workflows"
+fi

--- a/skills/init/SKILL.md
+++ b/skills/init/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: init
+description: Use when setting up DevFlow in a repo for the first time, or after a plugin update — scaffolds .devflow/config.json from the shipped template (only if absent) and refreshes config.schema.json. Invoke explicitly with /devflow:init.
+disable-model-invocation: true
+---
+
+# DevFlow Init
+
+Scaffold this repo's DevFlow config files. **One command does everything — do not hand-write `config.json` or guess field values.**
+
+## Run
+
+```bash
+bash "${CLAUDE_SKILL_DIR}/../../scripts/scaffold-config.sh"
+```
+
+This is the single shared scaffolder — the same script `install.sh` uses, so the two entry points can never drift. With no argument it targets the current repo root (git toplevel) and:
+
+- creates `.devflow/config.json` from the shipped `config.example.json` **only if it does not already exist** — it never clobbers a config you've already filled in with real project/board IDs;
+- always refreshes `.devflow/config.schema.json` so your editor validates against the current field set.
+
+It resolves the templates from the installed plugin (`${CLAUDE_SKILL_DIR}/../../.devflow/`), so it works whether DevFlow was installed via the marketplace or vendored by `install.sh`.
+
+## After running
+
+Read the scaffolder's output line and respond accordingly:
+
+- **`scaffolded …`** — a fresh `.devflow/config.json` was created. Tell the user to fill in the `YOUR_*` placeholders (e.g. `project_number`, `app_id`) before enabling workflows; their editor will validate against `config.schema.json`. **Do not invent these values** — they are GitHub-account-specific and only the user can supply them.
+- **`keeping existing …`** — they already had a `config.json`; it was left untouched and only the schema was refreshed. Nothing more to do.
+
+If the scaffolder exits non-zero (exit 2 = templates not found next to the script), the plugin install is incomplete. Tell the user to reinstall/update the DevFlow plugin (or run `install.sh` for the cloud tier). **Do not fall back to hand-writing the files** — that reintroduces exactly the drift this skill exists to prevent.


### PR DESCRIPTION
## Summary

Adds a clean way for **local-tier** plugin users to scaffold their `.devflow/` config, closing the gap that a `/plugin install` can't write into the consumer's repo. Implements both front doors agreed in design, sharing **one** scaffolder so they can't drift.

- **`scripts/scaffold-config.sh`** (new) — the single config-scaffolding implementation. Writes `.devflow/config.json` from the template **only if absent** (never clobbers a filled-in config) and always refreshes `config.schema.json`. Self-locates templates at `../.devflow`, so it works from the marketplace cache, a vendored plugin, or a clone. Exit 2 when templates are missing.
- **`/devflow:init`** (new skill) — thin, user-invoked setup command that runs the scaffolder. Ships with `disable-model-invocation: true` → **zero per-turn context cost**, hidden from the model's skill list, still runnable from the `/` menu. This was the core ask: a setup command that doesn't clutter the model's skill list.
- **`install.sh`** — step 5 now delegates to the shared scaffolder (behaviour unchanged) and vendors only the two templates so the vendored skill can find them.

The two paths **coexist safely**: whichever runs first creates `config.json`; the other preserves it and only refreshes the schema (order-independent, idempotent).

## Why this shape (not a SessionStart hook)

Research into Claude Code conventions: plugin installs are cache-only with no postinstall hook; the ecosystem scaffolds project files via **explicit user-invoked commands** (`claude init`, `plugin-dev`'s init, `skill-creator`), not silent writes. `disable-model-invocation` keeps the command out of the model's context entirely while staying discoverable.

## Notable correctness points

- Bare `/init` is **Claude Code's built-in CLAUDE.md generator** — DevFlow's scaffolder is `/devflow:init`. Documented in the README disambiguation note.
- The old README instruction `cp .devflow/config.example.json …` **silently fails on a marketplace install** (template isn't in the repo); replaced with `/devflow:init`.
- `install.sh` vendors *only* the two templates — copying the whole `.devflow/` tree would drag in `learnings/` and, from a dirty source, a live `config.json`.

## Verification

- **TDD**: 8 scaffolder tests written first (RED), then the script (GREEN). Full suite **214 passed, 0 failed**.
- **Skill (writing-skills Iron Law)**: RED baseline (agent improvised a `cp`, skipped schema refresh, would misfire in a real consumer repo) → wrote skill → GREEN (agent runs only the scaffolder, never hand-writes/guesses).
- **shellcheck** `--severity=warning -e SC1091`: clean (CI-equivalent sweep incl. new script).
- **preflight**: passes. No workflow/`.py` changes → actionlint/ruff N/A.

Version bumped 2.1.0 → **2.2.0** (minor, additive feature).