### PR TITLE
fix(workflows): fail loud on missing devflow.allowed_bots (command paths)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devflow",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "description": "End-to-end development workflow for Claude Code: /devflow:implement (4-phase orchestrator), /devflow:review and /devflow:review-and-fix (verification-checklist review engine), the /devflow:docs suite, /devflow:create-issue, plus the self-improving retrospective loop (/devflow:retrospective per-PR + /devflow:retrospective-audit weekly).",
   "author": {
     "name": "Daniel Radman",

--- a/.github/workflows/devflow-implement.yml
+++ b/.github/workflows/devflow-implement.yml
@@ -63,11 +63,24 @@ jobs:
           CONFIG_JSON: ${{ steps.cfg.outputs.json }}
         run: |
           set -euo pipefail
+          ENABLED=$(echo "$CONFIG_JSON" | jq -r '.workflows.devflow // false')
+          # `// empty` collapses a missing/null allowlist to a real empty string.
+          # Fail loud only when the workflow is ENABLED — a config left on the
+          # pre-2.2.5 `claude.allowed_bots` key would otherwise propagate a
+          # literal "null" allowlist that silently matches no bot. Disabled repos
+          # skip the check (allowed_bots is read only downstream of the enabled
+          # gate), so this never breaks an intentionally-off install. Mirrors the
+          # guard in devflow-runner.yml.
+          ALLOWED_BOTS=$(echo "$CONFIG_JSON" | jq -r '.devflow.allowed_bots // empty')
+          if [ "$ENABLED" = "true" ] && [ -z "$ALLOWED_BOTS" ]; then
+            echo "::error::devflow.allowed_bots is missing from .devflow/config.json (a pre-2.2.5 config may still use the old 'claude.allowed_bots' key — see CHANGELOG 2.2.5 migration)"
+            exit 1
+          fi
           {
-            echo "enabled=$(echo "$CONFIG_JSON" | jq -r '.workflows.devflow // false')"
+            echo "enabled=$ENABLED"
             echo "base_branch=$(echo "$CONFIG_JSON" | jq -r '.base_branch')"
             echo "claude_model=$(echo "$CONFIG_JSON" | jq -r '.claude_model')"
-            echo "allowed_bots=$(echo "$CONFIG_JSON" | jq -r '.devflow.allowed_bots')"
+            echo "allowed_bots=$ALLOWED_BOTS"
             # Human logins allowed to trigger /devflow:implement (AND-filter on
             # top of the collaborator-permission gate; '*' = any collaborator).
             echo "allowed_users=$(echo "$CONFIG_JSON" | jq -r '.devflow.allowed_users // "*"')"

--- a/.github/workflows/devflow.yml
+++ b/.github/workflows/devflow.yml
@@ -50,11 +50,24 @@ jobs:
           CONFIG_JSON: ${{ steps.cfg.outputs.json }}
         run: |
           set -euo pipefail
+          ENABLED=$(echo "$CONFIG_JSON" | jq -r '.workflows.devflow // false')
+          # `// empty` collapses a missing/null allowlist to a real empty string.
+          # Fail loud only when the workflow is ENABLED — a config left on the
+          # pre-2.2.5 `claude.allowed_bots` key would otherwise propagate a
+          # literal "null" allowlist that silently matches no bot. Disabled repos
+          # skip the check (allowed_bots is read only downstream of the enabled
+          # gate), so this never breaks an intentionally-off install. Mirrors the
+          # guard in devflow-runner.yml.
+          ALLOWED_BOTS=$(echo "$CONFIG_JSON" | jq -r '.devflow.allowed_bots // empty')
+          if [ "$ENABLED" = "true" ] && [ -z "$ALLOWED_BOTS" ]; then
+            echo "::error::devflow.allowed_bots is missing from .devflow/config.json (a pre-2.2.5 config may still use the old 'claude.allowed_bots' key — see CHANGELOG 2.2.5 migration)"
+            exit 1
+          fi
           {
-            echo "enabled=$(echo "$CONFIG_JSON" | jq -r '.workflows.devflow // false')"
+            echo "enabled=$ENABLED"
             echo "base_branch=$(echo "$CONFIG_JSON" | jq -r '.base_branch')"
             echo "claude_model=$(echo "$CONFIG_JSON" | jq -r '.claude_model')"
-            echo "allowed_bots=$(echo "$CONFIG_JSON" | jq -r '.devflow.allowed_bots')"
+            echo "allowed_bots=$ALLOWED_BOTS"
             # Human logins allowed to trigger the command path (AND-filter on top
             # of the collaborator-permission gate; '*' = any collaborator).
             echo "allowed_users=$(echo "$CONFIG_JSON" | jq -r '.devflow.allowed_users // "*"')"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to DevFlow are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project aims
 to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.6] — 2026-05-23
+
+### Fixed
+- **`devflow.yml` and `devflow-implement.yml` now fail loud on a missing `devflow.allowed_bots` instead of running with a `"null"` allowlist.** Previously the `config` job read `jq -r '.devflow.allowed_bots'` with no fallback, so a config left on the pre-2.2.5 `claude.allowed_bots` key emitted the literal string `null` — a bot allowlist that silently matches nothing, disabling triggering without telling the operator why. Both now read with `// empty` and emit a `::error::` + exit 1, but **only when `workflows.devflow` is enabled** (the allowlist is read only downstream of the enabled gate, so an intentionally-disabled repo is never failed). This brings the two command-path workflows in line with the fail-closed guard `devflow-runner.yml` already had.
+
 ## [2.2.5] — 2026-05-23
 
 ### Changed


### PR DESCRIPTION
## What

Follow-up to #13 (the `claude*`→`devflow*` config-key rename). The review of #13 flagged that `devflow.yml` and `devflow-implement.yml` read `.devflow.allowed_bots` with **no fallback**, unlike `devflow-runner.yml` which fails closed. A config left on the pre-2.2.5 `claude.allowed_bots` key therefore emits the literal string `null` into the allowlist — silently matching no bot and disabling triggering with no error. (This no-fallback predated #13, which is why it was deferred from that PR rather than fixed inline.)

## Change

Both command-path workflows now read with `// empty` and `exit 1` with a clear `::error::` — but **only when `workflows.devflow` is enabled**.

### Regression safety (the key design point)

`allowed_bots` is consumed only downstream of the `enabled == 'true'` gate, but the `config` job runs on **every** trigger. An unconditional `exit 1` would break repos that intentionally set `workflows.devflow: false`. Guarding on `ENABLED` avoids that. Verified by simulating the exact extracted bash:

| Scenario | Before | After |
|---|---|---|
| enabled + new key present | ok (value) | ok (value, **unchanged**) |
| enabled + only old `claude.allowed_bots` | silent `"null"` allowlist | **fail loud** + exit 1 |
| enabled + empty-string allowlist | silent empty | **fail loud** + exit 1 |
| **disabled + missing** | ok | **ok (not failed)** ✅ |
| empty config (default disabled) | ok | ok |

## Testing
- Simulated all 5 scenarios above against the literal guard bash — correct in every case.
- `bash lib/test/run.sh` → **311 passed, 0 failed**.
- YAML valid; CI lint job runs actionlint/shellcheck.

Bump 2.2.5 → 2.2.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)