### PR TITLE
Add per-step docs toggles (docs.internal_enabled / docs.external_enabled)

### DIFF
--- a/.devflow/config.example.json
+++ b/.devflow/config.example.json
@@ -31,6 +31,8 @@
   "docs": {
     "internal": "docs/internal/",
     "external": "docs/external/",
+    "internal_enabled": true,
+    "external_enabled": true,
     "release_notes_file": "docs/external/release-notes.md",
     "documented_label": "Documented"
   },

--- a/.devflow/config.json
+++ b/.devflow/config.json
@@ -28,8 +28,10 @@
     ]
   },
   "docs": {
-    "internal": "docs/internal/",
-    "external": "docs/external/",
+    "internal": "docs/",
+    "external": "docs/",
+    "internal_enabled": true,
+    "external_enabled": false,
     "release_notes_file": "CHANGELOG.md",
     "documented_label": "Documented"
   },

--- a/.devflow/config.schema.json
+++ b/.devflow/config.schema.json
@@ -169,6 +169,16 @@
       "properties": {
         "internal": { "type": "string", "default": "docs/internal/" },
         "external": { "type": "string", "default": "docs/external/" },
+        "internal_enabled": {
+          "type": "boolean",
+          "description": "When false, the /devflow:docs combined pass (and /devflow:implement's Phase 4.1 docs step) SKIPS internal-doc updates (Step 1, docs-sync-internal). Use it for repos with no internal docs tree, or to keep the implement pass from touching internal docs. Default true (run internal docs). Does not affect invoking /devflow:docs-sync-internal directly.",
+          "default": true
+        },
+        "external_enabled": {
+          "type": "boolean",
+          "description": "When false, the /devflow:docs combined pass (and /devflow:implement's Phase 4.1 docs step) SKIPS external-doc alignment (Step 2, docs-sync-external). Use it for repos with no separate customer-facing docs tree (e.g. a single flat docs/ directory). Default true (run external docs). Does not affect invoking /devflow:docs-sync-external directly.",
+          "default": true
+        },
         "release_notes_file": {
           "type": "string",
           "description": "Customer-facing release-notes file maintained by /devflow:docs-release-notes.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **Per-step toggles for the `/devflow:docs` pass (`docs.internal_enabled`, `docs.external_enabled`).** Two new boolean config keys (both default `true`) let you skip the internal-doc (Step 1) or external-doc (Step 2) sub-pass of the combined `/devflow:docs` run — which is what `/devflow:implement`'s Phase 4.1 invokes. Set `docs.external_enabled: false` for repos with a single flat `docs/` tree and no separate customer-facing docs, so the implement pass no longer runs external alignment; set `docs.internal_enabled: false` to skip internal-doc updates. Release-note generation (Step 3) is unaffected, and invoking `/devflow:docs-sync-internal` / `/devflow:docs-sync-external` directly still works regardless of the flags.
+
 ## [2.2.7] — 2026-05-23
 
 ### Added

--- a/lib/test/run.sh
+++ b/lib/test/run.sh
@@ -1681,6 +1681,40 @@ assert_eq "provision: schema default is false" "false" \
 assert_eq "provision: config.example.json sets provision_env false" "false" \
   "$(jq -r '.devflow_runner.provision_env' "$LIB/../.devflow/config.example.json")"
 
+# ────────────────────────────────────────────────────────────────────────────
+echo "docs per-step toggles (docs.internal_enabled / docs.external_enabled)"
+# ────────────────────────────────────────────────────────────────────────────
+# The /devflow:docs pass gates Step 1 (internal) and Step 2 (external) on these
+# booleans (default true). Pin the schema declaration, the example, and — most
+# importantly — that config-get.sh returns a literal "false" for a false flag
+# (not coerced to the default), since the skill's skip decision compares against
+# "false". A regression that coerced false→default would silently re-enable a
+# disabled step.
+SCHEMA="$LIB/../.devflow/config.schema.json"
+for key in internal_enabled external_enabled; do
+  assert_eq "docs toggle: schema declares $key boolean" "boolean" \
+    "$(jq -r ".properties.docs.properties.${key}.type" "$SCHEMA")"
+  assert_eq "docs toggle: schema default $key is true" "true" \
+    "$(jq -r ".properties.docs.properties.${key}.default" "$SCHEMA")"
+done
+# config-get.sh must surface a false flag as the literal string "false".
+DOCS_CFG="$(mktemp)"; printf '{"docs":{"internal_enabled":false,"external_enabled":true}}' > "$DOCS_CFG"
+assert_eq "docs toggle: config-get returns literal false (not the default)" "false" \
+  "$(bash "$LIB/../scripts/config-get.sh" .docs.internal_enabled true "$DOCS_CFG")"
+assert_eq "docs toggle: config-get returns true when set true" "true" \
+  "$(bash "$LIB/../scripts/config-get.sh" .docs.external_enabled false "$DOCS_CFG")"
+DOCS_CFG_BARE="$(mktemp)"; printf '{"docs":{}}' > "$DOCS_CFG_BARE"
+assert_eq "docs toggle: config-get falls back to default when key absent" "true" \
+  "$(bash "$LIB/../scripts/config-get.sh" .docs.internal_enabled true "$DOCS_CFG_BARE")"
+rm -f "$DOCS_CFG" "$DOCS_CFG_BARE"
+# The docs skill must actually consult both toggles (guards against silent drift
+# where the schema declares a flag the skill never reads).
+DOCS_SKILL="$LIB/../skills/docs/SKILL.md"
+assert_eq "docs toggle: skill reads .docs.internal_enabled" "1" \
+  "$(grep -c '\.docs\.internal_enabled' "$DOCS_SKILL" || true)"
+assert_eq "docs toggle: skill reads .docs.external_enabled" "1" \
+  "$(grep -c '\.docs\.external_enabled' "$DOCS_SKILL" || true)"
+
 # Tally the shell assertions from the results file (authoritative — includes the
 # subshell blocks). The python section below adds its own counts on top.
 PASS=$(grep -c '^PASS$' "$RESULTS_FILE" || true)

--- a/skills/docs/SKILL.md
+++ b/skills/docs/SKILL.md
@@ -5,11 +5,27 @@ description: Use when all documentation needs updating for a branch — internal
 
 ## Objective
 
-You are an **AI Documentation Agent** for code repositories. You perform three sequential documentation tasks in a single session, sharing context between them so that findings from earlier steps inform later steps.
+You are an **AI Documentation Agent** for code repositories. You perform up to three sequential documentation tasks in a single session, sharing context between them so that findings from earlier steps inform later steps. Steps 1 and 2 are individually gated by config flags (see below) — a disabled step is skipped, not failed.
+
+### Config gates (read once, up front)
+
+Read both toggles before starting (they default to `true` — enabled — when absent):
+
+```bash
+INTERNAL_ENABLED=$(${CLAUDE_SKILL_DIR}/../../scripts/config-get.sh .docs.internal_enabled true)
+EXTERNAL_ENABLED=$(${CLAUDE_SKILL_DIR}/../../scripts/config-get.sh .docs.external_enabled true)
+```
+
+- `INTERNAL_ENABLED == "false"` → **skip Step 1**.
+- `EXTERNAL_ENABLED == "false"` → **skip Step 2**.
+
+Step 3 (release notes) is not gated by these flags. Note which steps you skipped — the Final Summary must report it.
 
 ---
 
 ## Step 1: Update Internal Documentation
+
+**Skip this step when `INTERNAL_ENABLED == "false"`** — record "internal docs disabled by config" for the Final Summary and proceed to Step 2.
 
 Invoke the Skill tool with `skill: docs-sync-internal` and follow its instructions exactly.
 
@@ -19,9 +35,11 @@ After completing Step 1, note what you changed — you will need this context fo
 
 ## Step 2: Align External Documentation
 
+**Skip this step when `EXTERNAL_ENABLED == "false"`** — record "external docs disabled by config" for the Final Summary and proceed to Step 3.
+
 Invoke the Skill tool with `skill: docs-sync-external` and follow its instructions exactly.
 
-Use the internal documentation you updated in Step 1 as your primary source of truth when comparing against external docs.
+Use the internal documentation you updated in Step 1 as your primary source of truth when comparing against external docs (if Step 1 was skipped, use the branch diff as the source of truth instead).
 
 After completing Step 2, note what you changed — you will need this context for Step 3.
 
@@ -39,7 +57,7 @@ Use the documentation changes from Steps 1 and 2 as additional context when asse
 
 ## Final Summary
 
-After completing all three steps, provide a brief summary listing:
-- Internal doc files added or edited (Step 1)
-- External doc files added or edited (Step 2)
+After completing the enabled steps, provide a brief summary listing:
+- Internal doc files added or edited (Step 1) — or "skipped: disabled by config (`docs.internal_enabled: false`)"
+- External doc files added or edited (Step 2) — or "skipped: disabled by config (`docs.external_enabled: false`)"
 - Release note entry added or skipped with reason (Step 3)


### PR DESCRIPTION
## Summary
- Adds two boolean config keys — `docs.internal_enabled` and `docs.external_enabled` (both default `true`) — that gate the internal-doc (Step 1) and external-doc (Step 2) sub-passes of the combined `/devflow:docs` run, which is what `/devflow:implement`'s Phase 4.1 invokes.
- Motivation: repos with a single flat `docs/` tree (no separate customer-facing docs) want the implement docs pass to skip external alignment. This repo dogfoods it (`external_enabled: false`).
- A disabled step is **skipped, not failed**; release-note generation (Step 3) is unaffected, and invoking `/devflow:docs-sync-internal` / `/devflow:docs-sync-external` directly is unaffected.

## Changes
**Schema (`.devflow/config.schema.json`)**: declares `docs.internal_enabled` and `docs.external_enabled` (boolean, default `true`).
**`skills/docs/SKILL.md`**: reads both toggles up front via `config-get.sh`; skips Step 1 / Step 2 when the corresponding flag is `"false"`; reports skips in the Final Summary. If Step 1 is skipped, Step 2 falls back to the branch diff as its source of truth.
**`.devflow/config.example.json`**: surfaces both keys (default `true`) for discoverability.
**`.devflow/config.json` (this repo's dogfood config)**: `external_enabled: false` (flat `docs/` tree, no separate external docs) + corrected `docs.internal`/`docs.external` to `docs/` (the `docs/internal/`, `docs/external/` defaults never existed here, so the docs pass was silently no-op'ing on them).
**Tests (`lib/test/run.sh`)**: schema declaration + defaults; `config-get.sh` returns a literal `false` for a false flag (not coerced to the default — the skill's skip decision compares against `"false"`); the skill actually reads both keys.

## Resolves
N/A (follow-up from the #18 implement run's reflection that the `docs.internal`/`docs.external` paths didn't exist here).

## Test Plan
- [ ] CI `lib + python tests` passes (399 assertions, incl. 9 new docs-toggle checks).
- [ ] CI `lint (shellcheck + actionlint + ruff)` passes.
- [ ] With `docs.external_enabled: false`, a `/devflow:docs` run (or an implement Phase 4.1) skips Step 2 and reports "external docs disabled by config" in its summary.
- [ ] With both flags absent, behavior is unchanged (both steps run).

## Visual Changes
N/A

## Breaking Changes
None — both flags default to `true`, preserving current behavior. Existing configs without the keys are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)