### PR TITLE
feat: surface provisioning health into the reviewer prompt (#22)

### DIFF
--- a/.github/actions/setup-project-env/action.yml
+++ b/.github/actions/setup-project-env/action.yml
@@ -26,6 +26,19 @@ inputs:
     description: '.devflow/config.json contents, as emitted by the read-project-config action (steps.<id>.outputs.json). The automated reviewer (devflow-runner.yml, provision_env path) instead passes the TRUSTED base-ref config it reads directly via git show + `jq -c` — a different provenance but the same shape (a JSON object with a `.setup` block), so this action consumes it identically.'
     required: true
 
+outputs:
+  health_summary:
+    description: |
+      Empty string when every started service container is running/healthy (or
+      when no services are configured). Otherwise a multiline string with one
+      line per degraded service, naming the service and its failure reason (not
+      running, or unhealthy after the readiness timeout with its last status).
+      Provisioning stays warning-only — a degraded service populates this output
+      but never fails the step. Consumed by devflow-runner.yml to prepend an
+      infra-status note to the reviewer prompt so build/test failures tracing to
+      a service that never came up are attributed to infrastructure, not the PR.
+    value: ${{ steps.services.outputs.health_summary }}
+
 runs:
   using: composite
   steps:
@@ -107,6 +120,7 @@ runs:
           pip-${{ runner.os }}-
 
     - name: Start service containers
+      id: services
       shell: bash
       env:
         CONFIG_JSON: ${{ inputs.config_json }}
@@ -162,6 +176,13 @@ runs:
         # wait until healthy; otherwise just confirm they're still running. Best
         # effort — a timeout warns rather than failing the job, so the real test
         # failure (if any) surfaces with a clearer message downstream.
+        #
+        # Each degraded service ALSO accumulates a one-line entry in `degraded`,
+        # emitted below as the `health_summary` output so the calling workflow can
+        # tell the reviewer which dependency never came up. This is purely
+        # additive to the existing warning-only behavior — nothing here fails the
+        # step.
+        degraded=()
         for name in "${started[@]}"; do
           health=$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{end}}' "$name" 2>/dev/null || echo "")
           if [ -z "$health" ]; then
@@ -170,6 +191,7 @@ runs:
               echo "Service '$name' running (no health check declared)."
             else
               echo "::warning::Service '$name' is not running."
+              degraded+=("- $name: not running")
             fi
             continue
           fi
@@ -183,8 +205,23 @@ runs:
             echo "Service '$name' healthy."
           else
             echo "::warning::Service '$name' not healthy after ~120s (status: ${health:-unknown}); continuing."
+            degraded+=("- $name: not healthy after ~120s (status: ${health:-unknown})")
           fi
         done
+
+        # Emit the degraded-service summary as a multiline step output. When every
+        # service is healthy `degraded` is empty and we write nothing, so the
+        # output resolves to the empty string (the all-healthy contract). A unique,
+        # timestamped heredoc delimiter avoids any collision with the summary's own
+        # content, mirroring the heredoc transport used elsewhere in the runner.
+        if [ ${#degraded[@]} -gt 0 ]; then
+          delim="HEALTH_EOF_$(date +%s%N)_$$"
+          {
+            printf 'health_summary<<%s\n' "$delim"
+            printf '%s\n' "${degraded[@]}"
+            printf '%s\n' "$delim"
+          } >> "$GITHUB_OUTPUT"
+        fi
 
     - name: Provision project dependencies
       shell: bash

--- a/.github/workflows/devflow-runner.yml
+++ b/.github/workflows/devflow-runner.yml
@@ -410,10 +410,58 @@ jobs:
       # docs/cloud-setup.md.) When the flag is absent/false this step is skipped
       # and the runner behaves exactly as before: read-only, no build tools.
       - name: Provision project environment (opt-in)
+        id: provision
         if: steps.baseprovision.outputs.provision_env == 'true'
         uses: ./.github/actions/setup-project-env
         with:
           config_json: ${{ steps.baseprovision.outputs.config_json }}
+
+      # Provisioning is best-effort: a service container that never becomes
+      # healthy emits a `::warning::` and the job continues (see
+      # setup-project-env), so a build/verify command that then fails for lack of
+      # that dependency would otherwise look like a PR defect to the reviewer.
+      # When the action reports degraded services via its `health_summary` output,
+      # prepend a fenced infra-status note to the reviewer prompt instructing it to
+      # blame infrastructure, not the PR. This step is deliberately NOT gated on
+      # provision_env: when the provision step is skipped (or every service is
+      # healthy) the output resolves to empty and the prompt is forwarded
+      # byte-for-byte unchanged, so the read-only happy path is unaffected.
+      - name: Compose review prompt
+        id: compose
+        env:
+          BASE_PROMPT: ${{ inputs.prompt }}
+          HEALTH_SUMMARY: ${{ steps.provision.outputs.health_summary }}
+        run: |
+          set -euo pipefail
+          if [ -n "$HEALTH_SUMMARY" ]; then
+            PROMPT="> [!IMPORTANT]
+          > **Infrastructure status: one or more service containers did not come up.**
+          > This reviewer environment was provisioned (\`provision_env\` is on), but
+          > the following services are degraded:
+          >
+          ${HEALTH_SUMMARY}
+          >
+          > If any build, test, or verify command below fails because it could not
+          > reach one of these services, attribute that failure to the degraded
+          > infrastructure above — NOT to a defect in this pull request. Review the
+          > rest of the change normally.
+
+          ---
+
+          ${BASE_PROMPT}"
+          else
+            PROMPT="$BASE_PROMPT"
+          fi
+          # Heredoc transport with a unique, timestamped delimiter: the prompt is
+          # full of markdown/backticks, so a fixed sentinel could collide with its
+          # content and prematurely terminate the output. The same pattern guards
+          # the other multiline outputs in this workflow.
+          delim="PROMPT_EOF_$(date +%s%N)_$$"
+          {
+            printf 'prompt<<%s\n' "$delim"
+            printf '%s\n' "$PROMPT"
+            printf '%s\n' "$delim"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Run Claude Code
         id: claude
@@ -431,7 +479,7 @@ jobs:
           additional_permissions: |
             actions: read
 
-          prompt: ${{ inputs.prompt }}
+          prompt: ${{ steps.compose.outputs.prompt }}
 
           # Marketplaces and plugin install list are kept verbatim in sync with
           # devflow.yml's `command` job and devflow-implement.yml so the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **Infrastructure failures during a provisioned review are no longer misread as PR defects.** When `devflow_runner.provision_env: true` and a service container fails to come up, the `setup-project-env` action now emits a `health_summary` of the degraded services, and `devflow-runner.yml` prepends a fenced infra-status note to the reviewer prompt telling it to attribute any resulting build/test failures to the degraded infrastructure rather than the pull request. Provisioning stays warning-only (a degraded service never fails the step), and when every service is healthy — or `provision_env` is off — the prompt is forwarded byte-for-byte unchanged, so the read-only happy path is unaffected. (#22)
+
 ### Improved
 - **DevFlow-posted comments are easier to read.** In the `/devflow:implement` workpad, the `Decisions / Notes` bullets now carry a compact time-only `HH:MM:SS` timestamp and are grouped under `### {phase}` sub-headings that match the workpad's current `Status` (the full ISO-8601 timestamp is kept only on the `Last updated:` line). The `/devflow:review` report now collapses passing verification checks into a `<details>` block — so failing and inconclusive items stay visible up front — and prefixes each Code Review Finding with a severity icon (🔴 Critical, 🟠 Important/Major, 🟡 Suggestion/Minor, ℹ️ Informational). (#34)
 ### Fixed

--- a/docs/cloud-setup.md
+++ b/docs/cloud-setup.md
@@ -283,7 +283,13 @@ does two extra things before launching Claude:
 1. Runs the `setup-project-env` action — the same provisioning the
    `/devflow:*` command path and `/devflow:implement` already use (Python /
    Node / PHP → service containers → `setup.install`), so the reviewer has a
-   real built environment.
+   real built environment. Service-container startup is best-effort: if a
+   service fails to start or never becomes healthy, the runner prepends an
+   infra-status note to the reviewer prompt naming the degraded service and
+   instructing the reviewer to attribute any resulting build/test failures to
+   infrastructure rather than the PR — so a transient outage surfaces as a clear
+   caveat instead of silently degrading the review into a false "changes
+   requested" verdict.
 2. Extends the read-only `review` tool profile with the **freeform
    `devflow_runner.allowed_tools`** list from your base-branch config — read
    verbatim from the trusted base ref. This is **language-agnostic**: a Go shop


### PR DESCRIPTION
Resolves #22.

## Summary
- `setup-project-env/action.yml` now emits a `health_summary` output listing any degraded service container (empty string when all healthy or none configured).
- `devflow-runner.yml` gains a **Compose review prompt** step: when `health_summary` is non-empty it prepends a fenced infra-status note to the reviewer prompt instructing it to attribute build/test failures to the degraded infrastructure, not the PR. When empty (all healthy, or `provision_env` off / provision step skipped) the base prompt is forwarded **byte-for-byte unchanged**.
- Provisioning remains warning-only — a degraded service never fails the step.
- `docs/cloud-setup.md` documents the infra-status note.

## Notes on the workflow wiring
The `devflow-runner.yml` consumer step could not be pushed by the automated implement run (its GitHub App token lacks `workflows` permission). It was applied in this branch from a local env and verified:
- **Degraded path** → fenced `> [!IMPORTANT]` infra-status note prepended, each degraded service named, base prompt preserved after a `---` separator.
- **Healthy/empty path** → composed prompt is byte-for-byte identical to `inputs.prompt`.

## Test Plan
- [ ] `bash lib/test/run.sh` passes (the `lib + python tests` CI check).
- [ ] Lint (actionlint) passes on the new workflow step.
- [ ] Live run on a `provision_env: true` repo: force a service failure (bad image tag) → preamble appears; healthy run → prompt unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)