### PR TITLE
Post the /devflow:implement workpad earlier and streamline its body

### DIFF
--- a/.github/workflows/devflow-implement.yml
+++ b/.github/workflows/devflow-implement.yml
@@ -221,9 +221,12 @@ jobs:
       # the earliest the requester can see a durable "job started" comment. The
       # `claude` job's Phase 1.3 detects this workpad via `workpad.py id` and
       # resumes it (filling Plan + Acceptance Criteria into the same comment) —
-      # it never posts a second one. Best-effort: continue-on-error and a guard
-      # that skips when a workpad already exists (a re-trigger on the same
-      # issue) so we never create a duplicate.
+      # it never posts a second one. Best-effort: continue-on-error so a hiccup
+      # never blocks the run. The `workpad.py id` guard below skips creation
+      # when a workpad already exists (a re-trigger on the same thread), but the
+      # *real* guarantee against two concurrent runs both creating one is the
+      # upstream `dedupe` step (this step only runs when duplicate != 'true');
+      # the `id` guard can't be atomic on its own.
       - name: Create workpad (early acknowledgement)
         if: ${{ steps.resolve.outputs.should_run == 'true' && steps.dedupe.outputs.duplicate != 'true' }}
         continue-on-error: true
@@ -245,8 +248,15 @@ jobs:
             exit 0
           fi
           BODY="$(mktemp)"
-          python3 "$WP" new-body "$NUMBER" --run-link "[View run]($RUN_URL)" > "$BODY"
-          python3 "$WP" create "$NUMBER" "$BODY"
+          # Emit an explicit warning on failure rather than letting
+          # continue-on-error swallow it silently — the claude job still
+          # creates the workpad in Phase 1.3, so the run is unaffected, but an
+          # operator gets a breadcrumb (mirrors the missing-workpad.py warning).
+          if ! { python3 "$WP" new-body "$NUMBER" --run-link "[View run]($RUN_URL)" > "$BODY" \
+                 && python3 "$WP" create "$NUMBER" "$BODY"; }; then
+            echo "::warning::early workpad create failed for #$NUMBER; the claude job will create it instead." >&2
+            exit 0
+          fi
 
       # Duplicate notice: tell the requester their command was ignored because a
       # run for this issue/PR is already in flight. Best-effort. CRITICAL: the

--- a/.github/workflows/devflow-implement.yml
+++ b/.github/workflows/devflow-implement.yml
@@ -214,6 +214,40 @@ jobs:
         # absorbed by continue-on-error (best-effort ack).
         run: bash .devflow/vendor/devflow/scripts/react-to-trigger.sh
 
+      # Early workpad: post the run's single comment NOW — before the heavy
+      # `claude` job boots and provisions its runtime (setup-project-env:
+      # Python/Node/services/deps). The workpad is a pure acknowledgment that
+      # needs none of that, so creating it here (right after auth + dedupe) is
+      # the earliest the requester can see a durable "job started" comment. The
+      # `claude` job's Phase 1.3 detects this workpad via `workpad.py id` and
+      # resumes it (filling Plan + Acceptance Criteria into the same comment) —
+      # it never posts a second one. Best-effort: continue-on-error and a guard
+      # that skips when a workpad already exists (a re-trigger on the same
+      # issue) so we never create a duplicate.
+      - name: Create workpad (early acknowledgement)
+        if: ${{ steps.resolve.outputs.should_run == 'true' && steps.dedupe.outputs.duplicate != 'true' }}
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NUMBER: ${{ steps.resolve.outputs.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          WP=.devflow/vendor/devflow/scripts/workpad.py
+          if [ ! -f "$WP" ]; then
+            echo "::warning::workpad.py not vendored at $WP; skipping early workpad (the claude job will create it)." >&2
+            exit 0
+          fi
+          # Skip if a workpad already exists (re-trigger / earlier run) so the
+          # claude job resumes it instead of getting a duplicate.
+          if python3 "$WP" id "$NUMBER" >/dev/null 2>&1; then
+            echo "Workpad already exists for #$NUMBER — leaving it for the claude job to resume."
+            exit 0
+          fi
+          BODY="$(mktemp)"
+          python3 "$WP" new-body "$NUMBER" --run-link "[View run]($RUN_URL)" > "$BODY"
+          python3 "$WP" create "$NUMBER" "$BODY"
+
       # Duplicate notice: tell the requester their command was ignored because a
       # run for this issue/PR is already in flight. Best-effort. CRITICAL: the
       # body must contain NO DevFlow trigger phrase — this comment is itself an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to DevFlow are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project aims
 to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Improved
+- **The `/devflow:implement` workpad now appears almost immediately, and reads more cleanly.** The workpad — a run's single "job started" comment — is now created by the workflow's `gate` job right after authorization and de-duplication, *before* the heavy `claude` job boots and provisions its runtime (`setup-project-env`: Python/Node/service containers/dependency installs), which the acknowledgment never needed. On repos with containers or heavy installs that removes minutes of silence between the trigger and the first comment. The `claude` job's Phase 1.3 detects the pre-created workpad (`workpad.py id`) and resumes it — filling in the Plan and Acceptance Criteria on the *same* comment — so a run still posts exactly one comment. Two readability changes ship alongside: the `Last updated:` line is now friendly UTC (`2026-05-05 17:42 UTC`) instead of raw ISO-8601, and the separate `Decisions / Notes` section is gone — its timestamped notes now nest under the matching phase inside `## Progress`, so "what happened, by phase" lives in one place (`## Devflow Reflection` remains its own collapsible section). Workpads created before this change still resume without error and keep their existing notes. A new `workpad.py new-body` subcommand emits the lean initial skeleton the `gate` job posts. See `docs/workflow-triggers.md`. (#49)
+
 ## [2.3.1] — 2026-05-24
 
 ### Fixed

--- a/docs/workflow-triggers.md
+++ b/docs/workflow-triggers.md
@@ -71,21 +71,31 @@ that runs *before* authorization and number resolution: it declines any
 
 A run maintains a **single** GitHub comment, the marker-tagged *workpad*
 (`scripts/workpad.py`). It is both the immediate "job started" acknowledgment
-and the durable progress surface — Status, the `## Progress` phase checklist,
-run/branch/PR links, Plan, Acceptance Criteria, and (collapsed in `<details>`)
-Decisions/Notes and Reflection.
+and the durable progress surface — Status, the `## Progress` phase checklist
+(with append-only timestamped notes nested under each phase), run/branch/PR
+links, Plan, Acceptance Criteria, and (collapsed in `<details>`) the Devflow
+Reflection. There is no separate Decisions / Notes section — notes live inside
+`## Progress`. The `Last updated` line is friendly UTC (`2026-05-05 17:42 UTC`),
+not raw ISO-8601.
 
 - **`track_progress: false`** on the `claude-code-action` step in
   `.github/workflows/devflow-implement.yml` disables the action's *own*
   progress comment, so the workpad is the only comment a run posts. (The
   light `/devflow:review` · `/devflow:pr-description` listener in `devflow.yml`
   keeps `track_progress` as-is — those flows have no workpad.)
-- The workpad is created as the **first GitHub write** of the run, in Phase 1
-  *before* the branch, so the requester sees acknowledgment immediately. The
-  `Run` link is built inside the runner from
-  `$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID` (standard
-  env vars — no workflow wiring needed); the `Branch` line is filled the instant
-  the branch exists, and the `PR` link once the draft PR is created in Phase 3.1.
+- The workpad is created **as early as possible**, before the requester waits
+  on any runtime. In a cloud run the **`gate` job** creates a lean workpad
+  (`workpad.py new-body` → `create`) right after authorization + dedupe — *before*
+  the heavy `claude` job boots and runs `setup-project-env` (Python/Node/services/
+  deps), which the acknowledgment does not need. The `claude` job's Phase 1.3
+  detects that workpad via `workpad.py id` and **resumes** it (filling in the Plan
+  and the real Acceptance Criteria), never posting a second comment. A local-tier
+  run (no `gate` job) creates the workpad itself in Phase 1.3 as the first GitHub
+  write. Either way it is created *before* the branch. The `Run` link is built
+  from `$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID`
+  (standard env vars — no workflow wiring needed); the `Branch` line is filled the
+  instant the branch exists, and the `PR` link once the draft PR is created in
+  Phase 3.1.
 
 ### Status-glyph / reaction vocabulary
 

--- a/lib/test/test_python_scripts.py
+++ b/lib/test/test_python_scripts.py
@@ -232,20 +232,33 @@ assert_eq("note: two notes in one call preserve argument order", True,
           prog4.index('alpha note') < prog4.index('beta note'))
 
 # Status → phase mapping, incl. the Blocked fallback to the most recent
-# in-progress (last ticked top-level) phase.
+# *ticked* (completed) top-level phase.
 PROGRESS = ("- [x] **Setup** — branch & workpad\n"
             "- [x] **Implement**\n  - [x] code + sweeps\n"
             "- [ ] **Review**\n- [ ] **Documentation**\n- [ ] **PR marked ready**\n")
+assert_eq("phase-map: Setup → Setup", "**Setup** — branch & workpad",
+          workpad._progress_phase_for_status(PROGRESS, "Setup"))
+assert_eq("phase-map: Discovering → Implement", "**Implement**",
+          workpad._progress_phase_for_status(PROGRESS, "Discovering"))
+assert_eq("phase-map: Reproducing → Implement", "**Implement**",
+          workpad._progress_phase_for_status(PROGRESS, "Reproducing"))
 assert_eq("phase-map: Planning → Implement", "**Implement**",
           workpad._progress_phase_for_status(PROGRESS, "Planning"))
 assert_eq("phase-map: Documenting → Documentation", "**Documentation**",
           workpad._progress_phase_for_status(PROGRESS, "Documenting"))
 assert_eq("phase-map: Complete → PR marked ready", "**PR marked ready**",
           workpad._progress_phase_for_status(PROGRESS, "Complete"))
-assert_eq("phase-map: Blocked → most recent in-progress (last ticked) phase",
+assert_eq("phase-map: Blocked → most recent ticked (completed) phase",
           "**Implement**", workpad._progress_phase_for_status(PROGRESS, "Blocked"))
 assert_eq("phase-map: no phases → None", None,
           workpad._progress_phase_for_status("(none yet)\n", "Setup"))
+# Graceful-degradation fall-through: a mapped phase ABSENT from the checklist
+# (e.g. a template that dropped the Documentation row) falls back to the most
+# recent ticked phase rather than returning None / crashing — so the note is
+# never dropped.
+PROGRESS_NO_DOC = "- [x] **Setup**\n- [x] **Implement**\n- [ ] **Review**\n"
+assert_eq("phase-map: mapped phase absent → falls back to last ticked (not None)",
+          "**Implement**", workpad._progress_phase_for_status(PROGRESS_NO_DOC, "Documenting"))
 
 # _append_progress_note nests under the matched phase; an unmatched/None phase
 # appends flat (un-indented) so a note is never dropped.
@@ -425,6 +438,16 @@ assert_eq("new-body: Plan + AC are placeholders (not populated)", True,
           '_(planning in progress)_' in _nb and '_(pending' in _nb)
 assert_eq("new-body: no separate Decisions / Notes section", False,
           '## Decisions / Notes' in _nb)
+# Map ↔ template drift guard: every canonical phase (and therefore every value
+# the Status→phase map resolves to) must substring-match a top-level row that
+# the new-body template actually emits — otherwise a phase rename in one place
+# misfiles notes silently. This is the cross-boundary check the import-time
+# assert (map ⊆ _PROGRESS_PHASES) can't make on its own.
+_nb_rows = [m.group(2) for line in _nb.split('## Plan', 1)[0].split('\n')
+            if (m := workpad._TOP_LEVEL_CHECKBOX_RE.match(line))]
+for _ph in workpad._PROGRESS_PHASES:
+    assert_eq(f"new-body template emits a top-level row matching phase {_ph!r}", True,
+              any(_ph.lower() in _r.lower() for _r in _nb_rows))
 # The skeleton round-trips through the mutation engine (gate creates it, the
 # claude job then mutates the same comment).
 _rt = workpad._apply_mutations(_nb, make_args(tick_progress=['**Setup**'], note=['go']))

--- a/lib/test/test_python_scripts.py
+++ b/lib/test/test_python_scripts.py
@@ -27,7 +27,9 @@ Run from repo root:
 """
 
 import argparse
+import contextlib
 import importlib.util
+import io
 import re
 import sys
 import types
@@ -99,6 +101,14 @@ WORKPAD_BODY = """<!-- devflow:workpad -->
 **Branch:** `feat/x`
 **Last updated:** 2026-05-15T00:00:00Z
 
+## Progress
+- [ ] **Setup** — branch & workpad
+- [ ] **Implement**
+  - [ ] code + sweeps
+- [ ] **Review**
+- [ ] **Documentation**
+- [ ] **PR marked ready**
+
 ## Plan
 - [ ] Step alpha
 - [ ] Step beta
@@ -107,8 +117,6 @@ WORKPAD_BODY = """<!-- devflow:workpad -->
 ## Acceptance Criteria
 - [ ] AC one
 - [ ] AC two
-
-## Decisions / Notes
 
 ## Devflow Reflection
 """
@@ -174,67 +182,81 @@ assert_eq("case-insensitive heading: AC one ticked under lowercase heading",
           True, '- [x] AC one' in out)
 
 
-print("workpad._append_note: compact timestamp + phase sub-heading grouping")
+print("workpad notes: compact timestamp + nesting under ## Progress phase")
 
-# Compact timestamp: note bullet renders `- HH:MM:SS — {note}` (no date/T/Z).
+# Compact timestamp: note bullet renders `  - HH:MM:SS — {note}` (no date/T/Z),
+# nested (indented) under its phase.
 out = workpad._apply_mutations(WORKPAD_BODY, make_args(note=['narrowed AC']))
 note_line = next(ln for ln in out.splitlines() if '— narrowed AC' in ln)
-ts = note_line.split(' — ')[0].lstrip('- ').strip()
+assert_eq("note: bullet is indented (nested under its phase)", True,
+          note_line.startswith('  - '))
+ts = note_line.split(' — ')[0].lstrip(' -').strip()
 assert_eq("note: timestamp is HH:MM:SS", True,
           bool(re.fullmatch(r'\d{2}:\d{2}:\d{2}', ts)))
 assert_eq("note: timestamp has no date / T / Z", True,
           'T' not in ts and 'Z' not in ts and '-' not in ts)
 
-# First note creates a `### {Status}` sub-heading (Status is Implementing here).
-assert_eq("note: first note creates '### Implementing' sub-heading", True,
-          '### Implementing' in out)
+# The note nests under the phase matching the Status (Implementing → Implement):
+# it lands inside the Implement block, before the next top-level phase (Review).
+prog = out.split('## Plan', 1)[0]
+assert_eq("note: Implementing-status note nests under **Implement**", True,
+          prog.index('**Implement**') < prog.index('narrowed AC')
+          and prog.index('narrowed AC') < prog.index('**Review**'))
 
-# `Last updated` stays full ISO-8601 — only the note bullet became time-only.
+# `Last updated` is friendly UTC (YYYY-MM-DD HH:MM UTC), not ISO-8601 — no
+# `T` date/time separator and no trailing `Z`.
 lu = next(ln for ln in out.splitlines() if ln.startswith('**Last updated:**'))
-assert_eq("note: Last updated remains full ISO-8601", True,
-          bool(re.search(r'\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z', lu)))
+assert_eq("note: Last updated is friendly UTC (no ISO T-separator / Z)", True,
+          bool(re.search(r'\d{4}-\d{2}-\d{2} \d{2}:\d{2} UTC', lu))
+          and not re.search(r'\dT\d', lu) and not re.search(r'\dZ', lu))
 
-# Second same-phase note reuses the sub-heading (no duplicate) and follows the first.
+# Second same-phase note follows the first, still under Implement.
 out2 = workpad._apply_mutations(out, make_args(note=['second note']))
-assert_eq("note: second same-phase note reuses sub-heading (no duplicate)", 1,
-          out2.count('### Implementing'))
-nb2 = out2.split('## Decisions / Notes', 1)[1]
-assert_eq("note: second note follows first chronologically", True,
-          nb2.index('narrowed AC') < nb2.index('second note'))
+prog2 = out2.split('## Plan', 1)[0]
+assert_eq("note: second same-phase note follows the first chronologically", True,
+          prog2.index('narrowed AC') < prog2.index('second note'))
+assert_eq("note: second same-phase note still before next phase", True,
+          prog2.index('second note') < prog2.index('**Review**'))
 
-# Combined --status + --note groups the note under the POST-mutation Status.
+# Combined --status + --note nests under the POST-mutation Status's phase.
 out3 = workpad._apply_mutations(WORKPAD_BODY, make_args(status='Reviewing', note=['x']))
-assert_eq("note: combined --status/--note groups under NEW status", True,
-          '### Reviewing' in out3)
-assert_eq("note: combined --status/--note not under old status", False,
-          '### Implementing' in out3)
+prog3 = out3.split('## Plan', 1)[0]
+assert_eq("note: combined --status/--note nests under NEW status's phase (Review)", True,
+          prog3.index('**Review**') < prog3.index('— x')
+          and prog3.index('— x') < prog3.index('**Documentation**'))
 
-# Two notes in one call: one sub-heading, argument order preserved.
+# Two notes in one call: argument order preserved, both under Implement.
 out4 = workpad._apply_mutations(WORKPAD_BODY, make_args(note=['alpha note', 'beta note']))
-assert_eq("note: two notes in one call share a single sub-heading", 1,
-          out4.count('### Implementing'))
-nb4 = out4.split('## Decisions / Notes', 1)[1]
+prog4 = out4.split('## Plan', 1)[0]
 assert_eq("note: two notes in one call preserve argument order", True,
-          nb4.index('alpha note') < nb4.index('beta note'))
+          prog4.index('alpha note') < prog4.index('beta note'))
 
-# Inter-phase insertion: a note for an EARLIER phase lands at the end of that
-# phase's block, before a later phase's sub-heading — the core multi-phase
-# lifecycle invariant (Setup → Implementing → ... across many update calls).
-MULTI_PHASE = "### Setup\n- 04:00:00 — first setup\n\n### Implementing\n- 05:00:00 — impl note\n"
-mp = workpad._append_note(MULTI_PHASE, "late setup", "04:30:00", "Setup")
-assert_eq("note: inter-phase insert reuses earlier sub-heading", 1, mp.count('### Setup'))
-assert_eq("note: inter-phase insert does not duplicate later sub-heading", 1,
-          mp.count('### Implementing'))
-assert_eq("note: inter-phase note lands inside its phase, before the next sub-heading",
-          True, mp.index('late setup') < mp.index('### Implementing'))
-assert_eq("note: inter-phase note follows the earlier same-phase bullet", True,
-          mp.index('first setup') < mp.index('late setup'))
+# Status → phase mapping, incl. the Blocked fallback to the most recent
+# in-progress (last ticked top-level) phase.
+PROGRESS = ("- [x] **Setup** — branch & workpad\n"
+            "- [x] **Implement**\n  - [x] code + sweeps\n"
+            "- [ ] **Review**\n- [ ] **Documentation**\n- [ ] **PR marked ready**\n")
+assert_eq("phase-map: Planning → Implement", "**Implement**",
+          workpad._progress_phase_for_status(PROGRESS, "Planning"))
+assert_eq("phase-map: Documenting → Documentation", "**Documentation**",
+          workpad._progress_phase_for_status(PROGRESS, "Documenting"))
+assert_eq("phase-map: Complete → PR marked ready", "**PR marked ready**",
+          workpad._progress_phase_for_status(PROGRESS, "Complete"))
+assert_eq("phase-map: Blocked → most recent in-progress (last ticked) phase",
+          "**Implement**", workpad._progress_phase_for_status(PROGRESS, "Blocked"))
+assert_eq("phase-map: no phases → None", None,
+          workpad._progress_phase_for_status("(none yet)\n", "Setup"))
 
-# Falsy phase → flat append (legacy behavior): no `### ` sub-heading is created.
-flat = workpad._append_note("- 01:00:00 — old\n", "orphan", "02:00:00", None)
-assert_eq("note: phase=None appends flat (no sub-heading)", False, '### ' in flat)
-assert_eq("note: phase=None preserves order and bullet", True,
-          flat.index('old') < flat.index('orphan') and flat.endswith('- 02:00:00 — orphan\n'))
+# _append_progress_note nests under the matched phase; an unmatched/None phase
+# appends flat (un-indented) so a note is never dropped.
+nested = workpad._append_progress_note(PROGRESS, "hi", "06:00:00", "**Review**")
+rl = next(ln for ln in nested.splitlines() if '— hi' in ln)
+assert_eq("append-progress-note: nested under Review, indented", True,
+          rl.startswith('  - ') and nested.index('— hi') < nested.index('**Documentation**'))
+flat = workpad._append_progress_note(PROGRESS, "orphan", "07:00:00", None)
+fl = next(ln for ln in flat.splitlines() if '— orphan' in ln)
+assert_eq("append-progress-note: phase=None appends flat (un-indented)", True,
+          fl.startswith('- ') and not fl.startswith('  - '))
 
 
 print("workpad: status glyph / run+PR links / ## Progress / <details>")
@@ -295,11 +317,14 @@ assert_eq("status: glyph applied to Status line", True,
 out_idem = workpad._apply_mutations(WORKPAD_V2, make_args(status='🎉 Complete'))
 assert_eq("status: re-applying a glyph-prefixed status is idempotent", 1,
           out_idem.count('🎉'))
-# A status transition while a note is added groups the note under the bare
-# phase word (no glyph in the sub-heading).
+# A status transition while a note is added nests the note under the matching
+# ## Progress phase (Reviewing → Review), keyed on the bare (glyph-stripped)
+# post-mutation Status.
 out_note = workpad._apply_mutations(WORKPAD_V2, make_args(status='Reviewing', note=['x']))
-assert_eq("status+note: sub-heading is the bare phase (no glyph)", True,
-          '### Reviewing' in out_note and '### 🚀 Reviewing' not in out_note)
+prog_note = out_note.split('## Plan', 1)[0]
+assert_eq("status+note: note nests under the new status's phase (Review)", True,
+          prog_note.index('**Review**') < prog_note.index('— x')
+          and prog_note.index('— x') < prog_note.index('**Documentation**'))
 
 # Run / PR links: replace when present.
 out = workpad._apply_mutations(WORKPAD_V2, make_args(
@@ -344,13 +369,19 @@ def _amb_progress():
 assert_raises("ambiguous --tick-progress raises _UpdateError",
               workpad._UpdateError, _amb_progress)
 
-# <details>: --note appends INSIDE the block (before </details>), not after.
-out = workpad._apply_mutations(WORKPAD_V2, make_args(status='Implementing', note=['inside?']))
-dn = out.split('## Decisions / Notes', 1)[1].split('## Devflow Reflection', 1)[0]
-assert_eq("details/note: new note is before </details>", True,
-          'inside?' in dn and dn.index('inside?') < dn.index('</details>'))
-assert_eq("details/note: still exactly one </details> in section", 1,
-          dn.count('</details>'))
+# Legacy resume: WORKPAD_V2 still carries a pre-change separate ## Decisions /
+# Notes section. --note now writes into ## Progress, must NOT error, and must
+# leave that legacy section (and its existing bullets) intact (AC: resuming a
+# pre-change workpad doesn't error or drop note content).
+out = workpad._apply_mutations(WORKPAD_V2, make_args(status='Implementing', note=['fresh note']))
+prog = out.split('## Plan', 1)[0]
+assert_eq("legacy-resume: new note nests under ## Progress (Implement phase)", True,
+          '— fresh note' in prog
+          and prog.index('**Implement**') < prog.index('fresh note'))
+assert_eq("legacy-resume: legacy ## Decisions / Notes section preserved", True,
+          '## Decisions / Notes' in out)
+assert_eq("legacy-resume: existing legacy note content not dropped", True,
+          'run started' in out)
 # <details>: --reflection appends inside the (initially empty) Reflection block.
 out = workpad._apply_mutations(WORKPAD_V2, make_args(reflection=['reflect!']))
 rf = out.split('## Devflow Reflection', 1)[1]
@@ -362,14 +393,51 @@ out = workpad._apply_mutations(WORKPAD_V2, make_args(
     status='Reviewing', note=['n'], reflection=['r'], tick_ac=['AC one']))
 assert_eq("invariant: marker is still the first line", True,
           out.startswith('<!-- devflow:workpad -->'))
-assert_eq("invariant: ## Acceptance Criteria still present and outside <details>",
+assert_eq("invariant: ## Acceptance Criteria still present and before Devflow Reflection",
           True, '## Acceptance Criteria' in out
-          and out.index('## Acceptance Criteria') < out.index('## Decisions / Notes'))
+          and out.index('## Acceptance Criteria') < out.index('## Devflow Reflection'))
 _ac = parse_acs._parse_checkboxes(
     parse_acs._extract_section(out, 'Acceptance Criteria'))
 assert_eq("invariant: AC section parses to 2 checkboxes after mutation", 2, len(_ac))
 assert_eq("invariant: AC one ticked is visible to the parser", True,
           any(i['text'] == 'AC one' and i['ticked'] for i in _ac))
+
+
+print("workpad new-body: lean initial skeleton")
+
+_buf = io.StringIO()
+with contextlib.redirect_stdout(_buf):
+    workpad.cmd_new_body(argparse.Namespace(
+        issue=7, run_link='[View run](https://x/1)', branch=None))
+_nb = _buf.getvalue()
+assert_eq("new-body: starts with the workpad marker", True,
+          _nb.startswith(workpad._workpad_marker()))
+assert_eq("new-body: Status is 🚀 Setup", True, '**Status:** 🚀 Setup' in _nb)
+assert_eq("new-body: friendly Last updated (no T / Z)", True,
+          bool(re.search(r'\*\*Last updated:\*\* \d{4}-\d{2}-\d{2} \d{2}:\d{2} UTC', _nb)))
+assert_eq("new-body: Branch placeholder", True, '**Branch:** _(creating' in _nb)
+assert_eq("new-body: run link applied", True, '[View run](https://x/1)' in _nb)
+assert_eq("new-body: has ## Progress checklist", True,
+          '## Progress' in _nb and '**Setup**' in _nb)
+assert_eq("new-body: run-started note nested (indented) under Setup", True,
+          '  - ' in _nb and '/devflow:implement run started' in _nb)
+assert_eq("new-body: Plan + AC are placeholders (not populated)", True,
+          '_(planning in progress)_' in _nb and '_(pending' in _nb)
+assert_eq("new-body: no separate Decisions / Notes section", False,
+          '## Decisions / Notes' in _nb)
+# The skeleton round-trips through the mutation engine (gate creates it, the
+# claude job then mutates the same comment).
+_rt = workpad._apply_mutations(_nb, make_args(tick_progress=['**Setup**'], note=['go']))
+assert_eq("new-body: skeleton accepts --tick-progress + --note", True,
+          '- [x] **Setup**' in _rt and '— go' in _rt)
+# --branch fills the Branch line in backticks instead of the placeholder.
+_buf2 = io.StringIO()
+with contextlib.redirect_stdout(_buf2):
+    workpad.cmd_new_body(argparse.Namespace(issue=7, run_link=None, branch='issue-7-x'))
+_nb2 = _buf2.getvalue()
+assert_eq("new-body: --branch fills Branch line", True, '**Branch:** `issue-7-x`' in _nb2)
+assert_eq("new-body: omitted --run-link → local placeholder", True,
+          '**Run:** _(local run)_' in _nb2)
 
 
 print("parse_acs._is_post_merge")

--- a/scripts/workpad.py
+++ b/scripts/workpad.py
@@ -289,13 +289,21 @@ def _status_glyph(status: str) -> str:
     return '🚀'
 
 
+# The canonical ## Progress top-level phase labels, in order — the single
+# source of truth that `_STATUS_TO_PROGRESS_PHASE` (below) and the `new-body`
+# checklist (cmd_new_body) must both agree with. A note is nested under one of
+# these rows by substring match, so renaming a phase here, in the map, or in
+# the template without updating the others would misfile notes silently; the
+# import-time assert below and the `new-body`-template test guard against that.
+_PROGRESS_PHASES = ('Setup', 'Implement', 'Review', 'Documentation', 'PR marked ready')
+
 # Maps a workpad Status word (glyph-stripped, lowercased) to the ## Progress
 # top-level phase its notes nest under. Several in-progress statuses share one
 # phase (Discovering/Reproducing/Planning/Implementing → Implement). A status
-# absent from this map (Blocked) nests under the *most recent in-progress*
-# phase — see `_progress_phase_for_status`. The lookup degrades gracefully: if
-# the mapped phase label isn't present in the checklist (a template rename), it
-# falls back to the most-recent-active phase too, so a note is never dropped.
+# absent from this map (Blocked) nests under the most recent *ticked* phase —
+# see `_progress_phase_for_status`. The lookup degrades gracefully: if the
+# mapped phase label isn't present in the checklist (a template rename), it
+# falls back the same way, so a note is never dropped.
 _STATUS_TO_PROGRESS_PHASE = {
     'setup': 'Setup',
     'discovering': 'Implement',
@@ -306,6 +314,13 @@ _STATUS_TO_PROGRESS_PHASE = {
     'documenting': 'Documentation',
     'complete': 'PR marked ready',
 }
+
+# Fail loudly at import if the map ever names a phase the canonical list doesn't
+# — a rename that would otherwise misfile notes with no signal.
+assert set(_STATUS_TO_PROGRESS_PHASE.values()) <= set(_PROGRESS_PHASES), (
+    'workpad: _STATUS_TO_PROGRESS_PHASE names a phase not in _PROGRESS_PHASES: '
+    f'{set(_STATUS_TO_PROGRESS_PHASE.values()) - set(_PROGRESS_PHASES)}'
+)
 
 # A top-level (column-0, no leading whitespace) ## Progress checkbox — one row
 # per lifecycle phase. Nested sub-items (`  - [ ] code + sweeps`) and nested
@@ -319,8 +334,8 @@ def _progress_phase_for_status(progress_content: str, status: str | None) -> str
     caller then appends the note flat).
 
     Mapped statuses nest under their phase; an unmapped status (Blocked) or a
-    mapped phase that isn't present nests under the most recent in-progress
-    phase — the last ticked top-level row, else the first phase."""
+    mapped phase that isn't present nests under the most recent *ticked*
+    (completed) top-level row, else the first phase."""
     rows = []  # (label_text, ticked)
     for line in progress_content.split('\n'):
         m = _TOP_LEVEL_CHECKBOX_RE.match(line)

--- a/scripts/workpad.py
+++ b/scripts/workpad.py
@@ -16,12 +16,13 @@ back to the built-in default `<!-- devflow:workpad -->` when the config file or
 key is absent (so it works with no config).
 
 Usage:
-    workpad.py id      ISSUE
-    workpad.py body    COMMENT_ID
-    workpad.py patch   COMMENT_ID BODY_FILE
-    workpad.py create  ISSUE BODY_FILE
+    workpad.py id        ISSUE
+    workpad.py body      COMMENT_ID
+    workpad.py patch     COMMENT_ID BODY_FILE
+    workpad.py create    ISSUE BODY_FILE
+    workpad.py new-body  ISSUE [--run-link V] [--branch V]
     workpad.py now
-    workpad.py update  ISSUE [mutations...]
+    workpad.py update    ISSUE [mutations...]
 
 `id` exits 1 with empty stdout when no workpad exists yet (so callers can
 detect "first run" via `$?` or an empty captured value, the same shape the
@@ -30,9 +31,10 @@ previous bash helper had).
 `update` is the high-level mutation entry point used by /implement at every
 phase boundary. It re-fetches the workpad body, applies the requested
 mutations atomically, auto-updates `Last updated`, and PATCHes the result.
-The Decisions/Notes section is append-only; Devflow Reflection accumulates
-bullets; checkbox sections are mutated in place rather than rewritten. See
-`workpad.py update --help` for the available mutation flags.
+Notes (`--note`) are append-only and nest under their lifecycle phase inside
+the ## Progress section; Devflow Reflection accumulates bullets; checkbox
+sections are mutated in place rather than rewritten. See `workpad.py update
+--help` for the available mutation flags.
 """
 
 import argparse
@@ -184,6 +186,56 @@ def cmd_now(_args):
     print(now.strftime('%Y-%m-%dT%H:%M:%SZ'))
 
 
+def cmd_new_body(args):
+    """Print the lean initial workpad skeleton to stdout, for piping into a file
+    and `create`. Deliberately minimal — only what's available before the run
+    does any work: status, links, friendly timestamp, and the empty ## Progress
+    checklist (with the run-started note nested under Setup). The Plan and
+    Acceptance Criteria are placeholders the orchestrator fills once it begins
+    (Phase 2.2 / Phase 1.2). Used by the `gate` job to post the acknowledgment
+    before runtime provisioning, and by the local-tier fresh-issue path."""
+    marker = _workpad_marker()
+    now_dt = datetime.datetime.now(datetime.timezone.utc)
+    last_updated = now_dt.strftime('%Y-%m-%d %H:%M UTC')
+    seed_ts = now_dt.strftime('%H:%M:%S')
+    branch = f'`{args.branch}`' if args.branch else '_(creating…)_'
+    run = args.run_link or '_(local run)_'
+    sys.stdout.write(f"""{marker}
+# DevFlow Workpad — Issue #{args.issue}
+
+**Status:** 🚀 Setup
+**Branch:** {branch}
+**Run:** {run}
+**PR:** _not yet created_
+**Last updated:** {last_updated}
+
+## Progress
+- [ ] **Setup** — branch & workpad
+  - {seed_ts} — /devflow:implement run started
+- [ ] **Implement**
+  - [ ] reproduction captured (bug issues only)
+  - [ ] code + sweeps
+- [ ] **Review**
+  - [ ] `/simplify`
+  - [ ] `review-and-fix`
+  - [ ] acceptance-criteria gate
+- [ ] **Documentation**
+- [ ] **PR marked ready**
+
+## Plan
+- [ ] _(planning in progress)_
+
+## Acceptance Criteria
+_(pending — mirrored from the issue when the run begins)_
+
+## Devflow Reflection
+<details>
+<summary>Devflow Reflection (click to expand)</summary>
+
+</details>
+""")
+
+
 # ============================================================================
 # update: high-level mutation entry point
 # ============================================================================
@@ -235,6 +287,55 @@ def _status_glyph(status: str) -> str:
     if s.startswith('blocked'):
         return '👎'
     return '🚀'
+
+
+# Maps a workpad Status word (glyph-stripped, lowercased) to the ## Progress
+# top-level phase its notes nest under. Several in-progress statuses share one
+# phase (Discovering/Reproducing/Planning/Implementing → Implement). A status
+# absent from this map (Blocked) nests under the *most recent in-progress*
+# phase — see `_progress_phase_for_status`. The lookup degrades gracefully: if
+# the mapped phase label isn't present in the checklist (a template rename), it
+# falls back to the most-recent-active phase too, so a note is never dropped.
+_STATUS_TO_PROGRESS_PHASE = {
+    'setup': 'Setup',
+    'discovering': 'Implement',
+    'reproducing': 'Implement',
+    'planning': 'Implement',
+    'implementing': 'Implement',
+    'reviewing': 'Review',
+    'documenting': 'Documentation',
+    'complete': 'PR marked ready',
+}
+
+# A top-level (column-0, no leading whitespace) ## Progress checkbox — one row
+# per lifecycle phase. Nested sub-items (`  - [ ] code + sweeps`) and nested
+# note bullets carry leading whitespace and are deliberately not matched.
+_TOP_LEVEL_CHECKBOX_RE = re.compile(r'^[-*] \[([ xX])\]\s+(.*)$')
+
+
+def _progress_phase_for_status(progress_content: str, status: str | None) -> str | None:
+    """Return the label text of the ## Progress top-level phase a note for
+    `status` nests under, or None when the section has no top-level phases (the
+    caller then appends the note flat).
+
+    Mapped statuses nest under their phase; an unmapped status (Blocked) or a
+    mapped phase that isn't present nests under the most recent in-progress
+    phase — the last ticked top-level row, else the first phase."""
+    rows = []  # (label_text, ticked)
+    for line in progress_content.split('\n'):
+        m = _TOP_LEVEL_CHECKBOX_RE.match(line)
+        if m:
+            rows.append((m.group(2), m.group(1).lower() == 'x'))
+    if not rows:
+        return None
+    key = _strip_status_glyph(status or '').strip().lower()
+    mapped = _STATUS_TO_PROGRESS_PHASE.get(key)
+    if mapped:
+        for text, _ in rows:
+            if mapped.lower() in text.lower():
+                return text
+    ticked = [text for text, t in rows if t]
+    return ticked[-1] if ticked else rows[0][0]
 
 
 def _set_or_insert_header(
@@ -392,8 +493,8 @@ def _split_details(content: str) -> tuple[str | None, str, str | None]:
     `(None, content, None)` when there is no wrapper — so the append helpers
     operate on a legacy (un-wrapped) section unchanged.
 
-    This lets `Decisions / Notes` and `Devflow Reflection` be collapsed in a
-    `<details>` block while `--note`/`--reflection` still append *inside* it
+    This lets `Devflow Reflection` be collapsed in a `<details>` block while
+    `--reflection` still appends *inside* it
     (before `</details>`), never after — which would silently fall outside the
     collapsible region."""
     lines = content.split('\n')
@@ -421,53 +522,44 @@ def _rewrap_details(head: str, new_inner: str, tail: str) -> str:
     return head.rstrip('\n') + '\n\n' + new_inner.strip('\n') + '\n' + tail + '\n'
 
 
-def _append_note(content: str, note: str, timestamp: str, phase: str | None) -> str:
-    """`<details>`-aware wrapper around `_append_note_inner` (see that function
-    for the phase-grouping semantics)."""
-    head, inner, tail = _split_details(content)
-    new_inner = _append_note_inner(inner, note, timestamp, phase)
-    if head is None:
-        return new_inner
-    return _rewrap_details(head, new_inner, tail)
+def _append_progress_note(
+    content: str, note: str, timestamp: str, phase_label: str | None
+) -> str:
+    """Insert a `  - {timestamp} — {note}` bullet nested under the ## Progress
+    top-level phase whose row text contains `phase_label`.
 
-
-def _append_note_inner(content: str, note: str, timestamp: str, phase: str | None) -> str:
-    """Append a `- {timestamp} — {note}` bullet under a `### {phase}` sub-heading.
-
-    Notes are grouped by lifecycle phase: the `### {phase}` sub-heading is
-    created on first use and reused thereafter, and bullets stay in chronological
-    order within a phase (a new bullet lands at the end of its phase's block,
-    before any later phase). `timestamp` is the time-only `HH:MM:SS` string.
-    When `phase` is falsy (no resolvable Status), the bullet is appended flat —
-    preserving the legacy append-only behavior.
-    """
-    bullet = f"- {timestamp} — {note}"
-    if not phase:
+    Notes live inside the Progress section now (no separate Decisions / Notes
+    section): the bullet lands at the end of its phase's block — after that
+    phase's sub-checkboxes and any earlier notes, before the next top-level
+    phase — so a phase's notes stay grouped and chronological across many
+    update calls. `timestamp` is the time-only `HH:MM:SS` string. When
+    `phase_label` is None, or no row matches it, the note is appended flat at
+    the end of the section so it is never dropped."""
+    lines = content.split('\n')
+    start = None
+    if phase_label:
+        for i, line in enumerate(lines):
+            m = _TOP_LEVEL_CHECKBOX_RE.match(line)
+            if m and phase_label.lower() in m.group(2).lower():
+                start = i
+                break
+    if start is None:
+        # No resolvable phase row → flat (un-nested) append at section end.
         stripped = content.rstrip('\n')
-        if stripped and not stripped.endswith('\n'):
-            stripped += '\n'
-        return stripped + bullet + '\n'
-    heading = f"### {phase}"
-    lines = content.rstrip('\n').split('\n') if content.strip() else []
-    head_idx = next(
-        (i for i, ln in enumerate(lines) if ln.strip() == heading), None
-    )
-    if head_idx is None:
-        new_lines = list(lines)
-        if new_lines and new_lines[-1].strip():
-            new_lines.append('')  # blank line before a freshly-created sub-heading
-        new_lines += [heading, bullet]
-        return '\n'.join(new_lines) + '\n'
-    # Insert after the last bullet of this phase's block — before the next
-    # `### ` sub-heading (or end of section), skipping any trailing blank lines.
+        prefix = stripped + '\n' if stripped.strip() else ''
+        return prefix + f"- {timestamp} — {note}\n"
+    # Block end: the next top-level phase row, else end of section. Nested
+    # sub-items carry leading whitespace and never match, so they stay inside
+    # the block.
     end = next(
-        (j for j in range(head_idx + 1, len(lines)) if lines[j].startswith('### ')),
+        (j for j in range(start + 1, len(lines))
+         if _TOP_LEVEL_CHECKBOX_RE.match(lines[j])),
         len(lines),
     )
-    while end > head_idx + 1 and not lines[end - 1].strip():
+    while end > start + 1 and not lines[end - 1].strip():
         end -= 1
-    new_lines = lines[:end] + [bullet] + lines[end:]
-    return '\n'.join(new_lines) + '\n'
+    new_lines = lines[:end] + [f"  - {timestamp} — {note}"] + lines[end:]
+    return '\n'.join(new_lines) + ('\n' if content.endswith('\n') else '')
 
 
 def _append_bullet(content: str, text: str) -> str:
@@ -580,7 +672,10 @@ def _apply_mutations(body: str, args) -> str:
     """Apply all mutations from args atomically. Raises _UpdateError on any
     failure; caller should not patch on failure."""
     now_dt = datetime.datetime.now(datetime.timezone.utc)
-    now = now_dt.strftime('%Y-%m-%dT%H:%M:%SZ')  # full ISO for `Last updated`
+    # Friendly UTC for the human-facing `Last updated` line (the `now`
+    # subcommand still prints full ISO-8601 for machine uses like follow-up
+    # issue bodies; note bullets keep their time-only HH:MM:SS prefix).
+    last_updated = now_dt.strftime('%Y-%m-%d %H:%M UTC')
     now_time = now_dt.strftime('%H:%M:%S')        # time-only for note bullets
 
     # Front-matter mutations.
@@ -606,15 +701,14 @@ def _apply_mutations(body: str, args) -> str:
         )
 
     # Always refresh Last updated.
-    body, n = _LAST_UPDATED_RE.subn(f'**Last updated:** {now}', body, count=1)
+    body, n = _LAST_UPDATED_RE.subn(f'**Last updated:** {last_updated}', body, count=1)
     if n == 0:
         raise _UpdateError('Last updated line not found in workpad')
 
-    # Notes are grouped under a `### {Status}` sub-heading. Read the
+    # Notes nest under their lifecycle phase inside ## Progress. Read the
     # post-mutation Status so a combined `--status X --note Y` call files the
-    # note under X (the status line was already rewritten above). Strip the
-    # leading glyph so the sub-heading is the bare phase word ("Implementing"),
-    # not "🚀 Implementing".
+    # note under X's phase (the status line was already rewritten above). Strip
+    # the leading glyph so the phase lookup keys on the bare word ("Reviewing").
     status_match = _STATUS_VALUE_RE.search(body)
     current_phase = (
         _strip_status_glyph(status_match.group(1).strip()) if status_match else None
@@ -683,12 +777,13 @@ def _apply_mutations(body: str, args) -> str:
             )
 
     if args.note:
-        idx = _find_section(sections, 'Decisions / Notes')
+        idx = _find_section(sections, 'Progress')
         if idx is None:
-            raise _UpdateError("section '## Decisions / Notes' not found")
+            raise _UpdateError("section '## Progress' not found")
         heading, content = sections[idx]
+        phase_label = _progress_phase_for_status(content, current_phase)
         for text in args.note:
-            content = _append_note(content, text, now_time, current_phase)
+            content = _append_progress_note(content, text, now_time, phase_label)
         sections[idx] = (heading, content)
 
     if args.reflection:
@@ -728,6 +823,19 @@ def main():
     s = sub.add_parser('now', help='UTC ISO-8601 timestamp.')
     s.set_defaults(func=cmd_now)
 
+    s = sub.add_parser(
+        'new-body',
+        help='Print the lean initial workpad skeleton to stdout (pipe to a '
+             'file, then `create`).',
+    )
+    s.add_argument('issue', type=int)
+    s.add_argument('--run-link', metavar='VALUE', default=None,
+                   help='Run front-matter value (markdown ok). Defaults to a '
+                        '"_(local run)_" placeholder when omitted.')
+    s.add_argument('--branch', metavar='VALUE', default=None,
+                   help='Branch name. Defaults to a "_(creating…)_" placeholder.')
+    s.set_defaults(func=cmd_new_body)
+
     u = sub.add_parser(
         'update',
         help='Apply atomic mutations to the workpad and PATCH. Re-fetches the '
@@ -760,9 +868,9 @@ def main():
                    help='Find one AC matching OLD; replace its text with NEW. '
                         'Preserves the checkbox state. For Phase 2.2.6.')
     u.add_argument('--note', metavar='TEXT', action='append', default=[],
-                   help='Append a Decisions/Notes entry, prefixed with a '
-                        'time-only HH:MM:SS UTC timestamp and grouped under a '
-                        '### {current Status} sub-heading. May be passed '
+                   help='Append a note bullet, prefixed with a time-only '
+                        'HH:MM:SS UTC timestamp and nested under the current '
+                        'Status\'s phase inside ## Progress. May be passed '
                         'multiple times to append several entries (sharing one '
                         'timestamp) in one atomic update.')
     u.add_argument('--reflection', metavar='TEXT', action='append', default=[],

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -27,7 +27,7 @@ Output the phase header at the start of each phase so progress is trackable.
 
 ## Workpad Reference
 
-Throughout the run you maintain exactly **one** marker-tagged comment on the GitHub issue — the *workpad*. It is the run's **single GitHub comment** and durable progress surface: it is created as the very first GitHub write (Phase 1.2, before the branch), serves as the immediate "job started" acknowledgment, and re-runs and follow-up runs resume from it. It is the source of truth for the acceptance-criteria gate in Phase 3. claude-code-action's own progress comment is disabled (`track_progress: false` in `devflow-implement.yml`), so the workpad is the *only* comment a run posts.
+Throughout the run you maintain exactly **one** marker-tagged comment on the GitHub issue — the *workpad*. It is the run's **single GitHub comment** and durable progress surface, the immediate "job started" acknowledgment, and the thing re-runs and follow-up runs resume from. In cloud runs the `gate` job creates a lean workpad *before* the heavy `claude` job boots (so the acknowledgment lands as early as possible); Phase 1.3 then **detects and resumes** it, filling in the Plan and Acceptance Criteria — it never posts a second comment. In a local-tier run (no `gate` job) Phase 1.3 creates the workpad itself as the first GitHub write. Either way it is the source of truth for the acceptance-criteria gate in Phase 3, and claude-code-action's own progress comment is disabled (`track_progress: false` in `devflow-implement.yml`), so the workpad is the *only* comment a run posts.
 
 **Status glyph (canonical, reaction-compatible).** The `Status` line always begins with a glyph that `workpad.py` derives from the status word — you pass a bare status (`--status Setup`, `--status Complete`, `--status Blocked`) and the helper prepends it: 🚀 for any in-progress phase (Setup/Discovering/Reproducing/Planning/Implementing/Reviewing/Documenting), 🎉 for `Complete`, 👎 for `Blocked`. The same vocabulary drives the triggering-comment reaction (🚀 `rocket` on pickup → 🎉 `hooray` on Complete → 👎 `-1` on Blocked), so the comment glyph and the reaction always match. (✅/❌ are *not* valid GitHub reactions, which is why 👎 is the Blocked glyph.)
 
@@ -57,7 +57,7 @@ If the triggering comment can't be resolved (a review-body trigger has no reacti
 
 The workpad comment body MUST start with the marker line on its own line, followed by these sections (omit `Reproduction` when the issue is not labelled `bug`):
 
-The always-visible region (marker line, header, `Status`, links, `## Progress`, `## Plan`, `## Acceptance Criteria`) stays uncollapsed so the comment is scannable at a glance; the two append-only growing sections (`## Decisions / Notes`, `## Devflow Reflection`) are wrapped in `<details>` blocks so they don't push the rest of the comment out of view. **Keep `## Acceptance Criteria` outside any `<details>`** — the Phase 3.4 gate reads it.
+The always-visible region (marker line, header, `Status`, links, `## Progress`, `## Plan`, `## Acceptance Criteria`) stays uncollapsed so the comment is scannable at a glance. Append-only notes (`--note`) nest under their lifecycle phase *inside* `## Progress` — there is no separate Decisions / Notes section. Only `## Devflow Reflection` is wrapped in a `<details>` block so its accumulating bullets don't push the rest of the comment out of view. **Keep `## Acceptance Criteria` outside any `<details>`** — the Phase 3.4 gate reads it.
 
 ```markdown
 <!-- devflow:workpad -->
@@ -67,10 +67,11 @@ The always-visible region (marker line, header, `Status`, links, `## Progress`, 
 **Branch:** `{branch}`
 **Run:** [View run]({run_url})
 **PR:** _not yet created_
-**Last updated:** {output of `workpad.py now`, e.g. 2026-05-05T17:42:11Z}
+**Last updated:** {friendly UTC, auto-refreshed by `update`, e.g. 2026-05-05 17:42 UTC}
 
 ## Progress
 - [ ] **Setup** — branch & workpad
+  - {HH:MM:SS} — {append-only note, nested under the phase it was logged in}
 - [ ] **Implement**
   - [ ] reproduction captured (bug issues only)
   - [ ] code + sweeps
@@ -89,14 +90,6 @@ The always-visible region (marker line, header, `Status`, links, `## Progress`, 
 
 ## Reproduction
 {captured signal — failing test, error log, or repro command. Section only present for `bug`-labelled issues.}
-
-## Decisions / Notes
-<details>
-<summary>Decisions / Notes (click to expand)</summary>
-
-### {phase — the workpad's `Status` when the note was appended, e.g. Setup}
-- {HH:MM:SS} — {append-only chronological note}
-</details>
 
 ## Devflow Reflection
 <details>
@@ -118,7 +111,8 @@ Subcommand reference:
 | --- | --- |
 | `workpad.py id ISSUE` | Print the workpad comment ID, or exit 1 with empty stdout if none exists. |
 | `workpad.py body COMMENT_ID` | Print the full body of an existing workpad. |
-| `workpad.py create ISSUE BODY_FILE` | Create the workpad on a fresh issue and print the new comment ID. Use this exactly once per issue, in Phase 1.2 (the first GitHub write). |
+| `workpad.py create ISSUE BODY_FILE` | Create the workpad on a fresh issue from a body file and print the new comment ID. Use at most once per issue (the cloud `gate` job already does this; the local fresh-issue path does it in 1.3). |
+| `workpad.py new-body ISSUE [--run-link V] [--branch V]` | Print the lean initial workpad skeleton to stdout (Status/links/timestamp + empty `## Progress`, placeholder Plan/AC). Pipe to a temp file, then `create`. |
 | `workpad.py update ISSUE [mutations...]` | Apply atomic mutations and PATCH. **This is the mutation entry point used at every phase boundary after creation.** See the flags below. |
 | `workpad.py now` | Canonical UTC ISO-8601 timestamp. (`update` already refreshes `Last updated` automatically; use `now` only when you need a timestamp in some other string, e.g. a follow-up issue body.) |
 | `workpad.py patch COMMENT_ID BODY_FILE` | Low-level body-file PATCH. Prefer `update`; only use this for bulk-rewrite cases the `update` flags don't cover. |
@@ -135,7 +129,7 @@ Subcommand reference:
 | `--tick-plan TEXT` | Tick one unticked Plan checkbox whose text contains TEXT (substring). Fails if TEXT matches zero unticked checkboxes or multiple. **Repeatable** — pass multiple times to tick several boxes in one atomic update. |
 | `--tick-ac TEXT` | Same, for Acceptance Criteria. **Repeatable.** |
 | `--rewrite-ac OLD NEW` | Phase 2.2.6: find an AC by OLD substring, replace its full text with NEW, keep the box state. |
-| `--note TEXT` | Append a Decisions / Notes entry, prefixed with a time-only `HH:MM:SS` UTC timestamp and grouped under a `### {current Status}` sub-heading (created on first use, reused thereafter). **Repeatable** — multiple notes in one call share the same timestamp, land under the current `Status` sub-heading, and are appended in argument order. |
+| `--note TEXT` | Append a note bullet, prefixed with a time-only `HH:MM:SS` UTC timestamp and nested under the current `Status`'s phase inside `## Progress` (Setup/Discovering/…/Complete map to the matching top-level phase row; Blocked nests under the most recent in-progress phase). **Repeatable** — multiple notes in one call share the same timestamp and are appended in argument order. |
 | `--reflection TEXT` | Append a bullet to Devflow Reflection (no timestamp). **Repeatable.** |
 | `--replace-plan-file FILE` | Replace the Plan section content with FILE. |
 | `--replace-acs-file FILE` | Phase 2.2.5: replace Acceptance Criteria content with FILE. |
@@ -144,7 +138,7 @@ Subcommand reference:
 `update` always re-fetches the live body before mutating (this narrows but does not eliminate the clobber window for concurrent edits; acceptable because the orchestrator is the single writer in practice), always refreshes `Last updated`, and PATCHes atomically — within a single `update` call, all of its mutations apply or none do. The patched body is printed to stdout so callers can verify the change actually landed.
 
 Helper invariants baked into the script (orchestrator doesn't need to enforce them):
-- Decisions / Notes is append-only — `--note` only appends, never rewrites; each bullet is grouped under a `### {current Status}` sub-heading and carries a time-only `HH:MM:SS` prefix.
+- Notes are append-only — `--note` only appends, never rewrites; each bullet nests under its lifecycle phase inside `## Progress` and carries a time-only `HH:MM:SS` prefix.
 - `--note`/`--reflection` are **`<details>`-aware**: when the section body is wrapped in a `<details>` block (the template default), the new bullet is inserted *inside* the block (before `</details>`), never after — so the collapsible region stays intact and the marker-first / AC-parseable invariants hold.
 - The `Status` glyph is owned by the helper — `--status` derives and prepends it, and the `### {Status}` note sub-heading uses the bare phase word (no glyph).
 - Devflow Reflection accumulates bullets — `--reflection` only appends.
@@ -156,7 +150,7 @@ The helper reads `devflow.workpad_marker` from `.devflow/config.json`, falling b
 
 **Never create a second workpad on the same issue.** Phase 1.2 creates exactly one; every subsequent mutation goes through `update`. If you lose `$ISSUE_NUMBER` mid-run (context compaction), recover from `git log`, `git branch --show-current`, and `gh pr list --head $(git branch --show-current)` — then resume with `workpad.py update $ISSUE_NUMBER ...`.
 
-When a workpad already exists at the start of a re-run, treat its `Decisions / Notes` and `Devflow Reflection` as load-bearing context — read them via `workpad.py body $(workpad.py id $ISSUE_NUMBER)` before deciding what to do next. If `Status` is `Blocked`, surface `Devflow Reflection` to the user and pause for confirmation before proceeding past Phase 1 — otherwise an automated re-run will blow through the gate that originally stopped the previous run.
+When a workpad already exists at the start of a re-run, treat its `## Progress` notes and `Devflow Reflection` as load-bearing context — read them via `workpad.py body $(workpad.py id $ISSUE_NUMBER)` before deciding what to do next. (A `gate`-pre-created workpad on a fresh issue carries only the run-started note, so there is nothing prior to reconcile.) If `Status` is `Blocked`, surface `Devflow Reflection` to the user and pause for confirmation before proceeding past Phase 1 — otherwise an automated re-run will blow through the gate that originally stopped the previous run.
 
 **Always verify a Status PATCH actually landed.** `update` prints the new body on stdout — confirm the new `Status:` line is present before advancing to the next phase. (`gh api -X PATCH` can return success while the comment body is unchanged: transient API errors, oversized bodies, throttling.) If the response shows a stale `Status`, re-issue the `update` before continuing. Plan/Notes-only updates don't need this check.
 
@@ -166,7 +160,7 @@ When a workpad already exists at the start of a re-run, treat its `Decisions / N
 
 Output: `Phase 1/4: Setup — creating the workpad and branch...`
 
-**Ordering matters in Phase 1.** The workpad is the run's *only* GitHub comment and its "job started" acknowledgment, so it must be the **first GitHub write** — created (1.3) *before* the branch (1.4). Fetch the issue (1.1) and parse its acceptance criteria (1.2) first because the workpad body mirrors them; then create the workpad; then create the branch and immediately fill the workpad's `Branch` line.
+**Ordering matters in Phase 1.** The workpad is the run's *only* GitHub comment and its "job started" acknowledgment. In a cloud run the `gate` job has already created a lean workpad before this skill starts, so 1.3 **resumes** it; in a local-tier run 1.3 creates it as the **first GitHub write** — either way before the branch (1.4). Fetch the issue (1.1) and parse its acceptance criteria (1.2) first because the workpad body mirrors them; then initialize-or-load the workpad and populate its Acceptance Criteria; then create the branch and immediately fill the workpad's `Branch` line.
 
 ### 1.1 Fetch the GitHub Issue
 
@@ -195,13 +189,13 @@ A post-merge criterion is **not** deferred work (that's the 2.2.5 rule) — the 
 - *Demote to code-verifiable* — when a matching phrase appears inside quoted/example text within the criterion rather than describing the verification step itself (e.g. the criterion quotes a function name that happens to contain "click"). Strip the ` (post-merge)` suffix in the file before mirroring.
 - *Promote to post-merge* — when no trigger phrase matched but the criterion's intent clearly requires a live PR/deploy/CI environment. Append ` (post-merge)`.
 
-Either kind of override goes into `Decisions / Notes` with a one-line reason.
+Either kind of override goes into the workpad notes (`--note`) with a one-line reason.
 
 A criterion that is partially live (mixed code + live concerns) is tagged post-merge — verify the code-part during /devflow:implement, leave the live-part for after-merge.
 
-### 1.3 Initialize or Load the Workpad (first GitHub write)
+### 1.3 Initialize or Load the Workpad
 
-This is the **first GitHub write of the run** — before the branch exists — so the requester sees an acknowledgment immediately. Set `ISSUE_NUMBER=$ARGUMENTS`, derive the run link, and check whether a workpad already exists:
+The workpad is created before the branch exists so the requester sees an acknowledgment immediately. In a cloud run the `gate` job already posted a lean workpad; in a local run you create it here. Set `ISSUE_NUMBER=$ARGUMENTS`, derive the run link, and check whether a workpad already exists:
 
 ```bash
 ISSUE_NUMBER=$ARGUMENTS
@@ -209,8 +203,23 @@ RUN_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"   # 
 WORKPAD_ID=$(${CLAUDE_SKILL_DIR}/../../scripts/workpad.py id "$ISSUE_NUMBER" || true)
 ```
 
-- **`WORKPAD_ID` empty (fresh issue)** → Build the initial body to a temp file, following the **Workpad section template** above exactly: `**Status:** 🚀 Setup`; `**Branch:** _(creating…)_` (a placeholder — filled in 1.4 the instant the branch exists, so it is never left blank on a completed run); `**Run:** [View run]($RUN_URL)`; `**PR:** _not yet created_`; a placeholder `Last updated:`; the `## Progress` checklist (all unticked); empty `## Plan` (filled in during 2.2); the AC contents from `/tmp/acs-${ARGUMENTS}.md` (produced by 1.2); no `## Reproduction` section yet (added in 2.1.5 if applicable); `## Decisions / Notes` as a `<details>` block seeded under a `### Setup` sub-heading with one time-only bullet (`- {HH:MM:SS} — /devflow:implement run started`, where `{HH:MM:SS}` is the time portion of `workpad.py now`); and an empty `## Devflow Reflection` `<details>` block. Then `workpad.py create $ISSUE_NUMBER <tmp-file>`. (Do **not** pass a glyph-less `Status:` — the template seeds `🚀 Setup` directly; later transitions go through `--status`, which manages the glyph.)
-- **`WORKPAD_ID` non-empty (resume)** → Read the live body with `workpad.py body $WORKPAD_ID`. Treat its `Decisions / Notes` and `Devflow Reflection` as load-bearing context (see Workpad Reference). To reset for this run, apply: `workpad.py update $ISSUE_NUMBER --status Setup --run-link "[View run]($RUN_URL)" --note "/devflow:implement re-run started"`. If the issue's Acceptance Criteria section changed since the last run, also pass `--replace-acs-file /tmp/acs-${ARGUMENTS}.md`. **Legacy-workpad migration (required):** a workpad created before this change won't have `Run`/`PR`/`## Progress` lines. `--run-link`/`--pr-link` insert the missing header lines on their own, but `--tick-progress` (used at every later phase boundary) will **abort the run** with `section '## Progress' not found` if the section is absent. So when resuming such a workpad you MUST seed a `## Progress` section before Phase 1.5 — `workpad.py body` the live comment, splice the `## Progress` checklist from the template above into the body (right after the front-matter, before `## Plan`), and `workpad.py patch $WORKPAD_ID <file>`. Do not leave it to chance: skip this and the first `--tick-progress` call fails closed.
+- **`WORKPAD_ID` empty (fresh issue — local-tier run with no `gate` job)** → Build the lean skeleton with the helper and create it, then mirror the issue's Acceptance Criteria into it:
+  ```bash
+  BODY=$(mktemp)
+  workpad.py new-body $ISSUE_NUMBER --run-link "[View run]($RUN_URL)" > "$BODY"   # omit --run-link for a local run → "_(local run)_" placeholder
+  workpad.py create $ISSUE_NUMBER "$BODY"
+  workpad.py update $ISSUE_NUMBER --replace-acs-file /tmp/acs-${ARGUMENTS}.md
+  ```
+  `new-body` seeds `**Status:** 🚀 Setup`, the `**Branch:** _(creating…)_` placeholder (filled in 1.4 the instant the branch exists), the friendly `Last updated`, the full `## Progress` checklist with the `/devflow:implement run started` note nested under Setup, a placeholder `## Plan` (filled in 2.2), a placeholder `## Acceptance Criteria` (you replace it above), and an empty `## Devflow Reflection` `<details>` block. The `## Reproduction` section is added later in 2.1.5 if applicable.
+- **`WORKPAD_ID` non-empty (resume — the normal cloud path, since `gate` pre-created it; or a re-run)** → Read the live body with `workpad.py body $WORKPAD_ID`. Treat its `## Progress` notes and `Devflow Reflection` as load-bearing context (see Workpad Reference). Reset for this run **and populate the Acceptance Criteria** (a `gate`-created workpad carries only a placeholder AC section, so always replace it):
+  ```bash
+  workpad.py update $ISSUE_NUMBER \
+      --status Setup \
+      --run-link "[View run]($RUN_URL)" \
+      --replace-acs-file /tmp/acs-${ARGUMENTS}.md \
+      --note "/devflow:implement run resumed"
+  ```
+  **Legacy-workpad migration (required):** a workpad created before run/PR links and the `## Progress` checklist existed won't have those lines. `--run-link`/`--pr-link` insert the missing header lines on their own, but `--tick-progress`/`--note` (used at every later phase boundary) will **abort the run** with `section '## Progress' not found` if the section is absent. So when resuming such a workpad you MUST seed a `## Progress` section before Phase 1.5 — `workpad.py body` the live comment, splice the `## Progress` checklist from the template above into the body (right after the front-matter, before `## Plan`), and `workpad.py patch $WORKPAD_ID <file>`. Do not leave it to chance: skip this and the first `--tick-progress`/`--note` call fails closed.
 
 After this step, every later phase boundary touches the workpad via `workpad.py update $ISSUE_NUMBER ...` — no `WORKPAD_ID` variable to track across calls.
 
@@ -335,7 +344,7 @@ Steps when scoping down:
        --note "scope decision: {which subset this PR delivers}. Deferred (verbatim): {list}. Will be tracked in follow-up issue(s) filed in Phase 4.0."
    ```
 
-This is not "inventing" criteria (forbidden by 1.4) — the deferred items are preserved verbatim in `Decisions / Notes` and carried forward by Phase 4.0.
+This is not "inventing" criteria (forbidden by 1.4) — the deferred items are preserved verbatim in the workpad notes (`--note`) and carried forward by Phase 4.0.
 
 If you are unsure whether to scope down, prefer a single fully-in-scope PR. Only re-scope when the issue body itself describes phased work or the diff would otherwise exceed reasonable PR size.
 
@@ -416,7 +425,7 @@ After implementing, before running tests, do this sweep:
 
 1. From `git diff --staged -U0` (or `git diff -U0`), list every function/method/query/new file your diff added or changed lines in.
 2. Re-read each one in its post-edit state and check it against the rules in `CLAUDE.md` that apply to the languages and surfaces your diff touched.
-3. Fix any violation in code the diff already touches. If fixing it cleanly is genuinely out of scope (it would balloon the diff into an unrelated refactor), say so explicitly in the workpad `Decisions / Notes` with the reason — do not leave it silent for `/devflow:review` to catch.
+3. Fix any violation in code the diff already touches. If fixing it cleanly is genuinely out of scope (it would balloon the diff into an unrelated refactor), say so explicitly in the workpad notes (`--note`) with the reason — do not leave it silent for `/devflow:review` to catch.
 4. Do not reformat or rename code the diff didn't otherwise touch — this sweep covers only lines/functions/files your change already modified or introduced, never a repo-wide cleanup.
 
 Treat a known convention violation in touched code as a defect in **this** PR, not a pre-existing-style excuse — if the diff touched it, it leaves `CLAUDE.md`-compliant.
@@ -538,22 +547,22 @@ If the skill exits with unresolved findings after 4 iterations: `workpad.py upda
 Before advancing to Phase 4, verify every **non-post-merge** checkbox in the workpad's `## Acceptance Criteria` section is ticked (`- [x]`). For each criterion, the verification is one of:
 
 - a passing test in the diff that demonstrates the criterion,
-- a documented manual check (recorded in `Decisions / Notes` with the result), or
+- a documented manual check (recorded in the workpad notes via `--note` with the result), or
 - a code reference (file:line) that satisfies the criterion.
 
-Tick each criterion as you confirm it: `workpad.py update $ISSUE_NUMBER --tick-ac "{substring of AC text}"`. Cite the verification (a test, a file:line, or a Decisions/Notes entry) in a `--note` on the same call where helpful.
+Tick each criterion as you confirm it: `workpad.py update $ISSUE_NUMBER --tick-ac "{substring of AC text}"`. Cite the verification (a test, a file:line, or a prior note) in a `--note` on the same call where helpful.
 
 **Post-merge criteria are exempt from the gate.** A criterion whose checkbox line ends in `(post-merge)` (tagged during Phase 1.2) does not block. The orchestrator's responsibility for a post-merge criterion ends at "the code reaches the state where the live verification *becomes possible* to run." Leave the checkbox unticked — the merger will tick it after deploy via the `## Post-Merge Verification` section that `/pr-description` adds to the PR body in Phase 4.2. Do **not** invent evidence to tick a post-merge box during /devflow:implement; the live signal is what counts.
 
 If the workpad's Acceptance Criteria section reads `_(none provided in issue body)_`, the gate passes trivially.
 
-The gate applies only to criteria currently in the workpad's `## Acceptance Criteria` section. If you scoped down via the 2.2.5 rule, deferred criteria live in `Decisions / Notes` and are **not** gated here — they will be carried into a follow-up issue in Phase 4.0.
+The gate applies only to criteria currently in the workpad's `## Acceptance Criteria` section. If you scoped down via the 2.2.5 rule, deferred criteria live in the workpad notes and are **not** gated here — they will be carried into a follow-up issue in Phase 4.0.
 
 If non-post-merge criteria remain unchecked after Phase 3.3:
 
 1. If a criterion is satisfiable with a small follow-up edit, do it now (still inside Phase 3) — write the code, run tests, commit (using the `fix:` prefix), tick the box, and continue.
-2. If a criterion's *literal text* is now stale because /simplify or /devflow:review-and-fix refactored the structure (e.g. renamed jobs, merged files), but the *underlying behavior* the criterion verifies is preserved in the diff, apply **2.2.6** now: rewrite the AC text in the workpad with a `Decisions / Notes` paper trail, then tick the box.
-3. If a criterion is genuinely outside this PR's scope and you missed it during 2.2.5, **go back to 2.2.5 now**: move the item to `Decisions / Notes` as deferred, rewrite the Acceptance Criteria section, PATCH, and re-run this gate against the narrowed set. Then continue to Phase 4.
+2. If a criterion's *literal text* is now stale because /simplify or /devflow:review-and-fix refactored the structure (e.g. renamed jobs, merged files), but the *underlying behavior* the criterion verifies is preserved in the diff, apply **2.2.6** now: rewrite the AC text in the workpad with a `--note` paper trail, then tick the box.
+3. If a criterion is genuinely outside this PR's scope and you missed it during 2.2.5, **go back to 2.2.5 now**: move the item to the workpad notes (`--note`) as deferred, rewrite the Acceptance Criteria section, PATCH, and re-run this gate against the narrowed set. Then continue to Phase 4.
 4. Otherwise — i.e. the criterion is in-scope but you cannot satisfy it AND it is not tagged `(post-merge)` — `workpad.py update $ISSUE_NUMBER --status Blocked --reflection "AC unmet (in-scope, not post-merge): {AC text}"`, then emit the 👎 outcome reaction (see *Outcome reaction* in the Workpad Reference) and stop the run with a clear report to the user. Do **not** advance to Phase 4 with unmet in-scope, non-post-merge criteria.
 
 Once the gate passes (every non-post-merge AC ticked), tick the gate **and its parent phase** in the workpad: `workpad.py update $ISSUE_NUMBER --tick-progress "acceptance-criteria gate" --tick-progress "**Review**"`.
@@ -574,7 +583,7 @@ Output: `Phase 4/4: Documentation — updating docs and finalizing PR...`
 
 If Phase 2.2.5's scope-adjustment rule deferred any acceptance criteria, file a follow-up GitHub issue capturing them now. Skip this step if no criteria were deferred.
 
-For each logical chunk of deferred work (typically: one issue per remaining "phase" in a phased cleanup), create a GitHub issue. If multiple follow-up issues are needed, issue all `gh issue create` calls in a single assistant turn so they run in parallel, and append a single combined `Decisions / Notes` entry afterward (do not PATCH the workpad between each `gh issue create`):
+For each logical chunk of deferred work (typically: one issue per remaining "phase" in a phased cleanup), create a GitHub issue. If multiple follow-up issues are needed, issue all `gh issue create` calls in a single assistant turn so they run in parallel, and append a single combined note (`--note`) afterward (do not PATCH the workpad between each `gh issue create`):
 
 ```bash
 gh issue create \

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -129,7 +129,7 @@ Subcommand reference:
 | `--tick-plan TEXT` | Tick one unticked Plan checkbox whose text contains TEXT (substring). Fails if TEXT matches zero unticked checkboxes or multiple. **Repeatable** — pass multiple times to tick several boxes in one atomic update. |
 | `--tick-ac TEXT` | Same, for Acceptance Criteria. **Repeatable.** |
 | `--rewrite-ac OLD NEW` | Phase 2.2.6: find an AC by OLD substring, replace its full text with NEW, keep the box state. |
-| `--note TEXT` | Append a note bullet, prefixed with a time-only `HH:MM:SS` UTC timestamp and nested under the current `Status`'s phase inside `## Progress` (Setup/Discovering/…/Complete map to the matching top-level phase row; Blocked nests under the most recent in-progress phase). **Repeatable** — multiple notes in one call share the same timestamp and are appended in argument order. |
+| `--note TEXT` | Append a note bullet, prefixed with a time-only `HH:MM:SS` UTC timestamp and nested under the current `Status`'s phase inside `## Progress` (Setup/Discovering/…/Complete map to the matching top-level phase row; Blocked nests under the most recent completed phase). **Repeatable** — multiple notes in one call share the same timestamp and are appended in argument order. |
 | `--reflection TEXT` | Append a bullet to Devflow Reflection (no timestamp). **Repeatable.** |
 | `--replace-plan-file FILE` | Replace the Plan section content with FILE. |
 | `--replace-acs-file FILE` | Phase 2.2.5: replace Acceptance Criteria content with FILE. |
@@ -139,8 +139,8 @@ Subcommand reference:
 
 Helper invariants baked into the script (orchestrator doesn't need to enforce them):
 - Notes are append-only — `--note` only appends, never rewrites; each bullet nests under its lifecycle phase inside `## Progress` and carries a time-only `HH:MM:SS` prefix.
-- `--note`/`--reflection` are **`<details>`-aware**: when the section body is wrapped in a `<details>` block (the template default), the new bullet is inserted *inside* the block (before `</details>`), never after — so the collapsible region stays intact and the marker-first / AC-parseable invariants hold.
-- The `Status` glyph is owned by the helper — `--status` derives and prepends it, and the `### {Status}` note sub-heading uses the bare phase word (no glyph).
+- `--reflection` is **`<details>`-aware**: because `## Devflow Reflection` is wrapped in a `<details>` block, the new bullet is inserted *inside* the block (before `</details>`), never after — so the collapsible region stays intact and the marker-first / AC-parseable invariants hold. (`--note` writes plain bullets into the un-wrapped `## Progress` section, so this doesn't apply to it.)
+- The `Status` glyph is owned by the helper — `--status` derives and prepends it, and a note's phase is resolved from the bare (glyph-stripped) Status word.
 - Devflow Reflection accumulates bullets — `--reflection` only appends.
 - `--tick-*` flags edit only the box character and preserve the rest of the line.
 - `--rewrite-ac` preserves the original checkbox state (don't tick during a 2.2.6 rewrite — the gate ticks later via `--tick-ac`).


### PR DESCRIPTION
<!-- PR_BODY_START -->
## Summary
- Post the `/devflow:implement` workpad from the workflow's `gate` job — before the heavy `claude` job boots and provisions its runtime — so the requester sees the "job started" comment minutes sooner on repos with containers/heavy installs.
- Streamline the workpad: friendlier `Last updated` timestamp, and merge the separate `Decisions / Notes` section into `## Progress` (notes nest under their phase).
- Still exactly one comment per run: the `claude` job's Phase 1.3 detects and resumes the gate-created workpad rather than posting a second one.

## Changes
**Workflow (`.github/workflows/devflow-implement.yml`)**: New `gate`-job step creates the workpad (`workpad.py new-body` → `create`) after auth + dedupe and before the `claude` job's `setup-project-env`. Guarded to skip on a duplicate run or when a workpad already exists (re-trigger).

**Workpad helper (`scripts/workpad.py`)**: `Last updated` now renders as friendly UTC (`YYYY-MM-DD HH:MM UTC`); the `now` subcommand and note `HH:MM:SS` prefixes are unchanged. `--note` bullets now nest under the matching `## Progress` phase (Status→phase map; `Blocked`/unmapped → most recent in-progress phase) instead of a separate `## Decisions / Notes` section. New `new-body` subcommand emits the lean initial skeleton.

**Implement skill (`skills/implement/SKILL.md`)**: Body template, Phase 1.3 (gate pre-creation + resume populates Acceptance Criteria), `--note` semantics, and the always-visible-region description updated; stale `Decisions / Notes` references retired.

**Docs**: `docs/workflow-triggers.md` describes gate-job creation, the lean body, the friendly timestamp, and the merged Progress/Notes section. `CHANGELOG.md` gains an `[Unreleased]` entry.

**Tests (`lib/test/test_python_scripts.py`)**: Coverage for note-nesting under `## Progress`, the friendly timestamp, the Status→phase map (incl. the Blocked fallback), legacy-workpad resume (old `## Decisions / Notes` preserved, not dropped), and `new-body`.

## Resolves
Resolves #49

## Test Plan
- [ ] `bash lib/test/run.sh` passes (606 assertions, including the new workpad cases).
- [ ] Trigger `/devflow:implement` on a test issue in a repo with a non-trivial `setup-project-env`; confirm the workpad comment appears during the `gate` job (before runtime provisioning) and that the `claude` run updates that same comment rather than posting a second one.
- [ ] Confirm the posted workpad does not re-trigger a run (resolver's workpad-marker self-trigger guard).
- [ ] Inspect a finished workpad: `Last updated` is `YYYY-MM-DD HH:MM UTC`, notes are nested under their phase in `## Progress`, and there is no separate `Decisions / Notes` section.

## Visual Changes
N/A (changes the GitHub comment the implement workflow posts: timestamp format and note placement).

## Breaking Changes
None. Workpads created before this change resume without error and keep their existing notes; the `now` subcommand still emits ISO-8601 for machine uses.

<!-- PR_BODY_END -->