### PR TITLE
Deepen /devflow:create-issue Testing-Strategy template guidance (2.7.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devflow",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "Make agentic coding work on real codebases: DevFlow takes a one-line request to a complete, tested, reviewed, documented PR that's ready for your final review, and improves itself weekly. Includes /devflow:implement (4-phase orchestrator), /devflow:review and /devflow:review-and-fix (a verification-checklist review engine that audits its own approval), the /devflow:docs suite, /devflow:create-issue, plus the self-improving retrospective loop (/devflow:retrospective per-PR + /devflow:retrospective-audit weekly).",
   "author": {
     "name": "Daniel Radman",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to DevFlow are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project aims
 to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.7.1] — 2026-06-02
+
+### Changed
+- **`/devflow:create-issue` deepens the issue template's Testing-Strategy guidance from a binary classification into a three-move framework**, so every filed issue hands the implementer a concrete, test-first plan instead of a one-assertion-per-AC stub. The drafter now (1) classifies the test boundary **and names the level(s)** — a pure helper earns a unit test *and* its caller earns an integration test, no longer collapsed into one; (2) walks seven coverage dimensions (happy path, boundary & degenerate, error & failure, adversarial/encoding, state/concurrency/idempotency, scale, security) where the acceptance criteria are explicitly *the floor, not the ceiling* and an inapplicable dimension is dropped as a recorded decision; and (3) commits to named assertions with **bidirectional AC↔assertion mapping** (no orphans either way), fixtures/doubles spelled out ("never mock the unit under test"), and a "don't test the framework" rule. Two behaviors the previous text missed are now mandatory: **a bug fix's failing test must reproduce the reported defect** (not "behavior doesn't exist yet" — the wrong behavior already exists), and a **guarantee-class change** (a deterministic backstop/hook/gate on the Step 2 strength ladder) must be tested *on the path where the actor skipped the manual step*, since that is the entire reason the mechanism exists. The non-automatable stand-in is hardened from "confirmed by review" into a reproducible numbered checklist or adversarial input-shape trace. The matching self-check checklist item is updated to gate the richer expectation. Baseline subagent runs (feature, bug fix, guarantee-class) confirmed the prior text left each of these gaps uncovered and the new framework closes them while preserving the no-options discipline. See `skills/create-issue/references/issue-template.md`. (#83)
+
 ## [2.7.0] — 2026-06-02
 
 ### Added

--- a/skills/create-issue/references/issue-template.md
+++ b/skills/create-issue/references/issue-template.md
@@ -76,21 +76,78 @@ Checkbox items (`- [ ]`), each a **single unconditional, testable assertion**:
 Describe the **one** approach the user chose — not a comparison of candidates.
 - **Approach** — the decided design: the specific files to touch and how the change fits.
 - **Code Patterns** — patterns already used in this codebase to mirror.
-- **Testing Strategy** — classify against test automation first, then state the plan so
-  the implementer inherits a clear test-first expectation:
-  - **Can an automated test exercise this change?** — any automated test, not only a unit
-    test: a return value, an API/CLI contract, an exit code, a parser's handling of an
-    input shape, a state transition, a raised error, or an end-to-end path an integration
-    test can drive. If any such boundary exists, the change is covered by test automation.
-  - **If automatable:** name the specific assertion to write **before** the code (unit or
-    integration, whichever fits the boundary) — it must fail first for the right reason
-    (the behavior does not exist yet), then pass. Tie each assertion back to an Acceptance
-    Criterion above.
-  - **If no automated test applies** (the deliverable is prose, templates, config, or an
-    embedded DSL with no observable behavior boundary): say so with the one-line reason,
-    and name the verification that stands in for a test — the acceptance criteria
-    confirmed by review, or an adversarial trace of the input shapes the change must
-    survive.
+- **Testing Strategy** — the implementer must inherit a concrete, test-first plan, not a
+  vague intent. Build it in three moves: **(1) classify the boundary, (2) walk the coverage
+  dimensions, (3) commit to named assertions tied to ACs.** The plan you write is *decided*
+  — the no-options rule still applies here: state what **will** be tested, never "we could
+  test X or Y." The dimension list below is a checklist *for you while drafting*; it does
+  not get pasted into the issue. What lands in the issue is the chosen assertions.
+
+  **Move 1 — Classify the test boundary.** Can an automated test exercise this change? Any
+  automated test counts, not only a unit test: a return value, an API/CLI contract, an exit
+  code, a parser's handling of an input shape, a state transition, a raised error, or an
+  end-to-end path an integration test can drive. If any such boundary exists, the change is
+  covered by test automation. Then **name the test level(s)** deliberately — more than one
+  often applies: a pure helper (e.g. an RFC-4180 quoting function) earns a unit test *and*
+  the endpoint that calls it earns an integration test. Say both; do not collapse them.
+
+  **Move 2 — Walk the coverage dimensions.** For each dimension below, either include
+  concrete cases or let it drop because it genuinely does not apply — a dimension's absence
+  is a *decision*, not an oversight. The Acceptance Criteria above are the floor, not the
+  ceiling: most ACs spell out only the happy path, so the test plan routinely adds cases the
+  ACs never named.
+  - **Happy path** — the primary decided behavior for each AC.
+  - **Boundary & degenerate inputs** — empty / zero / one / max: empty collection, first and
+    last element, off-by-one edges, page 0 and past-the-end, size and length limits, empty
+    string vs. null vs. missing. (The CSV export with *zero* responses still emits a header
+    row; pagination is exercised at page 0, the exact-multiple page, and the partial final
+    page — these are where off-by-ones hide.)
+  - **Error & failure paths** — every error the change can raise or must reject: malformed
+    input, missing resource (404), unauthenticated vs. unauthorized (401 vs. 403), conflict,
+    downstream/dependency failure. Assert the *specific* failure (status, error type,
+    message contract), not merely "it errors."
+  - **Adversarial / malformed input** — values crafted to break parsing or escaping:
+    delimiter/quote/newline injection (RFC-4180), Unicode / non-ASCII / encoding (UTF-8,
+    BOM), oversized or deeply-nested payloads, and every hostile shape a parser or config
+    consumer must survive without detonating.
+  - **State, concurrency & idempotency** — re-running the operation, concurrent callers,
+    partial-failure rollback, ordering, and double-fire. Assert the invariant still holds.
+  - **Scale / performance** — only when an AC implies it (streaming vs. buffering, 100k+
+    rows, query-count ceilings). Assert the *property* (no full-collection buffering, bounded
+    query count), not a brittle wall-clock number.
+  - **Security / authorization** — ownership and tenant isolation, and that secrets or other
+    tenants' data are never exposed, whenever the change touches an access boundary.
+
+  **Move 3 — Commit to named assertions.**
+  - **Every AC maps to at least one named assertion, and every assertion maps back to an
+    AC** — no orphans in either direction. If an AC cannot be pinned by any assertion, it is
+    not testable as written: tighten it, or it belongs in `## 🚫 Blocked`.
+  - Each assertion is **test-first**: written before the code, it must fail first *for the
+    right reason* — and spell that reason out. For a *feature*, the right reason is that the
+    behavior does not exist yet. **For a bug fix, the right reason is that the test
+    reproduces the reported defect** — the regression test must fail against today's code by
+    exhibiting the exact wrong behavior (the dropped last row, the off-by-one), then pass
+    after the fix. "Behavior doesn't exist yet" is the wrong framing for a bug; the wrong
+    behavior already exists.
+  - Name the **fixtures / test doubles** the failing test needs, and what must **not** be
+    mocked — never mock the unit under test or the boundary the assertion is proving.
+  - **Don't test the framework.** Assert observable behavior (the CSV bytes round-trip
+    through a standard parser, the row count, the raised error type), not internal wiring or
+    library internals (a specific transport header the framework sets, a private call count)
+    *unless that wiring is itself the AC*.
+  - **Guarantee-class changes** (the deterministic backstop / hook / gate mechanisms on the
+    Step 2 strength ladder): the test must prove the guarantee holds **on the path where the
+    actor skipped the manual step** — that is the entire reason the mechanism exists. Assert
+    it fires (and is idempotent) when a human or agent *forgot* the cooperative step, not
+    only when everyone cooperated.
+
+  **If no automated test applies** — the deliverable is prose, marketing copy, pure config
+  with no consumer behavior, or a DSL with no observable boundary — say so with the one-line
+  reason, then give the stand-in as a **reproducible verification**: a numbered manual
+  checklist or an adversarial trace of the input shapes the change must survive, each item
+  tied to an AC and concrete enough that a second reviewer reaches the same verdict.
+  "Confirmed by review" alone is not a plan — state *what* the reviewer checks and *how they
+  know it passed.*
 - **Documentation Needed** — what doc updates the change requires.
 - **Potential Gotchas** — pitfalls and architectural constraints (these are warnings, not
   unresolved choices).
@@ -126,7 +183,7 @@ incomplete issues.
 - [ ] Technical context cites real file paths / class names from this project
 - [ ] Acceptance criteria are measurable, testable, and unconditional
 - [ ] Implementation notes describe a single chosen approach
-- [ ] Testing Strategy classifies test-automation coverage and states the test-first expectation (or names the stand-in verification when no automated test applies)
+- [ ] Testing Strategy classifies the boundary + level, walks the coverage dimensions (boundary/error/adversarial/state/scale/security as they apply), and gives test-first assertions with every AC mapped to ≥1 assertion and no orphan assertions — bug fixes reproduce the defect first; guarantee-class changes test the skipped-step path; or it names a reproducible stand-in verification when no automated test applies
 - [ ] **No-options gate passed**: no choice/hedge/deferral language outside `## 🚫 Blocked`
 - [ ] Any unresolved decision is in `## 🚫 Blocked`, phrased as a question — nowhere else
 - [ ] Edge cases and error handling are considered


### PR DESCRIPTION
## What

Rewrites the **Testing Strategy** bullet in `skills/create-issue/references/issue-template.md` (the reference loaded by `/devflow:create-issue`) from a binary *automatable / not* classification into a three-move framework, so every filed issue hands the implementer a concrete, test-first plan rather than a one-assertion-per-AC stub.

- **Move 1 — Classify the boundary, then name the test level(s).** A pure helper earns a unit test *and* its caller earns an integration test — no longer collapsed into one.
- **Move 2 — Walk seven coverage dimensions** (happy path · boundary & degenerate · error & failure · adversarial/encoding · state-concurrency-idempotency · scale · security). The acceptance criteria are explicitly *the floor, not the ceiling*; an inapplicable dimension is dropped as a recorded decision, not silently.
- **Move 3 — Commit to named assertions:** bidirectional **AC↔assertion mapping** (no orphans either way), fixtures/doubles spelled out ("never mock the unit under test"), and a "don't test the framework" rule.

Two rules the prior text never forced, both made mandatory:

- **Bug fix → the failing test must reproduce the reported defect** (the wrong behavior already exists; "doesn't exist yet" is the wrong framing for a bug).
- **Guarantee-class change** (a deterministic backstop / hook / gate on the Step 2 strength ladder) **must be tested on the path where the actor skipped the manual step** — the entire reason the mechanism exists.

The non-automatable stand-in is hardened from "confirmed by review" into a reproducible numbered checklist or adversarial input-shape trace, and the matching quality-checklist gate is updated.

## Why / how it was validated

Followed `superpowers:writing-skills` (RED → GREEN). **RED:** three baseline subagent runs (CSV-export feature, pagination bug fix, post-merge backstop hook) drafting the Testing Strategy under the *old* guidance consistently missed: degenerate/encoding cases, regression-reproduces-the-defect (got it only by luck), and guarantee-under-skip. **GREEN:** the same three scenarios under the new guidance covered every gap (zero-row→header-only, CRLF, 403-not-404 leak reasoning, "fails today by reproducing the defect", a dedicated skipped-step proof + idempotency) while preserving the no-options discipline.

## Notes

- Reference-doc + changelog only — no shell/py/jq touched. Full suite green (**834 passed, 0 failed**).
- Version bumped `2.7.0 → 2.7.1` (smallest correct step — a refinement of the existing Testing-Strategy feature) with the CHANGELOG entry the Phase 3 review gate requires.
- §11 of `DEVFLOW_SYSTEM_OVERVIEW.md` and the README describe create-issue at the process level and never enumerate the template's internal sections, so they stay current-state-accurate without edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)