### PR TITLE
Wire the issue #80 observability backstop: commit the Stop hook + cloud-workflow --persist steps (privileged/maintainer)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devflow",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "description": "Make agentic coding work on real codebases: DevFlow takes a one-line request to a complete, tested, reviewed, documented PR that's ready for your final review, and improves itself weekly. Includes /devflow:implement (4-phase orchestrator), /devflow:review and /devflow:review-and-fix (a verification-checklist review engine that audits its own approval), the /devflow:docs suite, /devflow:create-issue, plus the self-improving retrospective loop (/devflow:retrospective per-PR + /devflow:retrospective-audit weekly).",
   "author": {
     "name": "Daniel Radman",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,12 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          { "type": "command", "command": "bash lib/efficiency-trace.sh --persist || true" }
+        ]
+      }
+    ]
+  }
+}

--- a/.devflow/logs/efficiency/issue-84-add-a-consumer-prompt-extension-convention-for--local-20260602T163146Z-1.json
+++ b/.devflow/logs/efficiency/issue-84-add-a-consumer-prompt-extension-convention-for--local-20260602T163146Z-1.json
@@ -1,0 +1,249 @@
+{
+  "schema_version": 1,
+  "slug": "issue-84-add-a-consumer-prompt-extension-convention-for-",
+  "generated_at": "2026-06-03T20:10:56Z",
+  "source": "review-and-fix",
+  "cut_candidate_min_dispatch": 3,
+  "iterations": 5,
+  "per_iteration": [
+    {
+      "iter": 1,
+      "phase3_dispatched": [
+        "pr-review-toolkit:code-reviewer",
+        "pr-review-toolkit:silent-failure-hunter",
+        "pr-review-toolkit:comment-analyzer",
+        "pr-review-toolkit:pr-test-analyzer",
+        "superpowers:requesting-code-review"
+      ],
+      "phase3_dispatched_count": 5,
+      "phase3_dispatched_present": true,
+      "diff_profile": {
+        "small_diff": false,
+        "config_only": false,
+        "has_new_types": false,
+        "engine_self_modifying": true,
+        "checklist_skipped": null
+      },
+      "verification_posture": "none-recorded",
+      "checklist_lite_count": 0,
+      "checklist_agent_count": 0,
+      "fixes_applied": 5,
+      "added_nothing": false,
+      "agent_verdicts": [
+        {
+          "agent": "general-purpose:superpowers",
+          "verdict": "unique-effective"
+        },
+        {
+          "agent": "pr-review-toolkit:code-reviewer",
+          "verdict": null
+        },
+        {
+          "agent": "pr-review-toolkit:comment-analyzer",
+          "verdict": "unique-effective"
+        },
+        {
+          "agent": "pr-review-toolkit:pr-test-analyzer",
+          "verdict": "unique-effective"
+        },
+        {
+          "agent": "pr-review-toolkit:silent-failure-hunter",
+          "verdict": "unique-effective"
+        },
+        {
+          "agent": "superpowers:requesting-code-review",
+          "verdict": null
+        }
+      ]
+    },
+    {
+      "iter": 2,
+      "phase3_dispatched": [
+        "pr-review-toolkit:code-reviewer",
+        "pr-review-toolkit:silent-failure-hunter",
+        "pr-review-toolkit:comment-analyzer",
+        "pr-review-toolkit:pr-test-analyzer",
+        "superpowers:requesting-code-review"
+      ],
+      "phase3_dispatched_count": 5,
+      "phase3_dispatched_present": true,
+      "diff_profile": {
+        "small_diff": false,
+        "config_only": false,
+        "has_new_types": false,
+        "engine_self_modifying": true,
+        "checklist_skipped": null
+      },
+      "verification_posture": "none-recorded",
+      "checklist_lite_count": 0,
+      "checklist_agent_count": 0,
+      "fixes_applied": 2,
+      "added_nothing": false,
+      "agent_verdicts": [
+        {
+          "agent": "general-purpose:superpowers",
+          "verdict": "noise"
+        },
+        {
+          "agent": "pr-review-toolkit:code-reviewer",
+          "verdict": "unique-effective"
+        },
+        {
+          "agent": "pr-review-toolkit:comment-analyzer",
+          "verdict": null
+        },
+        {
+          "agent": "pr-review-toolkit:pr-test-analyzer",
+          "verdict": null
+        },
+        {
+          "agent": "pr-review-toolkit:silent-failure-hunter",
+          "verdict": "unique-effective"
+        },
+        {
+          "agent": "superpowers:requesting-code-review",
+          "verdict": null
+        }
+      ]
+    },
+    {
+      "iter": 3,
+      "phase3_dispatched": [
+        "pr-review-toolkit:code-reviewer",
+        "pr-review-toolkit:silent-failure-hunter",
+        "superpowers:requesting-code-review"
+      ],
+      "phase3_dispatched_count": 3,
+      "phase3_dispatched_present": true,
+      "diff_profile": {
+        "small_diff": false,
+        "config_only": false,
+        "has_new_types": false,
+        "engine_self_modifying": true,
+        "checklist_skipped": null
+      },
+      "verification_posture": "none-recorded",
+      "checklist_lite_count": 0,
+      "checklist_agent_count": 0,
+      "fixes_applied": 2,
+      "added_nothing": false,
+      "agent_verdicts": [
+        {
+          "agent": "general-purpose:superpowers",
+          "verdict": "unique-effective"
+        },
+        {
+          "agent": "pr-review-toolkit:code-reviewer",
+          "verdict": "corroborating"
+        },
+        {
+          "agent": "pr-review-toolkit:silent-failure-hunter",
+          "verdict": null
+        },
+        {
+          "agent": "superpowers:requesting-code-review",
+          "verdict": null
+        }
+      ]
+    },
+    {
+      "iter": 4,
+      "phase3_dispatched": [
+        "pr-review-toolkit:silent-failure-hunter",
+        "superpowers:requesting-code-review"
+      ],
+      "phase3_dispatched_count": 2,
+      "phase3_dispatched_present": true,
+      "diff_profile": {
+        "small_diff": false,
+        "config_only": false,
+        "has_new_types": false,
+        "engine_self_modifying": true,
+        "checklist_skipped": null
+      },
+      "verification_posture": "none-recorded",
+      "checklist_lite_count": 0,
+      "checklist_agent_count": 0,
+      "fixes_applied": 0,
+      "added_nothing": true,
+      "agent_verdicts": [
+        {
+          "agent": "pr-review-toolkit:silent-failure-hunter",
+          "verdict": null
+        },
+        {
+          "agent": "superpowers:requesting-code-review",
+          "verdict": null
+        }
+      ]
+    },
+    {
+      "iter": 5,
+      "phase3_dispatched": [
+        "pr-review-toolkit:code-reviewer",
+        "pr-review-toolkit:silent-failure-hunter",
+        "pr-review-toolkit:comment-analyzer",
+        "pr-review-toolkit:pr-test-analyzer",
+        "superpowers:requesting-code-review"
+      ],
+      "phase3_dispatched_count": 5,
+      "phase3_dispatched_present": true,
+      "diff_profile": {
+        "small_diff": false,
+        "config_only": false,
+        "has_new_types": false,
+        "engine_self_modifying": true,
+        "checklist_skipped": null
+      },
+      "verification_posture": "none-recorded",
+      "checklist_lite_count": 0,
+      "checklist_agent_count": 0,
+      "fixes_applied": 4,
+      "added_nothing": false,
+      "agent_verdicts": [
+        {
+          "agent": "pr-review-toolkit:code-reviewer",
+          "verdict": null
+        },
+        {
+          "agent": "pr-review-toolkit:comment-analyzer",
+          "verdict": "unique-effective"
+        },
+        {
+          "agent": "pr-review-toolkit:pr-test-analyzer",
+          "verdict": "unique-effective"
+        },
+        {
+          "agent": "pr-review-toolkit:silent-failure-hunter",
+          "verdict": "unique-effective"
+        },
+        {
+          "agent": "superpowers:requesting-code-review",
+          "verdict": null
+        }
+      ]
+    }
+  ],
+  "telemetry": [
+    {
+      "iter": 1,
+      "phases": null
+    },
+    {
+      "iter": 2,
+      "phases": null
+    },
+    {
+      "iter": 3,
+      "phases": null
+    },
+    {
+      "iter": 4,
+      "phases": null
+    },
+    {
+      "iter": 5,
+      "phases": null
+    }
+  ]
+}

--- a/.devflow/logs/efficiency/issue-90-add-an-advisory-claude-md-project-memory-nudge-to--local-20260603T083338Z-1.json
+++ b/.devflow/logs/efficiency/issue-90-add-an-advisory-claude-md-project-memory-nudge-to--local-20260603T083338Z-1.json
@@ -1,0 +1,293 @@
+{
+  "schema_version": 1,
+  "slug": "issue-90-add-an-advisory-claude-md-project-memory-nudge-to-",
+  "generated_at": "2026-06-03T20:10:56Z",
+  "source": "review-and-fix",
+  "cut_candidate_min_dispatch": 3,
+  "iterations": 5,
+  "per_iteration": [
+    {
+      "iter": 1,
+      "phase3_dispatched": [],
+      "phase3_dispatched_count": 0,
+      "phase3_dispatched_present": true,
+      "diff_profile": {
+        "small_diff": false,
+        "config_only": false,
+        "has_new_types": false,
+        "engine_self_modifying": true,
+        "checklist_skipped": null
+      },
+      "verification_posture": "mixed",
+      "checklist_lite_count": 7,
+      "checklist_agent_count": 8,
+      "fixes_applied": 1,
+      "added_nothing": false,
+      "agent_verdicts": []
+    },
+    {
+      "iter": 2,
+      "phase3_dispatched": [
+        "pr-review-toolkit:code-reviewer",
+        "pr-review-toolkit:silent-failure-hunter",
+        "pr-review-toolkit:comment-analyzer",
+        "pr-review-toolkit:pr-test-analyzer",
+        "superpowers:requesting-code-review"
+      ],
+      "phase3_dispatched_count": 5,
+      "phase3_dispatched_present": true,
+      "diff_profile": {
+        "small_diff": false,
+        "config_only": false,
+        "has_new_types": false,
+        "engine_self_modifying": true,
+        "checklist_skipped": null
+      },
+      "verification_posture": "agent-only",
+      "checklist_lite_count": 0,
+      "checklist_agent_count": 1,
+      "fixes_applied": 4,
+      "added_nothing": false,
+      "agent_verdicts": [
+        {
+          "agent": "checklist-generator-variance",
+          "verdict": "noise"
+        },
+        {
+          "agent": "pr-review-toolkit:code-reviewer",
+          "verdict": null
+        },
+        {
+          "agent": "pr-review-toolkit:comment-analyzer",
+          "verdict": "unique-effective"
+        },
+        {
+          "agent": "pr-review-toolkit:pr-test-analyzer",
+          "verdict": "unique-effective"
+        },
+        {
+          "agent": "pr-review-toolkit:silent-failure-hunter",
+          "verdict": "corroborating"
+        },
+        {
+          "agent": "superpowers:requesting-code-review",
+          "verdict": null
+        }
+      ]
+    },
+    {
+      "iter": 3,
+      "phase3_dispatched": [
+        "pr-review-toolkit:code-reviewer",
+        "pr-review-toolkit:silent-failure-hunter",
+        "pr-review-toolkit:comment-analyzer",
+        "pr-review-toolkit:pr-test-analyzer",
+        "superpowers:requesting-code-review"
+      ],
+      "phase3_dispatched_count": 5,
+      "phase3_dispatched_present": true,
+      "diff_profile": {
+        "small_diff": false,
+        "config_only": false,
+        "has_new_types": false,
+        "engine_self_modifying": true,
+        "checklist_skipped": null
+      },
+      "verification_posture": "none-recorded",
+      "checklist_lite_count": 0,
+      "checklist_agent_count": 0,
+      "fixes_applied": 3,
+      "added_nothing": false,
+      "agent_verdicts": [
+        {
+          "agent": "pr-review-toolkit:code-reviewer",
+          "verdict": "noise"
+        },
+        {
+          "agent": "pr-review-toolkit:comment-analyzer",
+          "verdict": "unique-effective"
+        },
+        {
+          "agent": "pr-review-toolkit:pr-test-analyzer",
+          "verdict": "corroborating"
+        },
+        {
+          "agent": "pr-review-toolkit:silent-failure-hunter",
+          "verdict": "unique-effective"
+        },
+        {
+          "agent": "superpowers:requesting-code-review",
+          "verdict": null
+        }
+      ]
+    },
+    {
+      "iter": 4,
+      "phase3_dispatched": [
+        "pr-review-toolkit:code-reviewer",
+        "pr-review-toolkit:silent-failure-hunter",
+        "pr-review-toolkit:comment-analyzer",
+        "pr-review-toolkit:pr-test-analyzer",
+        "superpowers:requesting-code-review"
+      ],
+      "phase3_dispatched_count": 5,
+      "phase3_dispatched_present": true,
+      "diff_profile": {
+        "small_diff": false,
+        "config_only": false,
+        "has_new_types": false,
+        "engine_self_modifying": true,
+        "checklist_skipped": null
+      },
+      "verification_posture": "none-recorded",
+      "checklist_lite_count": 0,
+      "checklist_agent_count": 0,
+      "fixes_applied": 3,
+      "added_nothing": false,
+      "agent_verdicts": [
+        {
+          "agent": "checklist-generator-variance",
+          "verdict": "noise"
+        },
+        {
+          "agent": "pr-review-toolkit:code-reviewer",
+          "verdict": null
+        },
+        {
+          "agent": "pr-review-toolkit:comment-analyzer",
+          "verdict": null
+        },
+        {
+          "agent": "pr-review-toolkit:pr-test-analyzer",
+          "verdict": "unique-effective"
+        },
+        {
+          "agent": "pr-review-toolkit:silent-failure-hunter",
+          "verdict": "corroborating"
+        },
+        {
+          "agent": "superpowers:requesting-code-review",
+          "verdict": null
+        }
+      ]
+    },
+    {
+      "iter": 5,
+      "phase3_dispatched": [
+        "pr-review-toolkit:code-reviewer",
+        "pr-review-toolkit:silent-failure-hunter",
+        "pr-review-toolkit:comment-analyzer",
+        "pr-review-toolkit:pr-test-analyzer",
+        "superpowers:requesting-code-review"
+      ],
+      "phase3_dispatched_count": 5,
+      "phase3_dispatched_present": true,
+      "diff_profile": {
+        "small_diff": false,
+        "config_only": false,
+        "has_new_types": false,
+        "engine_self_modifying": true,
+        "checklist_skipped": null
+      },
+      "verification_posture": "none-recorded",
+      "checklist_lite_count": 0,
+      "checklist_agent_count": 0,
+      "fixes_applied": 1,
+      "added_nothing": false,
+      "agent_verdicts": [
+        {
+          "agent": "pr-review-toolkit:code-reviewer",
+          "verdict": null
+        },
+        {
+          "agent": "pr-review-toolkit:comment-analyzer",
+          "verdict": null
+        },
+        {
+          "agent": "pr-review-toolkit:pr-test-analyzer",
+          "verdict": null
+        },
+        {
+          "agent": "pr-review-toolkit:silent-failure-hunter",
+          "verdict": "unique-effective"
+        },
+        {
+          "agent": "superpowers:requesting-code-review",
+          "verdict": null
+        }
+      ]
+    }
+  ],
+  "telemetry": [
+    {
+      "iter": 1,
+      "phases": {
+        "phase_1": {
+          "calls": 1
+        },
+        "phase_2": {
+          "calls": 8
+        },
+        "phase_3": {
+          "calls": 0
+        }
+      }
+    },
+    {
+      "iter": 2,
+      "phases": {
+        "phase_1": {
+          "calls": 1
+        },
+        "phase_2": {
+          "calls": 1
+        },
+        "phase_3": {
+          "calls": 5
+        }
+      }
+    },
+    {
+      "iter": 3,
+      "phases": {
+        "phase_1": {
+          "calls": 1
+        },
+        "phase_2": {
+          "calls": 0
+        },
+        "phase_3": {
+          "calls": 5
+        }
+      }
+    },
+    {
+      "iter": 4,
+      "phases": {
+        "phase_1": {
+          "calls": 1
+        },
+        "phase_2": {
+          "calls": 0
+        },
+        "phase_3": {
+          "calls": 5
+        }
+      }
+    },
+    {
+      "iter": 5,
+      "phases": {
+        "phase_1": {
+          "calls": 0
+        },
+        "phase_2": {
+          "calls": 0
+        },
+        "phase_3": {
+          "calls": 4
+        }
+      }
+    }
+  ]
+}

--- a/.devflow/logs/efficiency/pr-108-20260603T200417Z.json
+++ b/.devflow/logs/efficiency/pr-108-20260603T200417Z.json
@@ -1,0 +1,85 @@
+{
+  "schema_version": 1,
+  "slug": "pr-108",
+  "generated_at": "2026-06-03T20:04:18Z",
+  "source": "review-and-fix",
+  "cut_candidate_min_dispatch": 3,
+  "iterations": 2,
+  "per_iteration": [
+    {
+      "iter": 1,
+      "phase3_dispatched": [
+        "pr-review-toolkit:code-reviewer",
+        "pr-review-toolkit:silent-failure-hunter",
+        "pr-review-toolkit:comment-analyzer",
+        "superpowers:requesting-code-review"
+      ],
+      "phase3_dispatched_count": 4,
+      "phase3_dispatched_present": true,
+      "diff_profile": {
+        "small_diff": false,
+        "config_only": true,
+        "has_new_types": false,
+        "engine_self_modifying": false,
+        "checklist_skipped": null
+      },
+      "verification_posture": "mixed",
+      "checklist_lite_count": 3,
+      "checklist_agent_count": 4,
+      "fixes_applied": 0,
+      "added_nothing": true,
+      "agent_verdicts": [
+        {
+          "agent": "pr-review-toolkit:code-reviewer",
+          "verdict": null
+        },
+        {
+          "agent": "pr-review-toolkit:comment-analyzer",
+          "verdict": "noise"
+        },
+        {
+          "agent": "pr-review-toolkit:silent-failure-hunter",
+          "verdict": "noise"
+        },
+        {
+          "agent": "superpowers:requesting-code-review",
+          "verdict": "noise"
+        }
+      ]
+    },
+    {
+      "iter": 2,
+      "phase3_dispatched": [],
+      "phase3_dispatched_count": 0,
+      "phase3_dispatched_present": true,
+      "diff_profile": {
+        "small_diff": false,
+        "config_only": true,
+        "has_new_types": false,
+        "engine_self_modifying": false,
+        "checklist_skipped": "intentional"
+      },
+      "verification_posture": "skipped-intentional",
+      "checklist_lite_count": 0,
+      "checklist_agent_count": 0,
+      "fixes_applied": 0,
+      "added_nothing": true,
+      "agent_verdicts": [
+        {
+          "agent": "pr-review-toolkit:silent-failure-hunter",
+          "verdict": "noise"
+        }
+      ]
+    }
+  ],
+  "telemetry": [
+    {
+      "iter": 1,
+      "phases": null
+    },
+    {
+      "iter": 2,
+      "phases": null
+    }
+  ]
+}

--- a/.devflow/logs/efficiency/pr-108-local-20260603T195522Z-1.json
+++ b/.devflow/logs/efficiency/pr-108-local-20260603T195522Z-1.json
@@ -1,0 +1,85 @@
+{
+  "schema_version": 1,
+  "slug": "pr-108",
+  "generated_at": "2026-06-03T20:10:56Z",
+  "source": "review-and-fix",
+  "cut_candidate_min_dispatch": 3,
+  "iterations": 2,
+  "per_iteration": [
+    {
+      "iter": 1,
+      "phase3_dispatched": [
+        "pr-review-toolkit:code-reviewer",
+        "pr-review-toolkit:silent-failure-hunter",
+        "pr-review-toolkit:comment-analyzer",
+        "superpowers:requesting-code-review"
+      ],
+      "phase3_dispatched_count": 4,
+      "phase3_dispatched_present": true,
+      "diff_profile": {
+        "small_diff": false,
+        "config_only": true,
+        "has_new_types": false,
+        "engine_self_modifying": false,
+        "checklist_skipped": null
+      },
+      "verification_posture": "mixed",
+      "checklist_lite_count": 3,
+      "checklist_agent_count": 4,
+      "fixes_applied": 0,
+      "added_nothing": true,
+      "agent_verdicts": [
+        {
+          "agent": "pr-review-toolkit:code-reviewer",
+          "verdict": null
+        },
+        {
+          "agent": "pr-review-toolkit:comment-analyzer",
+          "verdict": "noise"
+        },
+        {
+          "agent": "pr-review-toolkit:silent-failure-hunter",
+          "verdict": "noise"
+        },
+        {
+          "agent": "superpowers:requesting-code-review",
+          "verdict": "noise"
+        }
+      ]
+    },
+    {
+      "iter": 2,
+      "phase3_dispatched": [],
+      "phase3_dispatched_count": 0,
+      "phase3_dispatched_present": true,
+      "diff_profile": {
+        "small_diff": false,
+        "config_only": true,
+        "has_new_types": false,
+        "engine_self_modifying": false,
+        "checklist_skipped": "intentional"
+      },
+      "verification_posture": "skipped-intentional",
+      "checklist_lite_count": 0,
+      "checklist_agent_count": 0,
+      "fixes_applied": 0,
+      "added_nothing": true,
+      "agent_verdicts": [
+        {
+          "agent": "pr-review-toolkit:silent-failure-hunter",
+          "verdict": "noise"
+        }
+      ]
+    }
+  ],
+  "telemetry": [
+    {
+      "iter": 1,
+      "phases": null
+    },
+    {
+      "iter": 2,
+      "phases": null
+    }
+  ]
+}

--- a/.devflow/logs/efficiency/pr-62-local-20260527T115350Z-1.json
+++ b/.devflow/logs/efficiency/pr-62-local-20260527T115350Z-1.json
@@ -1,0 +1,230 @@
+{
+  "schema_version": 1,
+  "slug": "pr-62",
+  "generated_at": "2026-06-03T20:10:56Z",
+  "source": "review-and-fix",
+  "cut_candidate_min_dispatch": 3,
+  "iterations": 3,
+  "per_iteration": [
+    {
+      "iter": 1,
+      "phase3_dispatched": [
+        "pr-review-toolkit:code-reviewer",
+        "pr-review-toolkit:silent-failure-hunter",
+        "pr-review-toolkit:comment-analyzer",
+        "superpowers:requesting-code-review"
+      ],
+      "phase3_dispatched_count": 4,
+      "phase3_dispatched_present": true,
+      "diff_profile": {
+        "small_diff": false,
+        "config_only": true,
+        "has_new_types": false,
+        "engine_self_modifying": true,
+        "checklist_skipped": null
+      },
+      "verification_posture": "mixed",
+      "checklist_lite_count": 5,
+      "checklist_agent_count": 14,
+      "fixes_applied": 11,
+      "added_nothing": false,
+      "agent_verdicts": [
+        {
+          "agent": "pr-review-toolkit:code-reviewer",
+          "verdict": "corroborating"
+        },
+        {
+          "agent": "pr-review-toolkit:comment-analyzer",
+          "verdict": "unique-effective"
+        },
+        {
+          "agent": "pr-review-toolkit:silent-failure-hunter",
+          "verdict": "unique-effective"
+        },
+        {
+          "agent": "superpowers:requesting-code-review",
+          "verdict": "unique-effective"
+        }
+      ]
+    },
+    {
+      "iter": 2,
+      "phase3_dispatched": [
+        "pr-review-toolkit:code-reviewer",
+        "pr-review-toolkit:silent-failure-hunter",
+        "pr-review-toolkit:comment-analyzer",
+        "superpowers:requesting-code-review"
+      ],
+      "phase3_dispatched_count": 4,
+      "phase3_dispatched_present": true,
+      "diff_profile": {
+        "small_diff": false,
+        "config_only": true,
+        "has_new_types": false,
+        "engine_self_modifying": true,
+        "checklist_skipped": null
+      },
+      "verification_posture": "lite-only",
+      "checklist_lite_count": 5,
+      "checklist_agent_count": 0,
+      "fixes_applied": 2,
+      "added_nothing": false,
+      "agent_verdicts": [
+        {
+          "agent": "pr-review-toolkit:code-reviewer",
+          "verdict": null
+        },
+        {
+          "agent": "pr-review-toolkit:comment-analyzer",
+          "verdict": "corroborating"
+        },
+        {
+          "agent": "pr-review-toolkit:silent-failure-hunter",
+          "verdict": "corroborating"
+        },
+        {
+          "agent": "superpowers:requesting-code-review",
+          "verdict": null
+        }
+      ]
+    },
+    {
+      "iter": 3,
+      "phase3_dispatched": [
+        "pr-review-toolkit:code-reviewer",
+        "pr-review-toolkit:silent-failure-hunter",
+        "pr-review-toolkit:comment-analyzer",
+        "superpowers:requesting-code-review"
+      ],
+      "phase3_dispatched_count": 4,
+      "phase3_dispatched_present": true,
+      "diff_profile": {
+        "small_diff": false,
+        "config_only": true,
+        "has_new_types": false,
+        "engine_self_modifying": true,
+        "checklist_skipped": null
+      },
+      "verification_posture": "none-recorded",
+      "checklist_lite_count": 0,
+      "checklist_agent_count": 0,
+      "fixes_applied": 1,
+      "added_nothing": false,
+      "agent_verdicts": [
+        {
+          "agent": "pr-review-toolkit:code-reviewer",
+          "verdict": null
+        },
+        {
+          "agent": "pr-review-toolkit:comment-analyzer",
+          "verdict": null
+        },
+        {
+          "agent": "pr-review-toolkit:silent-failure-hunter",
+          "verdict": "unique-effective"
+        },
+        {
+          "agent": "superpowers:requesting-code-review",
+          "verdict": null
+        }
+      ]
+    }
+  ],
+  "telemetry": [
+    {
+      "iter": 1,
+      "phases": {
+        "phase_0": {
+          "calls": 0,
+          "wall_clock_s": 6
+        },
+        "phase_0_5": {
+          "calls": 0,
+          "wall_clock_s": 1
+        },
+        "phase_1": {
+          "calls": 1,
+          "tokens": 99657,
+          "wall_clock_s": 105
+        },
+        "phase_2": {
+          "calls": 14,
+          "tokens": 408000,
+          "wall_clock_s": 50
+        },
+        "phase_3": {
+          "calls": 4,
+          "tokens": 302000,
+          "wall_clock_s": 133
+        },
+        "step_2_5": {
+          "calls": 0,
+          "wall_clock_s": 2,
+          "webfetches": 0
+        },
+        "phase_4_x": {
+          "calls": 0,
+          "wall_clock_s": 3
+        }
+      }
+    },
+    {
+      "iter": 2,
+      "phases": {
+        "phase_1": {
+          "calls": 1,
+          "tokens": 68717,
+          "wall_clock_s": 106
+        },
+        "phase_2": {
+          "calls": 0,
+          "wall_clock_s": 3,
+          "note": "variance items lite-verified post-fix by orchestrator; no verifier subagents dispatched"
+        },
+        "phase_3": {
+          "calls": 4,
+          "tokens": 376000,
+          "wall_clock_s": 134
+        },
+        "step_2_5": {
+          "calls": 0,
+          "wall_clock_s": 2,
+          "webfetches": 0
+        },
+        "phase_4_x": {
+          "calls": 0,
+          "wall_clock_s": 2
+        }
+      }
+    },
+    {
+      "iter": 3,
+      "phases": {
+        "phase_1": {
+          "calls": 1,
+          "tokens": 35663,
+          "wall_clock_s": 33
+        },
+        "phase_2": {
+          "calls": 0,
+          "wall_clock_s": 1,
+          "note": "variance generator returned [] — no new items to verify"
+        },
+        "phase_3": {
+          "calls": 4,
+          "tokens": 231000,
+          "wall_clock_s": 123
+        },
+        "step_2_5": {
+          "calls": 0,
+          "wall_clock_s": 2,
+          "webfetches": 0
+        },
+        "phase_4_x": {
+          "calls": 0,
+          "wall_clock_s": 2
+        }
+      }
+    }
+  ]
+}

--- a/.devflow/logs/efficiency/pr-64-local-20260527T135830Z-1.json
+++ b/.devflow/logs/efficiency/pr-64-local-20260527T135830Z-1.json
@@ -1,0 +1,337 @@
+{
+  "schema_version": 1,
+  "slug": "pr-64",
+  "generated_at": "2026-06-03T20:10:56Z",
+  "source": "review-and-fix",
+  "cut_candidate_min_dispatch": 3,
+  "iterations": 4,
+  "per_iteration": [
+    {
+      "iter": 1,
+      "phase3_dispatched": [
+        "pr-review-toolkit:code-reviewer",
+        "pr-review-toolkit:silent-failure-hunter",
+        "pr-review-toolkit:comment-analyzer",
+        "pr-review-toolkit:pr-test-analyzer",
+        "superpowers:requesting-code-review"
+      ],
+      "phase3_dispatched_count": 5,
+      "phase3_dispatched_present": true,
+      "diff_profile": {
+        "small_diff": false,
+        "config_only": false,
+        "has_new_types": false,
+        "engine_self_modifying": true,
+        "checklist_skipped": null
+      },
+      "verification_posture": "mixed",
+      "checklist_lite_count": 1,
+      "checklist_agent_count": 19,
+      "fixes_applied": 9,
+      "added_nothing": false,
+      "agent_verdicts": [
+        {
+          "agent": "pr-review-toolkit:code-reviewer",
+          "verdict": null
+        },
+        {
+          "agent": "pr-review-toolkit:comment-analyzer",
+          "verdict": "unique-effective"
+        },
+        {
+          "agent": "pr-review-toolkit:pr-test-analyzer",
+          "verdict": "unique-effective"
+        },
+        {
+          "agent": "pr-review-toolkit:silent-failure-hunter",
+          "verdict": "unique-effective"
+        },
+        {
+          "agent": "superpowers:requesting-code-review",
+          "verdict": "corroborating"
+        }
+      ]
+    },
+    {
+      "iter": 2,
+      "phase3_dispatched": [
+        "pr-review-toolkit:code-reviewer",
+        "pr-review-toolkit:silent-failure-hunter",
+        "pr-review-toolkit:comment-analyzer",
+        "pr-review-toolkit:pr-test-analyzer",
+        "superpowers:requesting-code-review"
+      ],
+      "phase3_dispatched_count": 5,
+      "phase3_dispatched_present": true,
+      "diff_profile": {
+        "small_diff": false,
+        "config_only": false,
+        "has_new_types": false,
+        "engine_self_modifying": true,
+        "checklist_skipped": null
+      },
+      "verification_posture": "mixed",
+      "checklist_lite_count": 1,
+      "checklist_agent_count": 9,
+      "fixes_applied": 5,
+      "added_nothing": false,
+      "agent_verdicts": [
+        {
+          "agent": "pr-review-toolkit:code-reviewer",
+          "verdict": null
+        },
+        {
+          "agent": "pr-review-toolkit:comment-analyzer",
+          "verdict": "unique-effective"
+        },
+        {
+          "agent": "pr-review-toolkit:pr-test-analyzer",
+          "verdict": "unique-effective"
+        },
+        {
+          "agent": "pr-review-toolkit:silent-failure-hunter",
+          "verdict": "unique-effective"
+        },
+        {
+          "agent": "superpowers:requesting-code-review",
+          "verdict": null
+        }
+      ]
+    },
+    {
+      "iter": 3,
+      "phase3_dispatched": [
+        "pr-review-toolkit:code-reviewer",
+        "pr-review-toolkit:silent-failure-hunter",
+        "pr-review-toolkit:comment-analyzer",
+        "pr-review-toolkit:pr-test-analyzer",
+        "superpowers:requesting-code-review"
+      ],
+      "phase3_dispatched_count": 5,
+      "phase3_dispatched_present": true,
+      "diff_profile": {
+        "small_diff": false,
+        "config_only": false,
+        "has_new_types": false,
+        "engine_self_modifying": true,
+        "checklist_skipped": null
+      },
+      "verification_posture": "mixed",
+      "checklist_lite_count": 1,
+      "checklist_agent_count": 6,
+      "fixes_applied": 2,
+      "added_nothing": false,
+      "agent_verdicts": [
+        {
+          "agent": "pr-review-toolkit:code-reviewer",
+          "verdict": null
+        },
+        {
+          "agent": "pr-review-toolkit:comment-analyzer",
+          "verdict": null
+        },
+        {
+          "agent": "pr-review-toolkit:pr-test-analyzer",
+          "verdict": "unique-effective"
+        },
+        {
+          "agent": "pr-review-toolkit:silent-failure-hunter",
+          "verdict": "unique-effective"
+        },
+        {
+          "agent": "superpowers:requesting-code-review",
+          "verdict": null
+        }
+      ]
+    },
+    {
+      "iter": 4,
+      "phase3_dispatched": [
+        "pr-review-toolkit:code-reviewer",
+        "pr-review-toolkit:silent-failure-hunter",
+        "pr-review-toolkit:comment-analyzer",
+        "pr-review-toolkit:pr-test-analyzer",
+        "superpowers:requesting-code-review"
+      ],
+      "phase3_dispatched_count": 5,
+      "phase3_dispatched_present": true,
+      "diff_profile": {
+        "small_diff": false,
+        "config_only": false,
+        "has_new_types": false,
+        "engine_self_modifying": true,
+        "checklist_skipped": null
+      },
+      "verification_posture": "mixed",
+      "checklist_lite_count": 1,
+      "checklist_agent_count": 2,
+      "fixes_applied": 0,
+      "added_nothing": true,
+      "agent_verdicts": [
+        {
+          "agent": "pr-review-toolkit:code-reviewer",
+          "verdict": null
+        },
+        {
+          "agent": "pr-review-toolkit:comment-analyzer",
+          "verdict": null
+        },
+        {
+          "agent": "pr-review-toolkit:pr-test-analyzer",
+          "verdict": null
+        },
+        {
+          "agent": "pr-review-toolkit:silent-failure-hunter",
+          "verdict": null
+        },
+        {
+          "agent": "superpowers:requesting-code-review",
+          "verdict": null
+        }
+      ]
+    }
+  ],
+  "telemetry": [
+    {
+      "iter": 1,
+      "phases": {
+        "phase_0": {
+          "calls": 0,
+          "tokens": 0,
+          "wall_clock_s": 5
+        },
+        "phase_0_5": {
+          "calls": 0,
+          "tokens": 0,
+          "wall_clock_s": 2
+        },
+        "phase_1": {
+          "calls": 1,
+          "tokens": 55004,
+          "wall_clock_s": 84
+        },
+        "phase_2": {
+          "calls": 19,
+          "tokens": 280000,
+          "wall_clock_s": 200
+        },
+        "phase_3": {
+          "calls": 5,
+          "tokens": 272000,
+          "wall_clock_s": 88
+        },
+        "step_2_5": {
+          "calls": 0,
+          "tokens": 0,
+          "wall_clock_s": 3,
+          "webfetches": 0
+        },
+        "phase_4_x": {
+          "calls": 0,
+          "tokens": 0,
+          "wall_clock_s": 2
+        }
+      }
+    },
+    {
+      "iter": 2,
+      "phases": {
+        "phase_0_5": {
+          "calls": 0,
+          "tokens": 0,
+          "wall_clock_s": 3
+        },
+        "phase_1": {
+          "calls": 1,
+          "tokens": 58638,
+          "wall_clock_s": 78
+        },
+        "phase_2": {
+          "calls": 0,
+          "tokens": 0,
+          "wall_clock_s": 10
+        },
+        "phase_3": {
+          "calls": 5,
+          "tokens": 290000,
+          "wall_clock_s": 104
+        },
+        "step_2_5": {
+          "calls": 0,
+          "tokens": 0,
+          "wall_clock_s": 2
+        },
+        "phase_4_x": {
+          "calls": 0,
+          "tokens": 0,
+          "wall_clock_s": 2
+        }
+      }
+    },
+    {
+      "iter": 3,
+      "phases": {
+        "phase_1": {
+          "calls": 1,
+          "tokens": 62402,
+          "wall_clock_s": 64
+        },
+        "phase_2": {
+          "calls": 0,
+          "tokens": 0,
+          "wall_clock_s": 8
+        },
+        "phase_3": {
+          "calls": 5,
+          "tokens": 280000,
+          "wall_clock_s": 90
+        },
+        "step_2_5": {
+          "calls": 0,
+          "tokens": 0,
+          "wall_clock_s": 2
+        },
+        "phase_4_x": {
+          "calls": 0,
+          "tokens": 0,
+          "wall_clock_s": 2
+        }
+      }
+    },
+    {
+      "iter": 4,
+      "phases": {
+        "phase_1": {
+          "calls": 1,
+          "tokens": 49382,
+          "wall_clock_s": 141
+        },
+        "phase_2": {
+          "calls": 0,
+          "tokens": 0,
+          "wall_clock_s": 6
+        },
+        "phase_3": {
+          "calls": 5,
+          "tokens": 280000,
+          "wall_clock_s": 67
+        },
+        "step_2_5": {
+          "calls": 0,
+          "tokens": 0,
+          "wall_clock_s": 2
+        },
+        "phase_4_x": {
+          "calls": 0,
+          "tokens": 0,
+          "wall_clock_s": 2
+        },
+        "step_2_6": {
+          "calls": 7,
+          "tokens": 397000,
+          "wall_clock_s": 171
+        }
+      }
+    }
+  ]
+}

--- a/.devflow/logs/efficiency/pr-85-local-20260602T192902Z-1.json
+++ b/.devflow/logs/efficiency/pr-85-local-20260602T192902Z-1.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": 1,
+  "slug": "pr-85",
+  "generated_at": "2026-06-03T20:10:56Z",
+  "source": "review-and-fix",
+  "cut_candidate_min_dispatch": 3,
+  "iterations": 1,
+  "per_iteration": [
+    {
+      "iter": 1,
+      "phase3_dispatched": [
+        "pr-review-toolkit:code-reviewer",
+        "pr-review-toolkit:silent-failure-hunter",
+        "pr-review-toolkit:comment-analyzer",
+        "pr-review-toolkit:pr-test-analyzer",
+        "superpowers:requesting-code-review"
+      ],
+      "phase3_dispatched_count": 5,
+      "phase3_dispatched_present": true,
+      "diff_profile": {
+        "small_diff": false,
+        "config_only": false,
+        "has_new_types": false,
+        "engine_self_modifying": true,
+        "checklist_skipped": null
+      },
+      "verification_posture": "none-recorded",
+      "checklist_lite_count": 0,
+      "checklist_agent_count": 0,
+      "fixes_applied": 0,
+      "added_nothing": true,
+      "agent_verdicts": [
+        {
+          "agent": "pr-review-toolkit:code-reviewer",
+          "verdict": null
+        },
+        {
+          "agent": "pr-review-toolkit:comment-analyzer",
+          "verdict": "noise"
+        },
+        {
+          "agent": "pr-review-toolkit:pr-test-analyzer",
+          "verdict": "noise"
+        },
+        {
+          "agent": "pr-review-toolkit:silent-failure-hunter",
+          "verdict": "noise"
+        },
+        {
+          "agent": "superpowers:requesting-code-review",
+          "verdict": "noise"
+        }
+      ]
+    }
+  ],
+  "telemetry": [
+    {
+      "iter": 1,
+      "phases": null
+    }
+  ]
+}

--- a/.devflow/logs/review/issue-84-add-a-consumer-prompt-extension-convention-for-/local-20260602T163146Z-1/iter-1.json
+++ b/.devflow/logs/review/issue-84-add-a-consumer-prompt-extension-convention-for-/local-20260602T163146Z-1/iter-1.json
@@ -1,0 +1,28 @@
+{"iter":1,"source":"review-and-fix","fix_commit_sha":"be8c48eee25eee4df8184ceb29dc208afbc8c0ec",
+"fix_files":[
+  "docs/DEVFLOW_SYSTEM_OVERVIEW.md",
+  "lib/test/run.sh",
+  "scripts/load-prompt-extension.sh"
+],
+"diff_profile":{"small_diff":false,"config_only":false,"has_new_types":false,"engine_self_modifying":true,"checklist_skipped":null},
+"phase3_dispatched":["pr-review-toolkit:code-reviewer","pr-review-toolkit:silent-failure-hunter","pr-review-toolkit:comment-analyzer","pr-review-toolkit:pr-test-analyzer","superpowers:requesting-code-review"],
+"phase3_findings":[
+ {"agent":"pr-review-toolkit:silent-failure-hunter","severity":"Important","description":"unreadable present file silently dropped","defect_signature":{"file":"scripts/load-prompt-extension.sh","line_range":[59,61],"kind":"unhandled_exception"},"corroboration_count":1,"fix_decision":"applied"},
+ {"agent":"pr-review-toolkit:silent-failure-hunter","severity":"Important","description":"symlink escapes dir; comment over-promises containment","defect_signature":{"file":"scripts/load-prompt-extension.sh","line_range":[23,53],"kind":"security"},"corroboration_count":2,"fix_decision":"applied"},
+ {"agent":"pr-review-toolkit:comment-analyzer","severity":"Suggestion","description":"model-supplied name wording imprecise","defect_signature":{"file":"scripts/load-prompt-extension.sh","line_range":[25,27],"kind":"comment_drift"},"corroboration_count":1,"fix_decision":"applied"},
+ {"agent":"pr-review-toolkit:pr-test-analyzer","severity":"Suggestion","description":"coverage guard vacuously green on empty glob","defect_signature":{"file":"lib/test/run.sh","line_range":[197,202],"kind":"test_gap"},"corroboration_count":1,"fix_decision":"applied"},
+ {"agent":"general-purpose:superpowers","severity":"Suggestion","description":"config.json gitignore analogy loose","defect_signature":{"file":"docs/DEVFLOW_SYSTEM_OVERVIEW.md","line_range":[67,67],"kind":"comment_drift"},"corroboration_count":1,"fix_decision":"applied"},
+ {"agent":"pr-review-toolkit:pr-test-analyzer","severity":"Suggestion","description":"no test for non-root CWD no-op","defect_signature":{"file":"lib/test/run.sh","line_range":[null,null],"kind":"test_gap"},"corroboration_count":1,"fix_decision":"pushed_back"},
+ {"agent":"pr-review-toolkit:pr-test-analyzer","severity":"Suggestion","description":"leading-dash skill names untested","defect_signature":{"file":"scripts/load-prompt-extension.sh","line_range":[48,53],"kind":"test_gap"},"corroboration_count":1,"fix_decision":"pushed_back"}
+],
+"fix_decisions":[
+ {"finding_id":"F-1","decision":"applied","commit":"be8c48eee25eee4df8184ceb29dc208afbc8c0ec"},
+ {"finding_id":"F-2","decision":"applied","commit":"be8c48eee25eee4df8184ceb29dc208afbc8c0ec"},
+ {"finding_id":"F-3","decision":"applied","commit":"be8c48eee25eee4df8184ceb29dc208afbc8c0ec"},
+ {"finding_id":"F-4","decision":"applied","commit":"be8c48eee25eee4df8184ceb29dc208afbc8c0ec"},
+ {"finding_id":"F-5","decision":"applied","commit":"be8c48eee25eee4df8184ceb29dc208afbc8c0ec"},
+ {"finding_id":"F-6","decision":"pushed_back","source_file":"lib/test/run.sh","claim_text":"no test for non-root CWD no-op","skip_category":"uncategorized","evidence":"low value; CWD-relative resolution is shared convention with config-get.sh which has no such test; wrong-CWD degrades safely to no-op"},
+ {"finding_id":"F-7","decision":"pushed_back","source_file":"scripts/load-prompt-extension.sh","claim_text":"leading-dash skill names untested","skip_category":"claim-quality","evidence":"ext_file always begins with '.devflow/', so cat never receives a dash-leading arg; no option-injection (confirmed by superpowers final-pass reviewer)"}
+],
+"convergence_inputs":{"fixes_applied":5,"fix_diff_lines":60,"new_corroborated_critical_count":0},
+"cap_drops":{"count":0,"by_category":{}}}

--- a/.devflow/logs/review/issue-84-add-a-consumer-prompt-extension-convention-for-/local-20260602T163146Z-1/iter-2.json
+++ b/.devflow/logs/review/issue-84-add-a-consumer-prompt-extension-convention-for-/local-20260602T163146Z-1/iter-2.json
@@ -1,0 +1,21 @@
+{"iter":2,"source":"review-and-fix","fix_commit_sha":"8bb317bf6be0a6b189ad0f8aca089d7aaab2f2af","fix_files":[
+  "lib/test/run.sh",
+  "scripts/load-prompt-extension.sh"
+],
+"diff_profile":{"small_diff":false,"config_only":false,"has_new_types":false,"engine_self_modifying":true,"checklist_skipped":null},
+"phase3_dispatched":["pr-review-toolkit:code-reviewer","pr-review-toolkit:silent-failure-hunter","pr-review-toolkit:comment-analyzer","pr-review-toolkit:pr-test-analyzer","superpowers:requesting-code-review"],
+"phase3_findings":[
+ {"agent":"pr-review-toolkit:silent-failure-hunter","severity":"Important","description":"broken symlink silently no-ops (missing target)","defect_signature":{"file":"scripts/load-prompt-extension.sh","line_range":[71,77],"kind":"logic_error"},"corroboration_count":1,"fix_decision":"applied"},
+ {"agent":"pr-review-toolkit:code-reviewer","severity":"Suggestion","description":"coverage-grep prefix weakness (substring)","defect_signature":{"file":"lib/test/run.sh","line_range":[230,231],"kind":"test_gap"},"corroboration_count":1,"fix_decision":"applied"},
+ {"agent":"pr-review-toolkit:silent-failure-hunter","severity":"Suggestion","description":"cat SIGPIPE→141 if caller streams (latent)","defect_signature":{"file":"scripts/load-prompt-extension.sh","line_range":[44,76],"kind":"api_misuse"},"corroboration_count":1,"fix_decision":"pushed_back"},
+ {"agent":"general-purpose:superpowers","severity":"Suggestion","description":"scaffold doesn't backfill example into pre-existing dir","defect_signature":{"file":"scripts/scaffold-config.sh","line_range":[123,149],"kind":"other"},"corroboration_count":1,"fix_decision":"pushed_back"},
+ {"agent":"pr-review-toolkit:code-reviewer","severity":"Suggestion","description":"CLAUDE.md sync gotcha not added","defect_signature":{"file":"CLAUDE.md","line_range":[null,null],"kind":"comment_drift"},"corroboration_count":1,"fix_decision":"pushed_back"}
+],
+"fix_decisions":[
+ {"finding_id":"F2-1","decision":"applied","commit":"8bb317bf6be0a6b189ad0f8aca089d7aaab2f2af"},
+ {"finding_id":"F2-2","decision":"applied","commit":"8bb317bf6be0a6b189ad0f8aca089d7aaab2f2af"},
+ {"finding_id":"F2-3","decision":"pushed_back","source_file":"scripts/load-prompt-extension.sh","claim_text":"cat SIGPIPE→141 if caller streams","skip_category":"claim-quality","evidence":"no shipped caller streams; all 16 SKILL.md invoke via $(...) full capture. Agent itself: 'No fix required for this PR'. Exit-code contract honest for actual usage."},
+ {"finding_id":"F2-4","decision":"pushed_back","source_file":"scripts/scaffold-config.sh","claim_text":"scaffold doesn't backfill example into pre-existing dir","skip_category":"uncategorized","evidence":"optional discoverability nicety; superpowers reviewer: 'genuinely optional and arguably out of scope... Ship as-is'. Consistent with the intentional don't-clobber-dir guard discipline."},
+ {"finding_id":"F2-5","decision":"pushed_back","source_file":"CLAUDE.md","claim_text":"new sync requirement not added to CLAUDE.md Gotchas","skip_category":"uncategorized","evidence":"~45 confidence sub-threshold; documented in CONTRIBUTING.md and enforced by the lib/test/run.sh coverage test. CLAUDE.md addition optional, out of this PR's core scope."}
+],
+"convergence_inputs":{"fixes_applied":2,"fix_diff_lines":32,"new_corroborated_critical_count":0}}

--- a/.devflow/logs/review/issue-84-add-a-consumer-prompt-extension-convention-for-/local-20260602T163146Z-1/iter-3.json
+++ b/.devflow/logs/review/issue-84-add-a-consumer-prompt-extension-convention-for-/local-20260602T163146Z-1/iter-3.json
@@ -1,0 +1,16 @@
+{"iter":3,"source":"review-and-fix","fix_commit_sha":"ca57b20a64b02ef50396e275612f8111e098f1e8","fix_files":[
+  ".github/workflows/devflow-runner.yml",
+  "lib/test/run.sh",
+  "scripts/load-prompt-extension.sh"
+],
+"diff_profile":{"small_diff":false,"config_only":false,"has_new_types":false,"engine_self_modifying":true,"checklist_skipped":null},
+"phase3_dispatched":["pr-review-toolkit:code-reviewer","pr-review-toolkit:silent-failure-hunter","superpowers:requesting-code-review"],
+"phase3_findings":[
+ {"agent":"pr-review-toolkit:code-reviewer","severity":"Important","description":"present-but-non-regular-file (dir / symlink-to-dir) silent no-op","defect_signature":{"file":"scripts/load-prompt-extension.sh","line_range":[73,89],"kind":"logic_error"},"corroboration_count":2,"fix_decision":"applied"},
+ {"agent":"general-purpose:superpowers","severity":"Important","description":"cloud review profile allowlist omits load-prompt-extension.sh → preflight silently denied in cloud","defect_signature":{"file":".github/workflows/devflow-runner.yml","line_range":[264,264],"kind":"api_misuse"},"corroboration_count":1,"fix_decision":"applied"}
+],
+"fix_decisions":[
+ {"finding_id":"F3-1","decision":"applied","commit":"ca57b20a64b02ef50396e275612f8111e098f1e8"},
+ {"finding_id":"F3-2","decision":"applied","commit":"ca57b20a64b02ef50396e275612f8111e098f1e8"}
+],
+"convergence_inputs":{"fixes_applied":2,"fix_diff_lines":44,"new_corroborated_critical_count":0,"new_corroborated_important_count":1}}

--- a/.devflow/logs/review/issue-84-add-a-consumer-prompt-extension-convention-for-/local-20260602T163146Z-1/iter-4.json
+++ b/.devflow/logs/review/issue-84-add-a-consumer-prompt-extension-convention-for-/local-20260602T163146Z-1/iter-4.json
@@ -1,0 +1,6 @@
+{"iter":4,"source":"review-and-fix","fix_commit_sha":null,"fix_files":[],
+"diff_profile":{"small_diff":false,"config_only":false,"has_new_types":false,"engine_self_modifying":true,"checklist_skipped":null},
+"phase3_dispatched":["pr-review-toolkit:silent-failure-hunter","superpowers:requesting-code-review"],
+"phase3_findings":[],
+"fix_decisions":[],
+"convergence_inputs":{"fixes_applied":0,"fix_diff_lines":0,"new_corroborated_critical_count":0,"new_corroborated_important_count":0}}

--- a/.devflow/logs/review/issue-84-add-a-consumer-prompt-extension-convention-for-/local-20260602T163146Z-1/iter-5.json
+++ b/.devflow/logs/review/issue-84-add-a-consumer-prompt-extension-convention-for-/local-20260602T163146Z-1/iter-5.json
@@ -1,0 +1,40 @@
+{"iter":5,"source":"review-and-fix","fix_commit_sha":"c5c59992361d37633e35ee96c13d59ff5ee901e4","fix_files":[
+  "docs/DEVFLOW_SYSTEM_OVERVIEW.md",
+  "lib/test/run.sh",
+  "scripts/load-prompt-extension.sh",
+  "skills/create-issue/SKILL.md",
+  "skills/docs-bootstrap-external/SKILL.md",
+  "skills/docs-bootstrap-internal/SKILL.md",
+  "skills/docs-release-notes/SKILL.md",
+  "skills/docs-sync-external/SKILL.md",
+  "skills/docs-sync-internal/SKILL.md",
+  "skills/docs-verify/SKILL.md",
+  "skills/docs/SKILL.md",
+  "skills/implement/SKILL.md",
+  "skills/init/SKILL.md",
+  "skills/pr-description/SKILL.md",
+  "skills/retrospective-audit/SKILL.md",
+  "skills/retrospective-weekly/SKILL.md",
+  "skills/retrospective/SKILL.md",
+  "skills/review-and-fix/SKILL.md",
+  "skills/review/SKILL.md"
+],
+"diff_profile":{"small_diff":false,"config_only":false,"has_new_types":false,"engine_self_modifying":true,"checklist_skipped":null},
+"phase3_dispatched":["pr-review-toolkit:code-reviewer","pr-review-toolkit:silent-failure-hunter","pr-review-toolkit:comment-analyzer","pr-review-toolkit:pr-test-analyzer","superpowers:requesting-code-review"],
+"phase3_findings":[
+ {"agent":"pr-review-toolkit:silent-failure-hunter","severity":"Important","description":"SKILL.md step ignored exit code → loud refusals swallowed at model layer","defect_signature":{"file":"skills/create-issue/SKILL.md","line_range":[null,null],"kind":"logic_error"},"corroboration_count":1,"fix_decision":"applied"},
+ {"agent":"pr-review-toolkit:pr-test-analyzer","severity":"Important","description":"coverage drift-guard false-passes on commented-out/prose-only mention","defect_signature":{"file":"lib/test/run.sh","line_range":[922,923],"kind":"test_gap"},"corroboration_count":1,"fix_decision":"applied"},
+ {"agent":"pr-review-toolkit:comment-analyzer","severity":"Suggestion","description":"'refused above' comment is backwards (guards are below)","defect_signature":{"file":"scripts/load-prompt-extension.sh","line_range":[66,68],"kind":"comment_drift"},"corroboration_count":1,"fix_decision":"applied"},
+ {"agent":"pr-review-toolkit:pr-test-analyzer","severity":"Suggestion","description":"symlink-to-dir case under-asserts (no breadcrumb)","defect_signature":{"file":"lib/test/run.sh","line_range":[244,249],"kind":"test_gap"},"corroboration_count":1,"fix_decision":"applied"},
+ {"agent":"pr-review-toolkit:silent-failure-hunter","severity":"Suggestion","description":"cat mid-stream partial read (race)","defect_signature":{"file":"scripts/load-prompt-extension.sh","line_range":[95,101],"kind":"race"},"corroboration_count":1,"fix_decision":"pushed_back"},
+ {"agent":"pr-review-toolkit:silent-failure-hunter","severity":"Suggestion","description":"scaffold mkdir not best-effort wrapped","defect_signature":{"file":"scripts/scaffold-config.sh","line_range":[123,149],"kind":"unhandled_exception"},"corroboration_count":1,"fix_decision":"pushed_back"}
+],
+"fix_decisions":[
+ {"finding_id":"F5-1","decision":"applied","commit":"c5c59992361d37633e35ee96c13d59ff5ee901e4"},
+ {"finding_id":"F5-2","decision":"applied","commit":"c5c59992361d37633e35ee96c13d59ff5ee901e4"},
+ {"finding_id":"F5-3","decision":"applied","commit":"c5c59992361d37633e35ee96c13d59ff5ee901e4"},
+ {"finding_id":"F5-4","decision":"applied","commit":"c5c59992361d37633e35ee96c13d59ff5ee901e4"},
+ {"finding_id":"F5-5","decision":"pushed_back","source_file":"scripts/load-prompt-extension.sh","claim_text":"cat mid-stream partial read yields truncated extension","skip_category":"claim-quality","evidence":"narrow race, POSIX-hard to fully close; no streaming caller (all 16 use $(...) full capture); set -e makes a cat failure non-zero (loud), not a silent success. Agent: 'flagging rather than insisting'. Documented residual."},
+ {"finding_id":"F5-6","decision":"pushed_back","source_file":"scripts/scaffold-config.sh","claim_text":"extension-dir mkdir/printf not wrapped in best-effort log-and-continue","skip_category":"uncategorized","evidence":"LOW; requires a pre-existing FILE named .devflow/prompt-extensions (bizarre); the mkdir/cp file-creation pattern already matches the surrounding mkdir -p $DEST / cp $SCHEMA blocks which also abort under set -e. Consistent with the file's hard-create steps, not its best-effort jq steps."}
+],
+"convergence_inputs":{"fixes_applied":4,"fix_diff_lines":43,"new_corroborated_critical_count":0,"new_corroborated_important_count":0}}

--- a/.devflow/logs/review/issue-90-add-an-advisory-claude-md-project-memory-nudge-to-/local-20260603T083338Z-1/iter-1.json
+++ b/.devflow/logs/review/issue-90-add-an-advisory-claude-md-project-memory-nudge-to-/local-20260603T083338Z-1/iter-1.json
@@ -1,0 +1,152 @@
+{
+  "iter": 1,
+  "source": "review-and-fix",
+  "fix_commit_sha": "d8e63a61e9664b0c8dd08e0cfb40acf2c86d8e75",
+  "fix_files": [
+    "skills/init/SKILL.md",
+    "lib/test/run.sh"
+  ],
+  "diff_profile": {
+    "small_diff": false,
+    "config_only": false,
+    "has_new_types": false,
+    "engine_self_modifying": true,
+    "checklist_skipped": null
+  },
+  "checklist": [
+    {
+      "id": "VC-1",
+      "verification_mode": "lite",
+      "verdict": "PASS",
+      "claim_signature": "string_presence:skill.md:never-creates-writes-edits-token",
+      "reused_from_iter_prev": false
+    },
+    {
+      "id": "VC-2",
+      "verification_mode": "lite",
+      "verdict": "PASS",
+      "claim_signature": "string_presence:skill.md:never-blocks-fails-init-token",
+      "reused_from_iter_prev": false
+    },
+    {
+      "id": "VC-3",
+      "verification_mode": "lite",
+      "verdict": "PASS",
+      "claim_signature": "string_presence:skill.md:built-in-init-token",
+      "reused_from_iter_prev": false
+    },
+    {
+      "id": "VC-4",
+      "verification_mode": "lite",
+      "verdict": "PASS",
+      "claim_signature": "string_presence:skill.md:lowercase-agents-variant-token",
+      "reused_from_iter_prev": false
+    },
+    {
+      "id": "VC-5",
+      "verification_mode": "lite",
+      "verdict": "PASS",
+      "claim_signature": "string_presence:skill.md:copilot-import-path-token",
+      "reused_from_iter_prev": false
+    },
+    {
+      "id": "VC-6",
+      "verification_mode": "agent",
+      "verdict": "PASS",
+      "claim_signature": "test_mock_alignment:run.sh:guard-token-set-matches-ac3",
+      "reused_from_iter_prev": false
+    },
+    {
+      "id": "VC-7",
+      "verification_mode": "agent",
+      "verdict": "PASS",
+      "claim_signature": "data_format_assumption:skill.md:import-path-grep-form",
+      "reused_from_iter_prev": false
+    },
+    {
+      "id": "VC-8",
+      "verification_mode": "agent",
+      "verdict": "PASS",
+      "claim_signature": "dependency_interaction:skill.md:posix-only-detection",
+      "reused_from_iter_prev": false
+    },
+    {
+      "id": "VC-9",
+      "verification_mode": "agent",
+      "verdict": "PASS",
+      "claim_signature": "api_contract:skill.md:four-case-matrix-covers-acs",
+      "reused_from_iter_prev": false
+    },
+    {
+      "id": "VC-10",
+      "verification_mode": "agent",
+      "verdict": "PASS",
+      "claim_signature": "api_contract:skill.md:placement-after-preflight-existing-steps-intact",
+      "reused_from_iter_prev": false
+    },
+    {
+      "id": "VC-11",
+      "verification_mode": "agent",
+      "verdict": "PASS",
+      "claim_signature": "api_contract:skill.md:nudge-states-improves-results",
+      "reused_from_iter_prev": false
+    },
+    {
+      "id": "VC-12",
+      "verification_mode": "lite",
+      "verdict": "PASS",
+      "claim_signature": "string_presence:changelog.md:2.8.0-entry-matches-version",
+      "reused_from_iter_prev": false
+    },
+    {
+      "id": "VC-13",
+      "verification_mode": "lite",
+      "verdict": "PASS",
+      "claim_signature": "string_presence:overview.md:notes-advisory-nudge",
+      "reused_from_iter_prev": false
+    },
+    {
+      "id": "VC-14",
+      "verification_mode": "agent",
+      "verdict": "FAIL",
+      "claim_signature": "data_format_assumption:skill.md:case-insensitive-fs-duplicate-agents",
+      "reused_from_iter_prev": false
+    },
+    {
+      "id": "VC-15",
+      "verification_mode": "agent",
+      "verdict": "PASS",
+      "claim_signature": "string_presence:run.sh:guard-tokens-block-unique",
+      "reused_from_iter_prev": false
+    }
+  ],
+  "phase3_dispatched": [],
+  "phase3_findings": [],
+  "fix_decisions": [
+    {
+      "finding_id": "VC-14",
+      "decision": "applied",
+      "commit": "d8e63a61e9664b0c8dd08e0cfb40acf2c86d8e75"
+    }
+  ],
+  "convergence_inputs": {
+    "fixes_applied": 1,
+    "fix_diff_lines": 24,
+    "new_corroborated_critical_count": 0
+  },
+  "cap_drops": {
+    "count": 0,
+    "by_category": {}
+  },
+  "telemetry": {
+    "phase_1": {
+      "calls": 1
+    },
+    "phase_2": {
+      "calls": 8
+    },
+    "phase_3": {
+      "calls": 0
+    }
+  }
+}

--- a/.devflow/logs/review/issue-90-add-an-advisory-claude-md-project-memory-nudge-to-/local-20260603T083338Z-1/iter-2.json
+++ b/.devflow/logs/review/issue-90-add-an-advisory-claude-md-project-memory-nudge-to-/local-20260603T083338Z-1/iter-2.json
@@ -1,0 +1,164 @@
+{
+  "iter": 2,
+  "source": "review-and-fix",
+  "fix_commit_sha": "86e5f3e36de139a110a0c9665454443a999e536a",
+  "fix_files": [
+    "skills/init/SKILL.md",
+    "lib/test/run.sh"
+  ],
+  "diff_profile": {
+    "small_diff": false,
+    "config_only": false,
+    "has_new_types": false,
+    "engine_self_modifying": true,
+    "checklist_skipped": null
+  },
+  "checklist": [
+    {
+      "id": "VC-14",
+      "verification_mode": "agent",
+      "verdict": "PASS",
+      "claim_signature": "data_format_assumption:skill.md:case-insensitive-fs-duplicate-agents",
+      "reused_from_iter_prev": false
+    }
+  ],
+  "phase3_dispatched": [
+    "pr-review-toolkit:code-reviewer",
+    "pr-review-toolkit:silent-failure-hunter",
+    "pr-review-toolkit:comment-analyzer",
+    "pr-review-toolkit:pr-test-analyzer",
+    "superpowers:requesting-code-review"
+  ],
+  "phase3_findings": [
+    {
+      "agent": "pr-review-toolkit:silent-failure-hunter",
+      "severity": "Important",
+      "description": "unguarded git rev-parse collapses ROOT to empty, misleading nudge + stderr leak",
+      "defect_signature": {
+        "file": "skills/init/SKILL.md",
+        "line_range": [
+          107,
+          122
+        ],
+        "kind": "logic_error"
+      },
+      "corroboration_count": 2,
+      "step25_classification": "codebase",
+      "fix_decision": "applied"
+    },
+    {
+      "agent": "pr-review-toolkit:silent-failure-hunter",
+      "severity": "Important",
+      "description": "case-sensitive @-import reference grep yields false unreferenced nudge on casing drift",
+      "defect_signature": {
+        "file": "skills/init/SKILL.md",
+        "line_range": [
+          125,
+          131
+        ],
+        "kind": "logic_error"
+      },
+      "corroboration_count": 2,
+      "step25_classification": "codebase",
+      "fix_decision": "applied"
+    },
+    {
+      "agent": "pr-review-toolkit:pr-test-analyzer",
+      "severity": "Important",
+      "description": "content guard does not pin silence discipline (AC6) or matrix case 3 (AC5)",
+      "defect_signature": {
+        "file": "lib/test/run.sh",
+        "line_range": [
+          970,
+          1006
+        ],
+        "kind": "test_gap"
+      },
+      "corroboration_count": 1,
+      "step25_classification": "codebase",
+      "fix_decision": "applied"
+    },
+    {
+      "agent": "pr-review-toolkit:comment-analyzer",
+      "severity": "Suggestion",
+      "description": "CASE-INSENSITIVELY comment overstates enumerated-casing probe",
+      "defect_signature": {
+        "file": "skills/init/SKILL.md",
+        "line_range": [
+          110,
+          114
+        ],
+        "kind": "comment_drift"
+      },
+      "corroboration_count": 1,
+      "step25_classification": "codebase",
+      "fix_decision": "applied"
+    },
+    {
+      "agent": "checklist-generator-variance",
+      "severity": "Suggestion",
+      "description": "CHANGELOG cites (#91) PR number vs issue #90 — confirmed repo convention (cites PR), non-issue",
+      "defect_signature": {
+        "file": "CHANGELOG.md",
+        "line_range": [
+          10,
+          10
+        ],
+        "kind": "other"
+      },
+      "corroboration_count": 1,
+      "step25_classification": "codebase",
+      "fix_decision": "pushed_back"
+    }
+  ],
+  "fix_decisions": [
+    {
+      "finding_id": "A",
+      "decision": "applied",
+      "commit": "86e5f3e36de139a110a0c9665454443a999e536a"
+    },
+    {
+      "finding_id": "B",
+      "decision": "applied",
+      "commit": "86e5f3e36de139a110a0c9665454443a999e536a"
+    },
+    {
+      "finding_id": "C",
+      "decision": "applied",
+      "commit": "86e5f3e36de139a110a0c9665454443a999e536a"
+    },
+    {
+      "finding_id": "D",
+      "decision": "applied",
+      "commit": "86e5f3e36de139a110a0c9665454443a999e536a"
+    },
+    {
+      "finding_id": "VC-20-changelog-issuenum",
+      "decision": "pushed_back",
+      "source_file": "CHANGELOG.md",
+      "claim_text": "CHANGELOG cites (#91) not (#90)",
+      "skip_category": "claim-quality",
+      "evidence": "repo convention is CHANGELOG cites the PR number, not the issue; git history shic-bump for issue #84 (#85). #91 is the PR — correct."
+    }
+  ],
+  "convergence_inputs": {
+    "fixes_applied": 4,
+    "fix_diff_lines": 38,
+    "new_corroborated_critical_count": 0
+  },
+  "cap_drops": {
+    "count": 0,
+    "by_category": {}
+  },
+  "telemetry": {
+    "phase_1": {
+      "calls": 1
+    },
+    "phase_2": {
+      "calls": 1
+    },
+    "phase_3": {
+      "calls": 5
+    }
+  }
+}

--- a/.devflow/logs/review/issue-90-add-an-advisory-claude-md-project-memory-nudge-to-/local-20260603T083338Z-1/iter-3.json
+++ b/.devflow/logs/review/issue-90-add-an-advisory-claude-md-project-memory-nudge-to-/local-20260603T083338Z-1/iter-3.json
@@ -1,0 +1,135 @@
+{
+  "iter": 3,
+  "source": "review-and-fix",
+  "fix_commit_sha": "beceb6addf922a611a970ec4ab7dc51c2af902fd",
+  "fix_files": [
+    "skills/init/SKILL.md",
+    "lib/test/run.sh"
+  ],
+  "diff_profile": {
+    "small_diff": false,
+    "config_only": false,
+    "has_new_types": false,
+    "engine_self_modifying": true,
+    "checklist_skipped": null
+  },
+  "checklist": [],
+  "phase3_dispatched": [
+    "pr-review-toolkit:code-reviewer",
+    "pr-review-toolkit:silent-failure-hunter",
+    "pr-review-toolkit:comment-analyzer",
+    "pr-review-toolkit:pr-test-analyzer",
+    "superpowers:requesting-code-review"
+  ],
+  "phase3_findings": [
+    {
+      "agent": "pr-review-toolkit:silent-failure-hunter",
+      "severity": "Important",
+      "description": "grep exit-2 (read error) conflated with exit-1 (no match) → misreport unreadable CLAUDE.md as unreferenced",
+      "defect_signature": {
+        "file": "skills/init/SKILL.md",
+        "line_range": [
+          137,
+          139
+        ],
+        "kind": "logic_error"
+      },
+      "corroboration_count": 1,
+      "step25_classification": "codebase",
+      "fix_decision": "applied"
+    },
+    {
+      "agent": "pr-review-toolkit:comment-analyzer",
+      "severity": "Important",
+      "description": "AGENT.md/agent.md are singular spellings, not casings of AGENTS.md — comment factually wrong",
+      "defect_signature": {
+        "file": "skills/init/SKILL.md",
+        "line_range": [
+          110,
+          122
+        ],
+        "kind": "comment_drift"
+      },
+      "corroboration_count": 1,
+      "step25_classification": "codebase",
+      "fix_decision": "applied"
+    },
+    {
+      "agent": "pr-review-toolkit:pr-test-analyzer",
+      "severity": "Important",
+      "description": "load-bearing defensive root guard unpinned by any test assertion",
+      "defect_signature": {
+        "file": "lib/test/run.sh",
+        "line_range": [
+          1000,
+          1063
+        ],
+        "kind": "test_gap"
+      },
+      "corroboration_count": 2,
+      "step25_classification": "codebase",
+      "fix_decision": "applied"
+    },
+    {
+      "agent": "pr-review-toolkit:code-reviewer",
+      "severity": "Important",
+      "description": "CHANGELOG cites (#91) — claimed should be #90",
+      "defect_signature": {
+        "file": "CHANGELOG.md",
+        "line_range": [
+          10,
+          10
+        ],
+        "kind": "logic_error"
+      },
+      "corroboration_count": 1,
+      "step25_classification": "codebase",
+      "fix_decision": "pushed_back"
+    }
+  ],
+  "fix_decisions": [
+    {
+      "finding_id": "rc-conflation",
+      "decision": "applied",
+      "commit": "beceb6addf922a611a970ec4ab7dc51c2af902fd"
+    },
+    {
+      "finding_id": "casing-mislabel",
+      "decision": "applied",
+      "commit": "beceb6addf922a611a970ec4ab7dc51c2af902fd"
+    },
+    {
+      "finding_id": "root-guard-testgap",
+      "decision": "applied",
+      "commit": "beceb6addf922a611a970ec4ab7dc51c2af902fd"
+    },
+    {
+      "finding_id": "changelog-91-vs-90",
+      "decision": "pushed_back",
+      "source_file": "CHANGELOG.md",
+      "claim_text": "CHANGELOG cites (#91) should be (#90)",
+      "skip_category": "claim-quality",
+      "evidence": "Verified via gh: #90 is the issue, #91 is the PR (same title). Repo convention cites the PR number in CHANGELOG (git log: chore bump for issue #84 (#85); 2.7.2 entry cites (#85)). (#91) is correct. Corroborated by comment-analyzer + final-pass agreeing it is correct."
+    }
+  ],
+  "convergence_inputs": {
+    "fixes_applied": 3,
+    "fix_diff_lines": 32,
+    "new_corroborated_critical_count": 0
+  },
+  "cap_drops": {
+    "count": 0,
+    "by_category": {}
+  },
+  "telemetry": {
+    "phase_1": {
+      "calls": 1
+    },
+    "phase_2": {
+      "calls": 0
+    },
+    "phase_3": {
+      "calls": 5
+    }
+  }
+}

--- a/.devflow/logs/review/issue-90-add-an-advisory-claude-md-project-memory-nudge-to-/local-20260603T083338Z-1/iter-4.json
+++ b/.devflow/logs/review/issue-90-add-an-advisory-claude-md-project-memory-nudge-to-/local-20260603T083338Z-1/iter-4.json
@@ -1,0 +1,114 @@
+{
+  "iter": 4,
+  "source": "review-and-fix",
+  "fix_commit_sha": "7565f8c67b86eafed5c05262a3bf060e1ecea966",
+  "fix_files": [
+    "skills/init/SKILL.md",
+    "lib/test/run.sh"
+  ],
+  "diff_profile": {
+    "small_diff": false,
+    "config_only": false,
+    "has_new_types": false,
+    "engine_self_modifying": true,
+    "checklist_skipped": null
+  },
+  "checklist": [],
+  "phase3_dispatched": [
+    "pr-review-toolkit:code-reviewer",
+    "pr-review-toolkit:silent-failure-hunter",
+    "pr-review-toolkit:comment-analyzer",
+    "pr-review-toolkit:pr-test-analyzer",
+    "superpowers:requesting-code-review"
+  ],
+  "phase3_findings": [
+    {
+      "agent": "pr-review-toolkit:silent-failure-hunter",
+      "severity": "Important",
+      "description": "block 2 free-form placeholder could re-glob and bypass AGENTS.md dedup / lose $ROOT cross-shell",
+      "defect_signature": {
+        "file": "skills/init/SKILL.md",
+        "line_range": [
+          139,
+          145
+        ],
+        "kind": "logic_error"
+      },
+      "corroboration_count": 2,
+      "step25_classification": "codebase",
+      "fix_decision": "applied"
+    },
+    {
+      "agent": "pr-review-toolkit:pr-test-analyzer",
+      "severity": "Suggestion",
+      "description": "case-2 dedup + rc>=2 silence unpinned by tests",
+      "defect_signature": {
+        "file": "lib/test/run.sh",
+        "line_range": [
+          1000,
+          1011
+        ],
+        "kind": "test_gap"
+      },
+      "corroboration_count": 1,
+      "step25_classification": "codebase",
+      "fix_decision": "applied"
+    },
+    {
+      "agent": "checklist-generator-variance",
+      "severity": "Suggestion",
+      "description": "version-string plugin.json<->CHANGELOG match + return/exit idiom — both verified sound",
+      "defect_signature": {
+        "file": "skills/init/SKILL.md",
+        "line_range": [
+          107,
+          109
+        ],
+        "kind": "other"
+      },
+      "corroboration_count": 1,
+      "step25_classification": "codebase",
+      "fix_decision": "advisory"
+    }
+  ],
+  "fix_decisions": [
+    {
+      "finding_id": "block-wiring",
+      "decision": "applied",
+      "commit": "7565f8c67b86eafed5c05262a3bf060e1ecea966"
+    },
+    {
+      "finding_id": "test-pins-case2-rc2",
+      "decision": "applied",
+      "commit": "7565f8c67b86eafed5c05262a3bf060e1ecea966"
+    },
+    {
+      "finding_id": "version-match-and-idiom",
+      "decision": "advisory",
+      "source_file": "skills/init/SKILL.md",
+      "claim_text": "version-string match + return/exit idiom",
+      "skip_category": "advisory-parked",
+      "evidence": "both verified sound by reviewers (version 2.8.0 matches CHANGELOG; rc=128 outside repo caught by guard)"
+    }
+  ],
+  "convergence_inputs": {
+    "fixes_applied": 3,
+    "fix_diff_lines": 28,
+    "new_corroborated_critical_count": 0
+  },
+  "cap_drops": {
+    "count": 0,
+    "by_category": {}
+  },
+  "telemetry": {
+    "phase_1": {
+      "calls": 1
+    },
+    "phase_2": {
+      "calls": 0
+    },
+    "phase_3": {
+      "calls": 5
+    }
+  }
+}

--- a/.devflow/logs/review/issue-90-add-an-advisory-claude-md-project-memory-nudge-to-/local-20260603T083338Z-1/iter-5.json
+++ b/.devflow/logs/review/issue-90-add-an-advisory-claude-md-project-memory-nudge-to-/local-20260603T083338Z-1/iter-5.json
@@ -1,0 +1,140 @@
+{
+  "iter": 5,
+  "source": "review-and-fix",
+  "fix_commit_sha": "c4d32191a52aab51bce89b321bf2a11a3e193230",
+  "fix_files": [
+    "skills/init/SKILL.md"
+  ],
+  "diff_profile": {
+    "small_diff": false,
+    "config_only": false,
+    "has_new_types": false,
+    "engine_self_modifying": true,
+    "checklist_skipped": null
+  },
+  "checklist": [],
+  "phase3_dispatched": [
+    "pr-review-toolkit:code-reviewer",
+    "pr-review-toolkit:silent-failure-hunter",
+    "pr-review-toolkit:comment-analyzer",
+    "pr-review-toolkit:pr-test-analyzer",
+    "superpowers:requesting-code-review"
+  ],
+  "phase3_findings": [
+    {
+      "agent": "pr-review-toolkit:silent-failure-hunter",
+      "severity": "Important",
+      "description": "block 2 lacked explicit [ -f CLAUDE.md ] precondition gate (correct only via rc>=2 swallow)",
+      "defect_signature": {
+        "file": "skills/init/SKILL.md",
+        "line_range": [
+          144,
+          150
+        ],
+        "kind": "logic_error"
+      },
+      "corroboration_count": 1,
+      "step25_classification": "codebase",
+      "fix_decision": "applied"
+    }
+  ],
+  "fix_decisions": [
+    {
+      "finding_id": "block2-precondition-gate",
+      "decision": "applied",
+      "commit": "c4d32191a52aab51bce89b321bf2a11a3e193230"
+    }
+  ],
+  "convergence_inputs": {
+    "fixes_applied": 1,
+    "fix_diff_lines": 9,
+    "new_corroborated_critical_count": 0
+  },
+  "cap_drops": {
+    "count": 0,
+    "by_category": {}
+  },
+  "telemetry": {
+    "phase_1": {
+      "calls": 0
+    },
+    "phase_2": {
+      "calls": 0
+    },
+    "phase_3": {
+      "calls": 4
+    }
+  },
+  "shadow": {
+    "ran_at": "2026-06-03T08:34:00Z",
+    "reviewed_sha": "c4d32191a52aab51bce89b321bf2a11a3e193230",
+    "verdict": "APPROVE",
+    "coverage": "full",
+    "reviewers_dispatched": [
+      "pr-review-toolkit:code-reviewer",
+      "pr-review-toolkit:silent-failure-hunter",
+      "pr-review-toolkit:comment-analyzer",
+      "pr-review-toolkit:pr-test-analyzer",
+      "superpowers:requesting-code-review"
+    ],
+    "expected_reviewers": [
+      "pr-review-toolkit:code-reviewer",
+      "pr-review-toolkit:silent-failure-hunter",
+      "pr-review-toolkit:comment-analyzer",
+      "pr-review-toolkit:pr-test-analyzer",
+      "superpowers:requesting-code-review"
+    ],
+    "reason": null,
+    "checklist_skipped": null,
+    "phase3_findings": [
+      {
+        "agent": "pr-review-toolkit:comment-analyzer",
+        "severity": "Suggestion",
+        "description": "CHANGELOG (#91) claimed should be (#90) — VERIFIED FALSE POSITIVE: #91 is the PR; convention cites PR number. Overlaps iter-3.",
+        "defect_signature": {
+          "file": "CHANGELOG.md",
+          "line_range": [
+            24,
+            24
+          ],
+          "kind": "other"
+        }
+      },
+      {
+        "agent": "pr-review-toolkit:pr-test-analyzer",
+        "severity": "Suggestion",
+        "description": "@GEMINI.md/@.cursorrules @-import paths unpinned by tests (minor)",
+        "defect_signature": {
+          "file": "lib/test/run.sh",
+          "line_range": [
+            99,
+            104
+          ],
+          "kind": "test_gap"
+        }
+      },
+      {
+        "agent": "pr-review-toolkit:comment-analyzer",
+        "severity": "Suggestion",
+        "description": "agents.md test token also matches prose occurrences (test-precision nit)",
+        "defect_signature": {
+          "file": "lib/test/run.sh",
+          "line_range": [
+            978,
+            986
+          ],
+          "kind": "test_gap"
+        }
+      }
+    ],
+    "phase2_fails": [],
+    "comparison": {
+      "shadow_total": 3,
+      "overlap_with_iter_N": 1,
+      "new": 2,
+      "new_critical": 0,
+      "new_important": 0
+    },
+    "promoted_to_iter_next": false
+  }
+}

--- a/.devflow/logs/review/pr-108/local-20260603T195522Z-1/iter-1.json
+++ b/.devflow/logs/review/pr-108/local-20260603T195522Z-1/iter-1.json
@@ -1,0 +1,216 @@
+{
+  "iter": 1,
+  "started_at": "2026-06-03T19:55:00Z",
+  "fix_commit_sha": null,
+  "fix_files": [],
+  "diff_profile": {
+    "small_diff": false,
+    "config_only": true,
+    "has_new_types": false,
+    "engine_self_modifying": false,
+    "checklist_skipped": null
+  },
+  "phase3_dispatched": [
+    "pr-review-toolkit:code-reviewer",
+    "pr-review-toolkit:silent-failure-hunter",
+    "pr-review-toolkit:comment-analyzer",
+    "superpowers:requesting-code-review"
+  ],
+  "checklist": [
+    {
+      "id": "VC-1",
+      "verification_mode": "lite",
+      "verdict": "PASS",
+      "claim_signature": "dependency_interaction:efficiency-trace.sh:persist-flag-supported"
+    },
+    {
+      "id": "VC-6",
+      "verification_mode": "agent",
+      "verdict": "PASS",
+      "claim_signature": "api_contract:devflow.yml:step-matches-doc-verbatim"
+    },
+    {
+      "id": "VC-7",
+      "verification_mode": "agent",
+      "verdict": "PASS",
+      "claim_signature": "api_contract:devflow-implement.yml:step-matches-doc-verbatim"
+    },
+    {
+      "id": "VC-8",
+      "verification_mode": "agent",
+      "verdict": "PASS",
+      "claim_signature": "api_contract:settings.json:stop-hook-matches-doc-verbatim"
+    },
+    {
+      "id": "VC-10",
+      "verification_mode": "lite",
+      "verdict": "PASS",
+      "claim_signature": "api_contract:plugin.json:version-changelog-match"
+    },
+    {
+      "id": "VC-11",
+      "verification_mode": "lite",
+      "verdict": "PASS",
+      "claim_signature": "dependency_interaction:devflow-runner.yml:backstop-excluded"
+    },
+    {
+      "id": "VC-13",
+      "verification_mode": "agent",
+      "verdict": "PASS",
+      "claim_signature": "data_format_assumption:settings.json:relative-helper-path-intent"
+    }
+  ],
+  "phase3_findings": [
+    {
+      "agent": "pr-review-toolkit:silent-failure-hunter",
+      "severity": "Important",
+      "description": "Stop hook relative path + || true can silently no-op with no breadcrumb if cwd is not repo root",
+      "defect_signature": {
+        "file": ".claude/settings.json",
+        "line_range": [
+          7,
+          7
+        ],
+        "kind": "api_misuse"
+      },
+      "corroboration_count": 1,
+      "step25_classification": "advisory",
+      "fix_decision": "advisory"
+    },
+    {
+      "agent": "pr-review-toolkit:comment-analyzer",
+      "severity": "Suggestion",
+      "description": "step name 'review-and-fix' in devflow-implement.yml could confuse a future maintainer",
+      "defect_signature": {
+        "file": ".github/workflows/devflow-implement.yml",
+        "line_range": [
+          494,
+          494
+        ],
+        "kind": "comment_drift"
+      },
+      "corroboration_count": 1,
+      "fix_decision": "advisory"
+    },
+    {
+      "agent": "superpowers:requesting-code-review",
+      "severity": "Suggestion",
+      "description": "CHANGELOG missing blank line before previous heading (cosmetic, pre-existing pattern)",
+      "defect_signature": {
+        "file": "CHANGELOG.md",
+        "line_range": [
+          10,
+          11
+        ],
+        "kind": "style"
+      },
+      "corroboration_count": 2,
+      "fix_decision": "advisory"
+    }
+  ],
+  "fix_decisions": [
+    {
+      "finding_id": "F-1",
+      "decision": "advisory",
+      "source_file": ".claude/settings.json",
+      "claim_text": "relative hook path + || true silent no-op",
+      "skip_category": "advisory-parked",
+      "evidence": "artifact is mandated VERBATIM by AC1 + docs/efficiency-trace.md; fixing desyncs the documented source of truth (out of scope for this wiring PR \u2014 critiques the #101 design); Claude Code Stop hooks run from project root so the relative path resolves; the hook is a best-effort local convenience and the cloud workflow step is the actual guarantee"
+    },
+    {
+      "finding_id": "F-2",
+      "decision": "advisory",
+      "source_file": ".github/workflows/devflow-implement.yml",
+      "claim_text": "step name could confuse",
+      "skip_category": "advisory-parked",
+      "evidence": "name is verbatim-from-docs and accurate (implement Phase 3 runs review-and-fix, producing that telemetry); a clarifying comment would diverge from the verbatim artifact"
+    },
+    {
+      "finding_id": "F-3",
+      "decision": "advisory",
+      "source_file": "CHANGELOG.md",
+      "claim_text": "missing blank line",
+      "skip_category": "advisory-parked",
+      "evidence": "pre-existing repo pattern (same at lines 15, 126); not a regression this PR introduces; cosmetic"
+    }
+  ],
+  "convergence_inputs": {
+    "fixes_applied": 0,
+    "fix_diff_lines": 0,
+    "new_corroborated_critical_count": 0
+  },
+  "cap_drops": {
+    "count": 0,
+    "by_category": {}
+  },
+  "shadow": {
+    "ran_at": "2026-06-03T20:05:00Z",
+    "reviewed_sha": "2fc6fa482347bb878fc0f1355b731c82e427195c",
+    "verdict": "APPROVE WITH ADVISORY NOTES",
+    "coverage": "full",
+    "reviewers_dispatched": [
+      "pr-review-toolkit:code-reviewer",
+      "pr-review-toolkit:silent-failure-hunter",
+      "pr-review-toolkit:comment-analyzer",
+      "superpowers:requesting-code-review"
+    ],
+    "expected_reviewers": [
+      "pr-review-toolkit:code-reviewer",
+      "pr-review-toolkit:silent-failure-hunter",
+      "pr-review-toolkit:comment-analyzer",
+      "superpowers:requesting-code-review"
+    ],
+    "reason": null,
+    "checklist_skipped": null,
+    "phase3_findings": [
+      {
+        "agent": "pr-review-toolkit:silent-failure-hunter",
+        "severity": "Important",
+        "description": "failed git push + presence-idempotent --persist claimed permanent silent loss",
+        "defect_signature": {
+          "file": ".github/workflows/devflow.yml",
+          "line_range": [
+            497,
+            499
+          ],
+          "kind": "logic_error"
+        }
+      },
+      {
+        "agent": "pr-review-toolkit:silent-failure-hunter",
+        "severity": "Important",
+        "description": "bare git push no refspec, detached-HEAD risk",
+        "defect_signature": {
+          "file": ".github/workflows/devflow.yml",
+          "line_range": [
+            495,
+            498
+          ],
+          "kind": "api_misuse"
+        }
+      },
+      {
+        "agent": "pr-review-toolkit:silent-failure-hunter",
+        "severity": "Suggestion",
+        "description": "git rev-parse failure silently coerced",
+        "defect_signature": {
+          "file": ".github/workflows/devflow.yml",
+          "line_range": [
+            494,
+            497
+          ],
+          "kind": "logic_error"
+        }
+      }
+    ],
+    "phase2_fails": [],
+    "comparison": {
+      "shadow_total": 7,
+      "overlap_with_iter_N": 4,
+      "new": 3,
+      "new_critical": 0,
+      "new_important": 2
+    },
+    "promoted_to_iter_next": true
+  }
+}

--- a/.devflow/logs/review/pr-108/local-20260603T195522Z-1/iter-2.json
+++ b/.devflow/logs/review/pr-108/local-20260603T195522Z-1/iter-2.json
@@ -1,0 +1,20 @@
+{
+  "iter": 2,
+  "started_at": "2026-06-03T20:06:00Z",
+  "promoted_from_shadow": true,
+  "fix_commit_sha": null,
+  "fix_files": [],
+  "diff_profile": {"small_diff": false, "config_only": true, "has_new_types": false, "engine_self_modifying": false, "checklist_skipped": "intentional"},
+  "phase3_dispatched": [],
+  "checklist": [],
+  "phase3_findings": [
+    {"agent":"pr-review-toolkit:silent-failure-hunter","severity":"Important","description":"git push failure + idempotent persist = permanent loss","defect_signature":{"file":".github/workflows/devflow.yml","line_range":[497,499],"kind":"logic_error"},"step25_classification":"web_refuted","fix_decision":"advisory"},
+    {"agent":"pr-review-toolkit:silent-failure-hunter","severity":"Important","description":"git push no refspec detached-HEAD","defect_signature":{"file":".github/workflows/devflow.yml","line_range":[495,498],"kind":"api_misuse"},"step25_classification":"codebase","fix_decision":"advisory"}
+  ],
+  "fix_decisions": [
+    {"finding_id":"S-1","decision":"advisory","source_file":".github/workflows/devflow.yml","claim_text":"push failure + idempotency = permanent silent loss","skip_category":"advisory-parked","evidence":"refuted on cloud-execution-model boundary: runners ephemeral, records run-id-keyed, failed-push commit discarded at teardown; next run starts from fresh checkout (record absent) and re-derives+pushes. Reduces to one-run best-effort loss WITH breadcrumb = documented contract. Also verbatim-from-docs artifact (out of scope to change here)"},
+    {"finding_id":"S-2","decision":"advisory","source_file":".github/workflows/devflow.yml","claim_text":"bare git push no refspec","skip_category":"advisory-parked","evidence":"verbatim-from-docs #101 artifact; best-effort by design (failure -> ::warning::, exit 0); changing desyncs docs/efficiency-trace.md. Surfaced for a possible docs-hardening follow-up"}
+  ],
+  "convergence_inputs": {"fixes_applied": 0, "fix_diff_lines": 0, "new_corroborated_critical_count": 0},
+  "cap_drops": {"count": 0, "by_category": {}}
+}

--- a/.devflow/logs/review/pr-62/local-20260527T115350Z-1/iter-1.json
+++ b/.devflow/logs/review/pr-62/local-20260527T115350Z-1/iter-1.json
@@ -1,0 +1,81 @@
+{
+  "iter": 1,
+  "started_at": "2026-05-27T11:53:50Z",
+  "fix_commit_sha": "dfe7565",
+  "fix_files": ["CHANGELOG.md", "docs/shadow-review.md", "skills/implement/SKILL.md", "skills/review-and-fix/SKILL.md"],
+  "diff_profile": {
+    "small_diff": false,
+    "config_only": true,
+    "has_new_types": false,
+    "engine_self_modifying": true,
+    "checklist_skipped": null
+  },
+  "checklist": [
+    {"id": "VC-1", "verification_mode": "agent", "verdict": "PASS", "claim_signature": "data_format_assumption:SKILL.md:dispatched-collected-1to1-join", "reused_from_iter_prev": false},
+    {"id": "VC-2", "verification_mode": "agent", "verdict": "PASS", "claim_signature": "api_contract:SKILL.md:outcome1-block-presence-gate", "reused_from_iter_prev": false},
+    {"id": "VC-3", "verification_mode": "agent", "verdict": "PASS", "claim_signature": "api_contract:SKILL.md:awusf-render-time-coverage-gate", "reused_from_iter_prev": false},
+    {"id": "VC-4", "verification_mode": "agent", "verdict": "PASS", "claim_signature": "data_format_assumption:SKILL.md:tripwire-keys-phase3-dispatched", "reused_from_iter_prev": false},
+    {"id": "VC-5", "verification_mode": "agent", "verdict": "PASS", "claim_signature": "api_contract:SKILL.md:outcome3-transient-vs-structural-retry", "reused_from_iter_prev": false},
+    {"id": "VC-6", "verification_mode": "lite", "verdict": "PASS", "claim_signature": "string_presence:SKILL.md:reason-empty-fallback-literal", "reused_from_iter_prev": false},
+    {"id": "VC-7", "verification_mode": "agent", "verdict": "PASS", "claim_signature": "api_contract:SKILL.md:outcome3-nulls-verdict", "reused_from_iter_prev": false},
+    {"id": "VC-8", "verification_mode": "agent", "verdict": "PASS", "claim_signature": "api_contract:SKILL.md:phase2fails-fieldname-mapping", "reused_from_iter_prev": false},
+    {"id": "VC-9", "verification_mode": "lite", "verdict": "PASS", "claim_signature": "data_format_assumption:SKILL.md:phase3dispatched-schema-adds-rcr", "reused_from_iter_prev": false},
+    {"id": "VC-10", "verification_mode": "lite", "verdict": "PASS", "claim_signature": "string_presence:SKILL.md:step26-telemetry-parenthetical", "reused_from_iter_prev": false},
+    {"id": "VC-11", "verification_mode": "lite", "verdict": "PASS", "claim_signature": "string_presence:shadow-review.md:calibration-section-present", "reused_from_iter_prev": false},
+    {"id": "VC-12", "verification_mode": "agent", "verdict": "PASS", "claim_signature": "api_contract:implement.md:approve-family-verdict-list", "reused_from_iter_prev": false},
+    {"id": "VC-13", "verification_mode": "agent", "verdict": "PASS", "claim_signature": "api_contract:implement.md:awusf-bounded-rereview-contract", "reused_from_iter_prev": false},
+    {"id": "VC-14", "verification_mode": "agent", "verdict": "PASS", "claim_signature": "data_format_assumption:SKILL.md:checklist-skip-tripwire-comparand", "reused_from_iter_prev": false},
+    {"id": "VC-15", "verification_mode": "agent", "verdict": "PASS", "claim_signature": "data_format_assumption:SKILL.md:expected-reviewers-union-definition", "reused_from_iter_prev": false},
+    {"id": "VC-16", "verification_mode": "lite", "verdict": "PASS", "claim_signature": "api_contract:CHANGELOG.md:version-243-entry-present", "reused_from_iter_prev": false},
+    {"id": "VC-17", "verification_mode": "agent", "verdict": "PASS", "claim_signature": "data_format_assumption:CHANGELOG.md:243-narrative-matches-spec", "reused_from_iter_prev": false},
+    {"id": "VC-18", "verification_mode": "agent", "verdict": "PASS", "claim_signature": "api_contract:SKILL.md:outcome2-persistence-asymmetry", "reused_from_iter_prev": false},
+    {"id": "VC-19", "verification_mode": "agent", "verdict": "PASS", "claim_signature": "api_contract:SKILL.md:awusf-coverage-branch-precedence", "reused_from_iter_prev": false}
+  ],
+  "phase3_dispatched": [
+    "pr-review-toolkit:code-reviewer",
+    "pr-review-toolkit:silent-failure-hunter",
+    "pr-review-toolkit:comment-analyzer",
+    "superpowers:requesting-code-review"
+  ],
+  "phase3_findings": [
+    {"agent": "pr-review-toolkit:code-reviewer", "severity": "Important", "description": "CHANGELOG 2.4.3 tripwire bullet duplicates the verbatim 2.4.1 roster-tripwire sentence", "defect_signature": {"file": "CHANGELOG.md", "line_range": [10, 10], "kind": "comment_drift"}, "corroboration_count": 2, "step25_classification": "codebase", "fix_decision": "applied"},
+    {"agent": "pr-review-toolkit:comment-analyzer", "severity": "Important", "description": "CHANGELOG double-attribution between 2.4.3 and already-shipped 2.4.1 for the same #61 tripwire fix", "defect_signature": {"file": "CHANGELOG.md", "line_range": [10, 20], "kind": "comment_drift"}, "corroboration_count": 2, "step25_classification": "codebase", "fix_decision": "applied"},
+    {"agent": "pr-review-toolkit:silent-failure-hunter", "severity": "Important", "description": "F1: implement bounded re-review clears on a re-review that returned APPROVE with coverage:not_verified (gate keys on verdict string only)", "defect_signature": {"file": "skills/implement/SKILL.md", "line_range": [567, 568], "kind": "logic_error"}, "corroboration_count": 1, "step25_classification": "codebase", "fix_decision": "applied"},
+    {"agent": "pr-review-toolkit:silent-failure-hunter", "severity": "Important", "description": "F2: first-run clean approve-family ticks the gate with no shadow-coverage check (not_verified silently consumed as full)", "defect_signature": {"file": "skills/implement/SKILL.md", "line_range": [558, 565], "kind": "logic_error"}, "corroboration_count": 1, "step25_classification": "codebase", "fix_decision": "applied"},
+    {"agent": "pr-review-toolkit:silent-failure-hunter", "severity": "Suggestion", "description": "F3: outcome-1 read-back failure routes to outcome 3 but does not specify downgrading in-memory coverage/verdict", "defect_signature": {"file": "skills/review-and-fix/SKILL.md", "line_range": [398, 398], "kind": "logic_error"}, "corroboration_count": 1, "step25_classification": "codebase", "fix_decision": "applied"},
+    {"agent": "pr-review-toolkit:silent-failure-hunter", "severity": "Suggestion", "description": "F4: absent-comparand checklist tripwire forces a re-audit on a trivial diff (fail-closed, but undocumented cost)", "defect_signature": {"file": "skills/review-and-fix/SKILL.md", "line_range": [376, 376], "kind": "logic_error"}, "corroboration_count": 1, "step25_classification": "codebase", "fix_decision": "applied"},
+    {"agent": "pr-review-toolkit:silent-failure-hunter", "severity": "Suggestion", "description": "F5: first-run no-recognizable-verdict not explicitly handled on implement side", "defect_signature": {"file": "skills/implement/SKILL.md", "line_range": [556, 573], "kind": "logic_error"}, "corroboration_count": 1, "step25_classification": "codebase", "fix_decision": "applied"},
+    {"agent": "pr-review-toolkit:silent-failure-hunter", "severity": "Suggestion", "description": "F6: AWUSF Coverage 'scan every iter' note could double-render the pinned lost block", "defect_signature": {"file": "skills/review-and-fix/SKILL.md", "line_range": [609, 609], "kind": "comment_drift"}, "corroboration_count": 1, "step25_classification": "codebase", "fix_decision": "applied"},
+    {"agent": "pr-review-toolkit:silent-failure-hunter", "severity": "Suggestion", "description": "F7: global single-retry budget not specified as un-persisted single-context state", "defect_signature": {"file": "skills/review-and-fix/SKILL.md", "line_range": [417, 417], "kind": "race"}, "corroboration_count": 1, "step25_classification": "codebase", "fix_decision": "applied"},
+    {"agent": "pr-review-toolkit:comment-analyzer", "severity": "Suggestion", "description": "docs/shadow-review.md uses both #57 and #58 for the same change", "defect_signature": {"file": "docs/shadow-review.md", "line_range": [221, 221], "kind": "comment_drift"}, "corroboration_count": 1, "step25_classification": "codebase", "fix_decision": "applied"},
+    {"agent": "superpowers:requesting-code-review", "severity": "Suggestion", "description": "phase3_dispatched example lists pr-test-analyzer not explained by diff_profile; '~7' magic number in docs calibration", "defect_signature": {"file": "docs/shadow-review.md", "line_range": [223, 223], "kind": "comment_drift"}, "corroboration_count": 1, "step25_classification": "codebase", "fix_decision": "applied"}
+  ],
+  "fix_decisions": [
+    {"finding_id": "F-changelog-dup", "decision": "applied", "commit": "dfe7565"},
+    {"finding_id": "F1-implement-rereview-coverage", "decision": "applied", "commit": "dfe7565"},
+    {"finding_id": "F2-implement-firstrun-coverage", "decision": "applied", "commit": "dfe7565"},
+    {"finding_id": "F3-outcome1-inmemory-downgrade", "decision": "applied", "commit": "dfe7565"},
+    {"finding_id": "F4-checklist-tripwire-cost", "decision": "applied", "commit": "dfe7565"},
+    {"finding_id": "F5-implement-norecognizable-verdict", "decision": "applied", "commit": "dfe7565"},
+    {"finding_id": "F6-awusf-double-render", "decision": "applied", "commit": "dfe7565"},
+    {"finding_id": "F7-retry-budget-persistence", "decision": "applied", "commit": "dfe7565"},
+    {"finding_id": "F-docs-5758-id", "decision": "applied", "commit": "dfe7565"},
+    {"finding_id": "F-docs-magic7", "decision": "applied", "commit": "dfe7565"},
+    {"finding_id": "F-phase3dispatched-example-note", "decision": "applied", "commit": "dfe7565"}
+  ],
+  "convergence_inputs": {
+    "fixes_applied": 11,
+    "fix_diff_lines": 22,
+    "new_corroborated_critical_count": 0
+  },
+  "cap_drops": {"count": 0, "by_category": {}},
+  "telemetry": {
+    "phase_0":   {"calls": 0, "wall_clock_s": 6},
+    "phase_0_5": {"calls": 0, "wall_clock_s": 1},
+    "phase_1":   {"calls": 1, "tokens": 99657, "wall_clock_s": 105},
+    "phase_2":   {"calls": 14, "tokens": 408000, "wall_clock_s": 50},
+    "phase_3":   {"calls": 4, "tokens": 302000, "wall_clock_s": 133},
+    "step_2_5":  {"calls": 0, "wall_clock_s": 2, "webfetches": 0},
+    "phase_4_x": {"calls": 0, "wall_clock_s": 3}
+  }
+}

--- a/.devflow/logs/review/pr-62/local-20260527T115350Z-1/iter-2.json
+++ b/.devflow/logs/review/pr-62/local-20260527T115350Z-1/iter-2.json
@@ -1,0 +1,48 @@
+{
+  "iter": 2,
+  "started_at": "2026-05-27T12:30:00Z",
+  "fix_commit_sha": "b0f6f8d",
+  "fix_files": ["skills/implement/SKILL.md", "skills/review-and-fix/SKILL.md"],
+  "diff_profile": {
+    "small_diff": false,
+    "config_only": true,
+    "has_new_types": false,
+    "engine_self_modifying": true,
+    "checklist_skipped": null
+  },
+  "checklist": [
+    {"id": "VC2-1", "verification_mode": "lite", "verdict": "PASS", "claim_signature": "api_contract:implement.md:shadow-status-string-source-location", "reused_from_iter_prev": false, "evidence": "post-fix: implement now points at the verdict headline {shadow status} token, not 'from the report'"},
+    {"id": "VC2-2", "verification_mode": "lite", "verdict": "PASS", "claim_signature": "api_contract:implement.md:rereview-clear-string-reachable", "reused_from_iter_prev": false},
+    {"id": "VC2-3", "verification_mode": "lite", "verdict": "PASS", "claim_signature": "data_format_assumption:CHANGELOG.md:approve-family-triple-matches-implement", "reused_from_iter_prev": false},
+    {"id": "VC2-9", "verification_mode": "lite", "verdict": "PASS", "claim_signature": "data_format_assumption:CHANGELOG.md:243-issue-refs-consistency", "reused_from_iter_prev": false},
+    {"id": "VC2-8", "verification_mode": "lite", "verdict": "PASS", "claim_signature": "api_contract:review-and-fix.md:checklist-skipped-field-path-nesting", "reused_from_iter_prev": false, "evidence": "post-fix: nesting made explicit at line 191"}
+  ],
+  "phase3_dispatched": [
+    "pr-review-toolkit:code-reviewer",
+    "pr-review-toolkit:silent-failure-hunter",
+    "pr-review-toolkit:comment-analyzer",
+    "superpowers:requesting-code-review"
+  ],
+  "phase3_findings": [
+    {"agent": "pr-review-toolkit:silent-failure-hunter", "severity": "Important", "description": "VARIANCE-RECOVERED: implement reads shadow-coverage status 'from the report' but the literals shadow agreed,full coverage / shadow agreement not verified live only in the verdict headline {shadow status}, not the report Coverage section — fix-induced by iter-1's F1/F2 edit", "defect_signature": {"file": "skills/implement/SKILL.md", "line_range": [565, 568], "kind": "api_misuse"}, "corroboration_count": 2, "step25_classification": "codebase", "fix_decision": "applied"},
+    {"agent": "pr-review-toolkit:comment-analyzer", "severity": "Suggestion", "description": "diff_profile.checklist_skipped dotted path vs sibling-reading schema prose (example JSON authoritative/nested)", "defect_signature": {"file": "skills/review-and-fix/SKILL.md", "line_range": [191, 191], "kind": "comment_drift"}, "corroboration_count": 2, "step25_classification": "codebase", "fix_decision": "applied"}
+  ],
+  "fix_decisions": [
+    {"finding_id": "F-iter2-string-source", "decision": "applied", "commit": "b0f6f8d"},
+    {"finding_id": "F-iter2-checklist-skipped-nesting", "decision": "applied", "commit": "b0f6f8d"}
+  ],
+  "convergence_inputs": {
+    "fixes_applied": 2,
+    "fix_diff_lines": 6,
+    "new_corroborated_critical_count": 0,
+    "new_corroborated_important_count": 1
+  },
+  "cap_drops": {"count": 0, "by_category": {}},
+  "telemetry": {
+    "phase_1":   {"calls": 1, "tokens": 68717, "wall_clock_s": 106},
+    "phase_2":   {"calls": 0, "wall_clock_s": 3, "note": "variance items lite-verified post-fix by orchestrator; no verifier subagents dispatched"},
+    "phase_3":   {"calls": 4, "tokens": 376000, "wall_clock_s": 134},
+    "step_2_5":  {"calls": 0, "wall_clock_s": 2, "webfetches": 0},
+    "phase_4_x": {"calls": 0, "wall_clock_s": 2}
+  }
+}

--- a/.devflow/logs/review/pr-62/local-20260527T115350Z-1/iter-3.json
+++ b/.devflow/logs/review/pr-62/local-20260527T115350Z-1/iter-3.json
@@ -1,0 +1,175 @@
+{
+ "iter": 3,
+ "started_at": "2026-05-27T13:00:00Z",
+ "fix_commit_sha": "96d76287a8347110c7c068c461eaf322ee54e7e4",
+ "fix_files": [
+  "skills/implement/SKILL.md"
+ ],
+ "diff_profile": {
+  "small_diff": false,
+  "config_only": true,
+  "has_new_types": false,
+  "engine_self_modifying": true,
+  "checklist_skipped": null
+ },
+ "checklist": [],
+ "phase3_dispatched": [
+  "pr-review-toolkit:code-reviewer",
+  "pr-review-toolkit:silent-failure-hunter",
+  "pr-review-toolkit:comment-analyzer",
+  "superpowers:requesting-code-review"
+ ],
+ "phase3_findings": [
+  {
+   "agent": "pr-review-toolkit:silent-failure-hunter",
+   "severity": "Important",
+   "description": "implement verdict-string routing surface is unpinned (verdict literal not in headline); coverage token could be mis-harvested from AWUSF fallback headline if read before bucketing",
+   "defect_signature": {
+    "file": "skills/implement/SKILL.md",
+    "line_range": [
+     558,
+     573
+    ],
+    "kind": "logic_error"
+   },
+   "corroboration_count": 1,
+   "step25_classification": "codebase",
+   "fix_decision": "applied"
+  },
+  {
+   "agent": "pr-review-toolkit:silent-failure-hunter",
+   "severity": "Suggestion",
+   "description": "Broader: re-architect routing as a positive-anchored sole test on the headline token",
+   "defect_signature": {
+    "file": "skills/implement/SKILL.md",
+    "line_range": [
+     568,
+     568
+    ],
+    "kind": "logic_error"
+   },
+   "corroboration_count": 1,
+   "step25_classification": "codebase",
+   "fix_decision": "pushed_back"
+  },
+  {
+   "agent": "superpowers:requesting-code-review",
+   "severity": "Suggestion",
+   "description": "S1 doc-clarity: the earlier-not-verified scan-exclusion rationale only spelled out for the AWUSF case; applies to ordinary outcome-3 too (behavior already correct)",
+   "defect_signature": {
+    "file": "skills/review-and-fix/SKILL.md",
+    "line_range": [
+     609,
+     609
+    ],
+    "kind": "comment_drift"
+   },
+   "corroboration_count": 1,
+   "step25_classification": "codebase",
+   "fix_decision": "deferred"
+  }
+ ],
+ "fix_decisions": [
+  {
+   "finding_id": "F-iter3-verdict-source-pin",
+   "decision": "applied",
+   "commit": "96d76287a8347110c7c068c461eaf322ee54e7e4"
+  },
+  {
+   "finding_id": "F-iter3-rearchitect-routing",
+   "decision": "pushed_back",
+   "source_file": "skills/implement/SKILL.md",
+   "claim_text": "re-architect implement routing as a positive-anchored sole test",
+   "skip_category": "out-of-scope",
+   "evidence": "verdict-string routing branches predate PR #62; this PR did not change the parsing surface, only which verdicts route where. The fail direction is already closed (unrecognized exit -> Blocked). Single-source (1/4 agents; the other 3 converged)."
+  },
+  {
+   "finding_id": "F-iter3-S1-scan-doc-clarity",
+   "decision": "deferred",
+   "source_file": "skills/review-and-fix/SKILL.md",
+   "claim_text": "spell out the scan-exclusion rationale for the ordinary outcome-3 case too",
+   "skip_category": "uncategorized",
+   "evidence": "behavior already correct; pure doc-clarity nit, not worth another fix-loop iteration"
+  }
+ ],
+ "convergence_inputs": {
+  "fixes_applied": 1,
+  "fix_diff_lines": 3,
+  "new_corroborated_critical_count": 0,
+  "new_corroborated_important_count": 0
+ },
+ "cap_drops": {
+  "count": 0,
+  "by_category": {}
+ },
+ "telemetry": {
+  "phase_1": {
+   "calls": 1,
+   "tokens": 35663,
+   "wall_clock_s": 33
+  },
+  "phase_2": {
+   "calls": 0,
+   "wall_clock_s": 1,
+   "note": "variance generator returned [] \u2014 no new items to verify"
+  },
+  "phase_3": {
+   "calls": 4,
+   "tokens": 231000,
+   "wall_clock_s": 123
+  },
+  "step_2_5": {
+   "calls": 0,
+   "wall_clock_s": 2,
+   "webfetches": 0
+  },
+  "phase_4_x": {
+   "calls": 0,
+   "wall_clock_s": 2
+  }
+ },
+ "shadow": {
+  "ran_at": "2026-05-27T13:20:00Z",
+  "verdict": "REJECT-equivalent (new corroborated Important)",
+  "coverage": "full",
+  "reviewers_dispatched": [
+   "pr-review-toolkit:code-reviewer",
+   "pr-review-toolkit:silent-failure-hunter",
+   "pr-review-toolkit:comment-analyzer",
+   "superpowers:requesting-code-review"
+  ],
+  "expected_reviewers": [
+   "pr-review-toolkit:code-reviewer",
+   "pr-review-toolkit:silent-failure-hunter",
+   "pr-review-toolkit:comment-analyzer",
+   "superpowers:requesting-code-review"
+  ],
+  "reason": null,
+  "checklist_skipped": null,
+  "phase3_findings": [
+   {
+    "agent": "all-4-shadow-reviewers",
+    "severity": "Important",
+    "description": "iter-3 fix re-opened AWUSF fail-open: implement told to bucket verdict from engine ## Verdict: line, which cannot express APPROVE WITH UNRESOLVED SHADOW FINDINGS (loop-level, headline-only) -> AWUSF run mis-read as clean approve",
+    "defect_signature": {
+     "file": "skills/implement/SKILL.md",
+     "line_range": [
+      565,
+      565
+     ],
+     "kind": "logic_error"
+    },
+    "corroboration_count": 4
+   }
+  ],
+  "phase2_fails": [],
+  "comparison": {
+   "shadow_total": 1,
+   "overlap_with_iter_N": 0,
+   "new": 1,
+   "new_critical": 0,
+   "new_important": 1
+  },
+  "promoted_to_iter_next": true
+ }
+}

--- a/.devflow/logs/review/pr-85/local-20260602T192902Z-1/iter-1.json
+++ b/.devflow/logs/review/pr-85/local-20260602T192902Z-1/iter-1.json
@@ -1,0 +1,22 @@
+{
+  "iter": 1,
+  "source": "review-and-fix",
+  "started_at": "2026-06-02T19:29:02Z",
+  "fix_commit_sha": null,
+  "fix_files": [],
+  "diff_profile": {"small_diff": false, "config_only": false, "has_new_types": false, "engine_self_modifying": true, "checklist_skipped": null},
+  "phase3_dispatched": ["pr-review-toolkit:code-reviewer","pr-review-toolkit:silent-failure-hunter","pr-review-toolkit:comment-analyzer","pr-review-toolkit:pr-test-analyzer","superpowers:requesting-code-review"],
+  "checklist_summary": {"total": 46, "lite": 19, "agent": 27, "pass": 46, "fail": 0, "inconclusive": 0},
+  "phase3_findings": [
+    {"agent":"pr-review-toolkit:comment-analyzer","severity":"Suggestion","description":"Header/CHANGELOG say 'plain POSIX-portable shell' but the script is portable bash (uses set -o pipefail, a bashism), not strict POSIX sh","defect_signature":{"file":"scripts/load-prompt-extension.sh","line_range":[33,33],"kind":"comment_drift"},"corroboration_count":1,"fix_decision":"advisory"},
+    {"agent":"superpowers:requesting-code-review","severity":"Suggestion","description":"review-and-fix post-shadow edit gate + mutation-check prose ships with no drift-guard test, unlike comparable locked verdict-gate contracts in the repo","defect_signature":{"file":"lib/test/run.sh","line_range":[744,960],"kind":"test_gap"},"corroboration_count":1,"fix_decision":"advisory"},
+    {"agent":"superpowers:requesting-code-review","severity":"Suggestion","description":"Clean-delta-review branch sets reviewed_sha=HEAD but does not touch coverage; Coverage section then renders 'full reviewer coverage' though the shipped commit was vetted only by a bounded delta-review","defect_signature":{"file":"skills/review-and-fix/SKILL.md","line_range":[616,620],"kind":"comment_drift"},"corroboration_count":1,"fix_decision":"advisory"},
+    {"agent":"pr-review-toolkit:silent-failure-hunter","severity":"Suggestion","description":"SKILL.md prose says 'surface its stderr' but the documented bare invocation has no explicit stderr capture; relies on harness surfacing tool stderr","defect_signature":{"file":"skills/create-issue/SKILL.md","line_range":[529,529],"kind":"api_misuse"},"corroboration_count":1,"fix_decision":"advisory"},
+    {"agent":"pr-review-toolkit:silent-failure-hunter","severity":"Suggestion","description":"Name guard accepts dot-only/control-char names (., newline) that resolve in-dir and silently no-op; harmless (name-confined) but an unpinned validation edge","defect_signature":{"file":"scripts/load-prompt-extension.sh","line_range":[57,62],"kind":"logic_error"},"corroboration_count":2,"fix_decision":"advisory"},
+    {"agent":"pr-review-toolkit:pr-test-analyzer","severity":"Suggestion","description":"FIFO/device + symlink-to-device non-regular shapes are advertised in the helper header but not exercised by tests (directory/symlink-to-dir variants are)","defect_signature":{"file":"lib/test/run.sh","line_range":[256,276],"kind":"test_gap"},"corroboration_count":1,"fix_decision":"advisory"}
+  ],
+  "fix_decisions": [],
+  "convergence_inputs": {"fixes_applied": 0, "fix_diff_lines": 0, "new_corroborated_critical_count": 0},
+  "cap_drops": {"count": 0, "by_category": {}},
+  "reviewed_sha": null
+}

--- a/.github/workflows/devflow-implement.yml
+++ b/.github/workflows/devflow-implement.yml
@@ -490,3 +490,19 @@ jobs:
             Bash(mv:*),
             Bash(cp:*),
             Bash(tee:*)${{ needs.config.outputs.allowed_tools_extra }}"
+
+      - name: Persist review-and-fix observability artifacts (backstop)
+        if: ${{ always() }}
+        run: |
+          set +e
+          HELPER=.devflow/vendor/devflow/lib/efficiency-trace.sh
+          [ -f "$HELPER" ] || { echo "::warning::observability backstop: $HELPER missing; skipped"; exit 0; }
+          git config user.name "github-actions[bot]" 2>/dev/null || true
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com" 2>/dev/null || true
+          before=$(git rev-parse HEAD 2>/dev/null)
+          bash "$HELPER" --persist
+          after=$(git rev-parse HEAD 2>/dev/null)
+          if [ -n "$after" ] && [ "$before" != "$after" ]; then
+            git push || echo "::warning::observability backstop: push of persisted artifacts failed; commit is local-only"
+          fi
+          exit 0

--- a/.github/workflows/devflow.yml
+++ b/.github/workflows/devflow.yml
@@ -482,3 +482,19 @@ jobs:
             Bash(mv:*),
             Bash(cp:*),
             Bash(tee:*)${{ needs.config.outputs.allowed_tools_extra }}"
+
+      - name: Persist review-and-fix observability artifacts (backstop)
+        if: ${{ always() }}
+        run: |
+          set +e
+          HELPER=.devflow/vendor/devflow/lib/efficiency-trace.sh
+          [ -f "$HELPER" ] || { echo "::warning::observability backstop: $HELPER missing; skipped"; exit 0; }
+          git config user.name "github-actions[bot]" 2>/dev/null || true
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com" 2>/dev/null || true
+          before=$(git rev-parse HEAD 2>/dev/null)
+          bash "$HELPER" --persist
+          after=$(git rev-parse HEAD 2>/dev/null)
+          if [ -n "$after" ] && [ "$before" != "$after" ]; then
+            git push || echo "::warning::observability backstop: push of persisted artifacts failed; commit is local-only"
+          fi
+          exit 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DevFlow are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project aims
 to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.8.2] — 2026-06-03
+
+### Added
+- **The issue #80 review-and-fix observability backstop now runs automatically — the privileged wiring deferred from #101 is committed.** PR #101 shipped the portable core (`lib/efficiency-trace.sh --persist`, `--self-check`, tests, docs) but left two entry points that invoke `--persist` uncommitted, because a GitHub App token cannot push `.github/workflows/` and an agent cannot write `.claude/` — so nothing called the backstop automatically. Both are now in place, copied verbatim from `docs/efficiency-trace.md`: a local-tier `Stop` hook in `.claude/settings.json` that runs `bash lib/efficiency-trace.sh --persist || true` after the turn (best-effort, never blocks), and an unconditional `Persist review-and-fix observability artifacts (backstop)` step (`if: ${{ always() }}`, best-effort, pushes only when a recovery commit was created) appended after `Run Claude Code` in the cloud writable workflows `.github/workflows/devflow.yml` (the `command` job) and `.github/workflows/devflow-implement.yml`. `devflow-runner.yml` is intentionally excluded (read-only `review` profile, no fix loop, nothing to persist). The cloud guarantee rides solely on the workflow steps — `claude-code-action` wipes and restores `.claude/` from the base branch, so the local hook never runs in cloud. (#108)
 ## [2.8.1] — 2026-06-03
 
 ### Fixed

--- a/docs/efficiency-trace.md
+++ b/docs/efficiency-trace.md
@@ -260,9 +260,9 @@ interactive-drop failure mode so a future orchestrator does not silently skip th
 
   > **Note on this repo's `.claude/settings.json`.** Writing `.claude/` is a privileged,
   > self-modifying action that an agent is structurally barred from (it is the harness boundary that
-  > stops an agent rewriting its own hooks/permissions), so the file itself is committed by a
-  > maintainer, not by `/devflow:implement`. The `--persist` mode it calls, the cloud-tier guarantee,
-  > and this documentation all ship in the same change; only the local hook file is the human step.
+  > stops an agent rewriting its own hooks/permissions), so this hook file was committed by a
+  > maintainer, not by `/devflow:implement`. It now ships committed in this repo (`.claude/settings.json`);
+  > the `--persist` mode it calls and the cloud-tier guarantee land in the same wiring.
 - *Cloud-tier wrapper.* **`Stop` hooks are local-only**: `claude-code-action` `rm -rf`s and restores
   `.claude/` from the **base** branch before installing plugins, so a PR branch's `.claude/` hook is
   discarded for that PR's own cloud run, and the cloud guarantee must **never** depend on the hook.
@@ -272,8 +272,9 @@ interactive-drop failure mode so a future orchestrator does not silently skip th
   unconditionally (`if: always()`, best-effort) in a workflow step **after** `Run Claude Code`,
   pushing only if a recovery commit was created. (`devflow-runner.yml` is the read-only `review`
   profile — it runs no fix loop and cannot write the tree, so it is intentionally **excluded**: there
-  is nothing to persist there.) The step to add after `Run Claude Code` in each of those two
-  workflows (a GitHub App token cannot self-modify `.github/workflows/`, so a maintainer commits this):
+  is nothing to persist there.) Because a GitHub App token cannot self-modify `.github/workflows/`,
+  a maintainer committed this step after `Run Claude Code` in each of those two workflows; it now
+  ships committed in both:
 
   ```yaml
   - name: Persist review-and-fix observability artifacts (backstop)


### PR DESCRIPTION
<!-- PR_BODY_START -->
## Summary
- Commits the two privileged entry points that invoke the `lib/efficiency-trace.sh --persist` observability backstop, deferred from #80/#101 because an agent cannot write `.claude/` and a GitHub App token cannot push `.github/workflows/`.
- Without this wiring the `--persist` backstop shipped in #101 was fully tested but never invoked automatically — this closes that gap on both the local and cloud tiers.

## Changes
**Local tier**: Adds `.claude/settings.json` with a `Stop` hook running `bash lib/efficiency-trace.sh --persist || true` after each turn (best-effort, never blocks the session).
**Cloud tier**: Appends an identical `Persist review-and-fix observability artifacts (backstop)` step (`if: ${{ always() }}`, best-effort, pushes only when a recovery commit was created) after `Run Claude Code` in `.github/workflows/devflow.yml` (command job) and `.github/workflows/devflow-implement.yml`. `devflow-runner.yml` is intentionally excluded (read-only `review` profile — no fix loop, nothing to persist).
**Docs**: Updates `docs/efficiency-trace.md` so its "to be committed by a maintainer" framing reflects that these artifacts now ship committed. Both artifacts were copied verbatim from that doc.
**Versioning**: Bumps `.claude-plugin/plugin.json` 2.8.1 → 2.8.2 (patch) with a matching `CHANGELOG.md` entry.

## Resolves
Resolves #102

## Test Plan
- [ ] `bash lib/test/run.sh` passes (1106/0 at time of writing)
- [ ] Both workflows parse as valid YAML; `.claude/settings.json` is valid JSON
- [ ] Confirm the backstop step is present in `devflow.yml` + `devflow-implement.yml` and absent from `devflow-runner.yml`
- [ ] On the first real cloud `review-and-fix` recovery commit, confirm the `--persist` step actually pushes (the one path not exercised by the gh-stubbed suite)

## Visual Changes
N/A

## Breaking Changes
None

<!-- PR_BODY_END -->