### PR TITLE
Add `implement_pr_state` config setting to control whether /devflow:implement publishes the PR or leaves it a draft

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devflow",
-  "version": "2.8.3",
+  "version": "2.8.4",
   "description": "Make agentic coding work on real codebases: DevFlow takes a one-line request to a complete, tested, reviewed, documented PR that's ready for your final review, and improves itself weekly. Includes /devflow:implement (4-phase orchestrator), /devflow:review and /devflow:review-and-fix (a verification-checklist review engine that audits its own approval), the /devflow:docs suite, /devflow:create-issue, plus the self-improving retrospective loop (/devflow:retrospective per-PR + /devflow:retrospective-audit weekly).",
   "author": {
     "name": "Daniel Radman",

--- a/.devflow/config.example.json
+++ b/.devflow/config.example.json
@@ -12,6 +12,7 @@
   },
   "devflow_implement": {
     "effort": "high",
+    "implement_pr_state": "ready_for_review",
     "allowed_tools": []
   },
   "devflow_runner": {

--- a/.devflow/config.json
+++ b/.devflow/config.json
@@ -39,7 +39,7 @@
     "enabled": true,
     "retrospective_model": "claude-opus-4-8",
     "audit_model": "claude-opus-4-8",
-    "implementation_branch_prefix": "claude/",
+    "implementation_branch_prefix": "",
     "min_occurrences": 2,
     "cooldown_days": 3,
     "max_prs_per_run": 500

--- a/.devflow/config.json
+++ b/.devflow/config.json
@@ -39,7 +39,7 @@
     "enabled": true,
     "retrospective_model": "claude-opus-4-8",
     "audit_model": "claude-opus-4-8",
-    "implementation_branch_prefix": "",
+    "implementation_branch_prefix": "claude/",
     "min_occurrences": 2,
     "cooldown_days": 3,
     "max_prs_per_run": 500

--- a/.devflow/config.json
+++ b/.devflow/config.json
@@ -11,6 +11,7 @@
   },
   "devflow_implement": {
     "effort": "high",
+    "implement_pr_state": "ready_for_review",
     "allowed_tools": []
   },
   "devflow_runner": {

--- a/.devflow/config.schema.json
+++ b/.devflow/config.schema.json
@@ -62,6 +62,12 @@
       "type": "object",
       "properties": {
         "effort": { "type": "string", "enum": ["low", "medium", "high", "xhigh", "max"] },
+        "implement_pr_state": {
+          "type": "string",
+          "enum": ["ready_for_review", "draft"],
+          "description": "Final state of the PR a /devflow:implement run produces. 'ready_for_review' (the default) publishes the PR in Phase 4.3 (runs `gh pr ready`), exactly as before — and so triggers the cloud review (devflow-review.yml's ready_for_review event) and CI's ready_for_review listener. 'draft' leaves the PR as the draft created in Phase 3.1: the run still finalizes the workpad with Status: Complete and emits the outcome reaction, but does NOT publish, so a human publishes it on their own cadence and the cloud review + CI ready_for_review listener do not auto-fire until then. Any other value (missing key, empty string, or an unrecognized string) resolves to 'ready_for_review' — default-to-publish is the safe direction.",
+          "default": "ready_for_review"
+        },
         "allowed_tools": {
           "type": "array",
           "items": { "type": "string" },

--- a/.devflow/config.schema.json
+++ b/.devflow/config.schema.json
@@ -65,7 +65,7 @@
         "implement_pr_state": {
           "type": "string",
           "enum": ["ready_for_review", "draft"],
-          "description": "Final state of the PR a /devflow:implement run produces. 'ready_for_review' (the default) publishes the PR in Phase 4.3 (runs `gh pr ready`), exactly as before — and so triggers the cloud review (devflow-review.yml's ready_for_review event) and CI's ready_for_review listener. 'draft' leaves the PR as the draft created in Phase 3.1: the run still finalizes the workpad with Status: Complete and emits the outcome reaction, but does NOT publish, so a human publishes it on their own cadence and the cloud review + CI ready_for_review listener do not auto-fire until then. Any other value (missing key, empty string, or an unrecognized string) resolves to 'ready_for_review' — default-to-publish is the safe direction.",
+          "description": "Final state of the PR a /devflow:implement run produces. 'ready_for_review' (the default) publishes the PR in Phase 4.3 via `gh pr ready`, exactly as before. 'draft' leaves it the draft created in Phase 3.1 (the run still finalizes with Status: Complete and the outcome reaction, but does not publish, so the cloud review and CI ready_for_review listener do not auto-fire until a human publishes). Any other value — missing key, empty string, or an unrecognized string — resolves to 'ready_for_review'; default-to-publish is the safe direction. See docs/implement-skill.md for the full Phase 4.3 behavior.",
           "default": "ready_for_review"
         },
         "allowed_tools": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to DevFlow are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project aims
 to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.8.4] — 2026-06-23
+
+### Added
+- **`devflow_implement.implement_pr_state` config setting controls whether `/devflow:implement` publishes its PR or leaves it a draft.** A string under `devflow_implement` (`enum: ["ready_for_review", "draft"]`, `default: "ready_for_review"`): the default publishes the PR in Phase 4.3 (`gh pr ready`) exactly as before, while `draft` leaves the PR as the draft created in Phase 3.1 — the run still finalizes the workpad with `Status: Complete` (🎉) and emits the outcome reaction, but does not publish and posts no extra PR-thread comment, so the cloud review (`devflow-review.yml`'s `ready_for_review` event) and CI's `ready_for_review` listener do not auto-fire until a human publishes. Any other value (missing key, empty string, or an unrecognized string) resolves to `ready_for_review` — default-to-publish is the safe direction. The gate lives once in the shared `skills/implement/SKILL.md` Phase 4.3 (no workflow fork); the Phase 4.3 clean-tree backstop runs in both cases. Documented in `docs/implement-skill.md`. (#117, closes #116)
+
 ## [2.8.3] — 2026-06-03
 
 Consolidated patch bump for the 2026-W23 weekly-retrospective intervention batch (one bump covers the whole set).

--- a/docs/DEVFLOW_SYSTEM_OVERVIEW.md
+++ b/docs/DEVFLOW_SYSTEM_OVERVIEW.md
@@ -249,7 +249,7 @@ DevFlow maintains **exactly one** marker-tagged comment on the GitHub issue for 
 - **4.0.5** Merge all run-scoped deferral manifests into one slug-level aggregate, then file **one follow-up issue per source file** (via `scripts/file-deferrals.py`) for review findings deliberately deferred during the fix loop.
 - **4.1** Update internal + external docs + release notes (via the `/devflow:docs` subagent); commit (`docs:`); apply configured labels (default `Documented`).
 - **4.2** Generate the PR description (`/devflow:pr-description`).
-- **4.3** Mark the PR **ready** (`gh pr ready`); set status `Complete`; emit the 🎉 reaction.
+- **4.3** Publish the PR (`gh pr ready`) — unless `devflow_implement.implement_pr_state` is `draft`, which leaves it the Phase 3.1 draft for a human to publish; set status `Complete`; emit the 🎉 reaction (both cases).
 
 ---
 

--- a/docs/implement-skill.md
+++ b/docs/implement-skill.md
@@ -1,4 +1,4 @@
-# `/devflow:implement` skill — Phase 2.3 sweep discipline
+# `/devflow:implement` skill — Phase 2.3 sweep discipline and Phase 4.3 finalize
 
 **Skill:** `skills/implement/SKILL.md` (Phase 2.3, *Implement*)
 
@@ -71,6 +71,28 @@ wrong assumption — so a green run is not confirmation, and a test assertion *a
 itself an unverified claim. A boundary that genuinely cannot be verified in-environment is never
 asserted as true: it is recorded with a `--reflection` note and, only when a specific acceptance
 criterion's verification depends on it, retagged `(post-merge)`.
+
+## Phase 4.3 finalize: publish vs. draft (`implement_pr_state`)
+
+Phase 4.3 (*Finalize the PR and Finalize Workpad*) is where a run ends. It runs three things in order:
+
+1. **Clean-tree backstop (unconditional).** `git status --porcelain` must be empty before finalizing. The run started from a clean base-branch checkout, so anything dirty here is this run's own work an earlier phase failed to commit — it is committed with the right prefix and the under-committing phase is recorded in `Devflow Reflection`, never papered over. This runs in *both* the publish and draft cases; it is independent of the publish decision.
+2. **Publish decision.** By default the run publishes the draft PR created in Phase 3.1 by running `gh pr ready`.
+3. **Workpad finalization.** `Status` flips to `Complete` (🎉), the final `## Progress` item is ticked, and the 🎉 outcome reaction is emitted on the triggering comment — in both cases.
+
+The publish step is gated by a per-consumer config key, **`devflow_implement.implement_pr_state`** (string, read via `config-get.sh .devflow_implement.implement_pr_state ready_for_review`):
+
+| Value | Phase 4.3 behavior |
+|---|---|
+| `ready_for_review` (default) | Runs `gh pr ready` — the PR is published, exactly as before. |
+| `draft` | Skips `gh pr ready` — the PR is left as the Phase 3.1 draft. No extra comment is posted to the PR thread. The workpad `--note` wording states the PR was *left as a draft* rather than marked ready. |
+| missing / empty / any other value | Resolves to `ready_for_review` (publish). |
+
+**Default-to-publish is the safe direction**: only the exact literal `draft` suppresses publishing, so a typo'd or future value can never accidentally leave a PR unpublished, and a hard config read failure (malformed config) also falls back to publishing. Existing consumers and DevFlow's own runs — which do not set the key — are unaffected.
+
+**Downstream consequence of `draft`.** Publishing a PR is what fires the rest of the pipeline: the cloud review (`devflow-review.yml` triggers on the `ready_for_review` event) and CI's `ready_for_review` listener both key off the draft→ready transition. Choosing `draft` therefore *intentionally* suppresses those for that run until a human publishes the PR — this is the documented trade-off a consumer accepts, not a bug to be fixed. It lets maintainers of repos that adopt DevFlow keep bot-completed PRs out of the ready-for-review queue and publish them on their own cadence (after a manual look, on a release boundary, or to avoid auto-notifying reviewers).
+
+The gate lives once in `skills/implement/SKILL.md` Phase 4.3 — the skill body is shared by the local and cloud `/devflow:implement` paths, and both read the same `config.json` via `config-get.sh`, so no workflow change is needed and the logic is never forked.
 
 ## Scope boundary between Phase 2.3.2 and Phase 4.1
 

--- a/lib/test/run.sh
+++ b/lib/test/run.sh
@@ -514,6 +514,41 @@ printf '%s' '{bad json' > "$IPS_E2E"
 assert_eq "implement_pr_state e2e: malformed config (resolver hard-fail) → publish" "publish" "$(ips_state_decision "$IPS_E2E")"
 rm -f "$IPS_E2E"
 
+# Three-way outcome guard. The SKILL's gate is NOT two-way (draft/publish): the publish
+# arm splits on `gh pr ready`'s exit into `published` vs `publish_failed`, and the
+# publish_failed capture (the workpad never falsely claims a PR was published on a
+# `gh pr ready` failure) is the headline correctness property of this change. Mirror the
+# full elif chain so a refactor that dropped the `else` arm (reverting to a bare
+# failure-swallowing `gh pr ready`) is caught here. $1 = PR_STATE, $2 = simulated
+# `gh pr ready` exit (0 ok / non-0 failure).
+ips_outcome() {
+  [ "$1" = "draft" ] && { printf 'draft\n'; return; }
+  if [ "${2:-0}" -eq 0 ]; then printf 'published\n'; else printf 'publish_failed\n'; fi
+}
+assert_eq "implement_pr_state outcome: draft → draft (no gh pr ready)"             "draft"          "$(ips_outcome draft 0)"
+assert_eq "implement_pr_state outcome: publish + gh pr ready ok → published"       "published"      "$(ips_outcome ready_for_review 0)"
+assert_eq "implement_pr_state outcome: publish + gh pr ready fails → publish_failed" "publish_failed" "$(ips_outcome ready_for_review 1)"
+
+# Token pins for the publish_failed failure-capture branch and the outcome-specific
+# finalize wording — the prior pass pinned only the draft note (`left as draft`), leaving
+# the load-bearing "never falsely claim published" path uncovered.
+assert_eq "implement_pr_state: SKILL captures the publish_failed outcome (gh pr ready failure not swallowed)" "yes" \
+  "$(grep -qF 'PR_OUTCOME=publish_failed' "$IMPL_SKILL" && echo yes || echo no)"
+assert_eq "implement_pr_state: SKILL leaves a gh-pr-ready failure breadcrumb" "yes" \
+  "$(grep -qF 'gh pr ready FAILED' "$IMPL_SKILL" && echo yes || echo no)"
+assert_eq "implement_pr_state: SKILL has a distinct published-outcome note" "yes" \
+  "$(grep -qF 'PR published (gh pr ready)' "$IMPL_SKILL" && echo yes || echo no)"
+assert_eq "implement_pr_state: draft case posts no extra PR-thread comment (AC7)" "yes" \
+  "$(grep -qF 'no additional comment' "$IMPL_SKILL" && echo yes || echo no)"
+
+# Positional check: the clean-tree backstop must run ABOVE the publish gate (the diff's
+# behavioral change is that it runs unconditionally in BOTH publish and draft cases), not
+# merely be present somewhere. Assert line ordering, not bare presence.
+IPS_BACKSTOP_LN=$(grep -nF 'git status --porcelain' "$IMPL_SKILL" | head -1 | cut -d: -f1)
+IPS_GATE_LN=$(grep -nF '[ "$PR_STATE" = "draft" ]' "$IMPL_SKILL" | head -1 | cut -d: -f1)
+assert_eq "implement_pr_state: clean-tree backstop precedes the publish gate (runs in both cases)" "yes" \
+  "$([ -n "$IPS_BACKSTOP_LN" ] && [ -n "$IPS_GATE_LN" ] && [ "$IPS_BACKSTOP_LN" -lt "$IPS_GATE_LN" ] && echo yes || echo no)"
+
 # ────────────────────────────────────────────────────────────────────────────
 echo "scaffold-config.sh"
 # ────────────────────────────────────────────────────────────────────────────

--- a/lib/test/run.sh
+++ b/lib/test/run.sh
@@ -552,6 +552,13 @@ assert_eq "implement_pr_state: SKILL keeps the idempotent already-non-draft re-c
   "$(grep -qF 'gh pr view --json isDraft' "$IMPL_SKILL" && echo yes || echo no)"
 assert_eq "implement_pr_state: SKILL labels the idempotent re-run breadcrumb" "yes" \
   "$(grep -qF 'idempotent re-run' "$IMPL_SKILL" && echo yes || echo no)"
+# Couple the fail-safe construct: the re-check must redirect stderr (empty-on-error) AND
+# compare against the literal `= "false"` — so an unconfirmed/errored re-check (empty
+# substitution) is `!= "false"` and falls through to publish_failed (the conservative
+# direction). Pinning the two together catches a silent fail-safe inversion (e.g. someone
+# rewriting it as `!= "true"`, under which an empty result would wrongly read as published).
+assert_eq "implement_pr_state: SKILL idempotent re-check is fail-safe (2>/dev/null coupled to = \"false\")" "yes" \
+  "$(grep -qF '2>/dev/null)" = "false" ]' "$IMPL_SKILL" && echo yes || echo no)"
 assert_eq "implement_pr_state: SKILL has a distinct published-outcome note" "yes" \
   "$(grep -qF 'PR published (gh pr ready)' "$IMPL_SKILL" && echo yes || echo no)"
 assert_eq "implement_pr_state: draft case posts no extra PR-thread comment (AC7)" "yes" \

--- a/lib/test/run.sh
+++ b/lib/test/run.sh
@@ -470,9 +470,10 @@ assert_eq "implement_pr_state: SKILL has draft-aware finalize wording" "yes" \
   "$(grep -qF 'left as draft' "$IMPL_SKILL" && echo yes || echo no)"
 
 # Executable publish-decision guard — mirrors the SKILL's single literal-`draft`
-# comparison so the dry-trace matrix {draft, ready_for_review, "", published, default}
-# is exercised as behavior, not just asserted as prose. Keep byte-aligned with the
-# SKILL's Phase 4.3 branch.
+# comparison so the dry-trace matrix {draft, ready_for_review, "", published} is
+# exercised as behavior, not just asserted as prose (the absent/default row is the
+# resolver matrix above feeding `ready_for_review` into this guard). Keep
+# byte-aligned with the SKILL's Phase 4.3 branch.
 ips_publishes() {
   [ "$1" = "draft" ] && { printf 'draft\n'; return; }
   printf 'publish\n'
@@ -481,7 +482,6 @@ assert_eq "implement_pr_state gate: 'draft' → leave draft"             "draft"
 assert_eq "implement_pr_state gate: 'ready_for_review' → publish"      "publish" "$(ips_publishes ready_for_review)"
 assert_eq "implement_pr_state gate: empty string → publish"           "publish" "$(ips_publishes '')"
 assert_eq "implement_pr_state gate: unrecognized 'published' → publish" "publish" "$(ips_publishes published)"
-assert_eq "implement_pr_state gate: default ready_for_review → publish" "publish" "$(ips_publishes ready_for_review)"
 
 # ────────────────────────────────────────────────────────────────────────────
 echo "scaffold-config.sh"

--- a/lib/test/run.sh
+++ b/lib/test/run.sh
@@ -408,6 +408,82 @@ assert_eq "base_branch guard: empty read (rc 0) → main"            "main"    "
 assert_eq "base_branch guard: hard-failure read (rc≠0, empty) → main" "main" "$(base_guard '' 2)"
 
 # ────────────────────────────────────────────────────────────────────────────
+echo "devflow_implement.implement_pr_state (schema + resolution + Phase 4.3 gate)"
+# ────────────────────────────────────────────────────────────────────────────
+# implement_pr_state gates whether /devflow:implement Phase 4.3 publishes the PR
+# (runs `gh pr ready`) or leaves it the draft created in Phase 3.1. The resolution
+# boundary is config-get.sh (a deterministic string), so it is unit-testable here;
+# the Phase 4.3 prose change (whether `gh pr ready` runs) is non-executable skill
+# instructions, pinned below by token + an executable publish-decision guard that
+# mirrors the SKILL's single literal-`draft` comparison. Default-to-publish is the
+# safe direction: only the exact literal `draft` suppresses publishing.
+IPS_SCHEMA="$LIB/../.devflow/config.schema.json"
+IPS_EXAMPLE="$LIB/../.devflow/config.example.json"
+IPS_PROP='.properties.devflow_implement.properties.implement_pr_state'
+assert_eq "implement_pr_state: schema type is string" "string" \
+  "$(jq -r "$IPS_PROP.type" "$IPS_SCHEMA")"
+assert_eq "implement_pr_state: schema enum is [ready_for_review, draft]" "ready_for_review,draft" \
+  "$(jq -r "$IPS_PROP.enum | join(\",\")" "$IPS_SCHEMA")"
+assert_eq "implement_pr_state: schema default is ready_for_review" "ready_for_review" \
+  "$(jq -r "$IPS_PROP.default" "$IPS_SCHEMA")"
+assert_eq "implement_pr_state: schema has a non-empty description" "yes" \
+  "$(jq -e "$IPS_PROP.description | type == \"string\" and (length > 0)" "$IPS_SCHEMA" >/dev/null && echo yes || echo no)"
+assert_eq "implement_pr_state: example value matches schema default" \
+  "$(jq -r "$IPS_PROP.default" "$IPS_SCHEMA")" \
+  "$(jq -r '.devflow_implement.implement_pr_state' "$IPS_EXAMPLE")"
+
+# Resolver-read behavior (the string the SKILL's Phase 4.3 reads). config-get maps an
+# absent key OR an empty-string value to the supplied default (ready_for_review); any
+# other value is returned verbatim and the SKILL treats non-`draft` as publish.
+IPS_CFG="$(mktemp)"
+printf '%s' '{"devflow_implement":{"implement_pr_state":"draft"}}' > "$IPS_CFG"
+assert_eq "implement_pr_state: configured 'draft' read back verbatim" "draft" \
+  "$("$CG" .devflow_implement.implement_pr_state ready_for_review "$IPS_CFG")"
+printf '%s' '{"devflow_implement":{"implement_pr_state":"ready_for_review"}}' > "$IPS_CFG"
+assert_eq "implement_pr_state: configured 'ready_for_review' read back verbatim" "ready_for_review" \
+  "$("$CG" .devflow_implement.implement_pr_state ready_for_review "$IPS_CFG")"
+printf '%s' '{"devflow_implement":{}}' > "$IPS_CFG"
+assert_eq "implement_pr_state: absent key → resolver default ready_for_review" "ready_for_review" \
+  "$("$CG" .devflow_implement.implement_pr_state ready_for_review "$IPS_CFG")"
+printf '%s' '{"devflow_implement":{"implement_pr_state":""}}' > "$IPS_CFG"
+assert_eq "implement_pr_state: empty-string value → resolver default ready_for_review" "ready_for_review" \
+  "$("$CG" .devflow_implement.implement_pr_state ready_for_review "$IPS_CFG")"
+printf '%s' '{"devflow_implement":{"implement_pr_state":"published"}}' > "$IPS_CFG"
+assert_eq "implement_pr_state: unrecognized value read back verbatim (SKILL treats as publish)" "published" \
+  "$("$CG" .devflow_implement.implement_pr_state ready_for_review "$IPS_CFG")"
+assert_eq "implement_pr_state: missing config file → resolver default ready_for_review" "ready_for_review" \
+  "$("$CG" .devflow_implement.implement_pr_state ready_for_review /no/such/config.json)"
+rm -f "$IPS_CFG"
+
+# SKILL Phase 4.3 token pins: the gate is one piece of load-bearing inline bash in
+# implement/SKILL.md. Pin the tokens so a refactor that drops them fails here rather
+# than silently always-publishing (or always-drafting).
+assert_eq "implement_pr_state: SKILL reads via config-get with the ready_for_review default" "yes" \
+  "$(grep -qF 'config-get.sh .devflow_implement.implement_pr_state ready_for_review' "$IMPL_SKILL" && echo yes || echo no)"
+assert_eq "implement_pr_state: SKILL gates publish on the literal draft" "yes" \
+  "$(grep -qF '[ "$PR_STATE" = "draft" ]' "$IMPL_SKILL" && echo yes || echo no)"
+assert_eq "implement_pr_state: SKILL still runs gh pr ready (guarded, not removed)" "yes" \
+  "$(grep -qF 'gh pr ready' "$IMPL_SKILL" && echo yes || echo no)"
+assert_eq "implement_pr_state: SKILL keeps the clean-tree backstop above the gate" "yes" \
+  "$(grep -qF 'git status --porcelain' "$IMPL_SKILL" && echo yes || echo no)"
+assert_eq "implement_pr_state: SKILL has draft-aware finalize wording" "yes" \
+  "$(grep -qF 'left as draft' "$IMPL_SKILL" && echo yes || echo no)"
+
+# Executable publish-decision guard — mirrors the SKILL's single literal-`draft`
+# comparison so the dry-trace matrix {draft, ready_for_review, "", published, default}
+# is exercised as behavior, not just asserted as prose. Keep byte-aligned with the
+# SKILL's Phase 4.3 branch.
+ips_publishes() {
+  [ "$1" = "draft" ] && { printf 'draft\n'; return; }
+  printf 'publish\n'
+}
+assert_eq "implement_pr_state gate: 'draft' → leave draft"             "draft"   "$(ips_publishes draft)"
+assert_eq "implement_pr_state gate: 'ready_for_review' → publish"      "publish" "$(ips_publishes ready_for_review)"
+assert_eq "implement_pr_state gate: empty string → publish"           "publish" "$(ips_publishes '')"
+assert_eq "implement_pr_state gate: unrecognized 'published' → publish" "publish" "$(ips_publishes published)"
+assert_eq "implement_pr_state gate: default ready_for_review → publish" "publish" "$(ips_publishes ready_for_review)"
+
+# ────────────────────────────────────────────────────────────────────────────
 echo "scaffold-config.sh"
 # ────────────────────────────────────────────────────────────────────────────
 # Single shared scaffolder used by BOTH install.sh and the /devflow:init skill.

--- a/lib/test/run.sh
+++ b/lib/test/run.sh
@@ -453,6 +453,14 @@ assert_eq "implement_pr_state: unrecognized value read back verbatim (SKILL trea
   "$("$CG" .devflow_implement.implement_pr_state ready_for_review "$IPS_CFG")"
 assert_eq "implement_pr_state: missing config file → resolver default ready_for_review" "ready_for_review" \
   "$("$CG" .devflow_implement.implement_pr_state ready_for_review /no/such/config.json)"
+# Hard read failure (malformed JSON): config-get exits NON-zero with EMPTY stdout — the
+# exact contract the SKILL's `PR_STATE=$(…) || PR_STATE=ready_for_review` fallback leans
+# on. This is the headline safety property (default-to-publish on a corrupt config); pin
+# the resolver half here and the end-to-end half in the guard below.
+printf '%s' '{bad json' > "$IPS_CFG"
+IPS_OUT="$("$CG" .devflow_implement.implement_pr_state ready_for_review "$IPS_CFG" 2>/dev/null)"; IPS_RC=$?
+assert_eq "implement_pr_state: malformed config → resolver exits non-zero, empty stdout" "nonzero-empty" \
+  "$([ "$IPS_RC" -ne 0 ] && [ -z "$IPS_OUT" ] && echo nonzero-empty || echo "rc=$IPS_RC out='$IPS_OUT'")"
 rm -f "$IPS_CFG"
 
 # SKILL Phase 4.3 token pins: the gate is one piece of load-bearing inline bash in
@@ -462,18 +470,22 @@ assert_eq "implement_pr_state: SKILL reads via config-get with the ready_for_rev
   "$(grep -qF 'config-get.sh .devflow_implement.implement_pr_state ready_for_review' "$IMPL_SKILL" && echo yes || echo no)"
 assert_eq "implement_pr_state: SKILL gates publish on the literal draft" "yes" \
   "$(grep -qF '[ "$PR_STATE" = "draft" ]' "$IMPL_SKILL" && echo yes || echo no)"
-assert_eq "implement_pr_state: SKILL still runs gh pr ready (guarded, not removed)" "yes" \
-  "$(grep -qF 'gh pr ready' "$IMPL_SKILL" && echo yes || echo no)"
+# Pin the *command* form, not the bare token: a plain `grep -qF 'gh pr ready'` is also
+# satisfied by the draft-branch diagnostic echo and the explanatory prose, so it would
+# stay green even if the actual publish invocation were deleted. Pin the guarded
+# `elif gh pr ready; then` so this asserts the publish command itself survives.
+assert_eq "implement_pr_state: SKILL keeps the guarded publish invocation (elif gh pr ready)" "yes" \
+  "$(grep -qF 'elif gh pr ready; then' "$IMPL_SKILL" && echo yes || echo no)"
 assert_eq "implement_pr_state: SKILL keeps the clean-tree backstop above the gate" "yes" \
   "$(grep -qF 'git status --porcelain' "$IMPL_SKILL" && echo yes || echo no)"
 assert_eq "implement_pr_state: SKILL has draft-aware finalize wording" "yes" \
   "$(grep -qF 'left as draft' "$IMPL_SKILL" && echo yes || echo no)"
 
-# Executable publish-decision guard — mirrors the SKILL's single literal-`draft`
-# comparison so the dry-trace matrix {draft, ready_for_review, "", published} is
+# Executable publish-decision guard — logic-equivalent to the SKILL's single literal-`draft`
+# comparison (semantically mirrors `[ "$PR_STATE" = "draft" ]`; `$1` stands in for
+# `$PR_STATE`) so the dry-trace matrix {draft, ready_for_review, "", published} is
 # exercised as behavior, not just asserted as prose (the absent/default row is the
-# resolver matrix above feeding `ready_for_review` into this guard). Keep
-# byte-aligned with the SKILL's Phase 4.3 branch.
+# resolver matrix above feeding `ready_for_review` into this guard).
 ips_publishes() {
   [ "$1" = "draft" ] && { printf 'draft\n'; return; }
   printf 'publish\n'
@@ -482,6 +494,25 @@ assert_eq "implement_pr_state gate: 'draft' → leave draft"             "draft"
 assert_eq "implement_pr_state gate: 'ready_for_review' → publish"      "publish" "$(ips_publishes ready_for_review)"
 assert_eq "implement_pr_state gate: empty string → publish"           "publish" "$(ips_publishes '')"
 assert_eq "implement_pr_state gate: unrecognized 'published' → publish" "publish" "$(ips_publishes published)"
+
+# End-to-end read+guard, mirroring the SKILL's full Phase 4.3 line
+# `PR_STATE=$(config-get … ready_for_review) || PR_STATE=ready_for_review` then the
+# literal-`draft` decision. This exercises the load-bearing safety property — a hard
+# resolver failure (malformed config) falls back to PUBLISH — through the real resolver,
+# which the `ips_publishes` matrix alone does not cover.
+ips_state_decision() {
+  local st
+  st="$("$CG" .devflow_implement.implement_pr_state ready_for_review "$1" 2>/dev/null)" || st=ready_for_review
+  ips_publishes "$st"
+}
+IPS_E2E="$(mktemp)"
+printf '%s' '{"devflow_implement":{"implement_pr_state":"draft"}}' > "$IPS_E2E"
+assert_eq "implement_pr_state e2e: configured draft → leave draft"        "draft"   "$(ips_state_decision "$IPS_E2E")"
+printf '%s' '{"devflow_implement":{}}' > "$IPS_E2E"
+assert_eq "implement_pr_state e2e: absent key → publish"                  "publish" "$(ips_state_decision "$IPS_E2E")"
+printf '%s' '{bad json' > "$IPS_E2E"
+assert_eq "implement_pr_state e2e: malformed config (resolver hard-fail) → publish" "publish" "$(ips_state_decision "$IPS_E2E")"
+rm -f "$IPS_E2E"
 
 # ────────────────────────────────────────────────────────────────────────────
 echo "scaffold-config.sh"

--- a/lib/test/run.sh
+++ b/lib/test/run.sh
@@ -515,28 +515,43 @@ printf '%s' '{bad json' > "$IPS_E2E"
 assert_eq "implement_pr_state e2e: malformed config (resolver hard-fail) → publish" "publish" "$(ips_state_decision "$IPS_E2E")"
 rm -f "$IPS_E2E"
 
-# Three-way outcome guard. The SKILL's gate is NOT two-way (draft/publish): the publish
-# arm splits on `gh pr ready`'s exit into `published` vs `publish_failed`, and the
-# publish_failed capture (the workpad never falsely claims a PR was published on a
-# `gh pr ready` failure) is the headline correctness property of this change. Mirror the
-# full elif chain so a refactor that dropped the `else` arm (reverting to a bare
-# failure-swallowing `gh pr ready`) is caught here. $1 = PR_STATE, $2 = simulated
-# `gh pr ready` exit (0 ok / non-0 failure).
+# Outcome guard mirroring the SKILL's FOUR-arm Phase 4.3 chain:
+#   1. PR_STATE=draft                          → draft (no gh pr ready)
+#   2. gh pr ready succeeds                     → published
+#   3. gh pr ready fails BUT PR is non-draft    → published (idempotent re-run: gh pr ready
+#                                                 returns non-zero on an already-ready PR)
+#   4. else (still draft, or state unknown)     → publish_failed (fail-safe direction)
+# The publish_failed capture (the workpad never falsely claims a PR was published on a
+# `gh pr ready` failure) and the idempotent arm (a re-run of an already-published PR is
+# NOT a failure) are the headline correctness properties of this change. Modelling all
+# four arms here — plus the token pins below for the idempotent re-check command and
+# breadcrumb — means a refactor that dropped the `else` arm OR the idempotent arm is
+# caught. $1 = PR_STATE, $2 = simulated `gh pr ready` exit (0 ok / non-0), $3 = simulated
+# `isDraft` re-check result ("true"/"false"/"" when the re-check itself errored).
 ips_outcome() {
   [ "$1" = "draft" ] && { printf 'draft\n'; return; }
-  if [ "${2:-0}" -eq 0 ]; then printf 'published\n'; else printf 'publish_failed\n'; fi
+  if [ "${2:-0}" -eq 0 ]; then printf 'published\n'; return; fi
+  [ "${3:-}" = "false" ] && { printf 'published\n'; return; }   # gh failed but PR already non-draft
+  printf 'publish_failed\n'                                     # still draft, or state unconfirmed
 }
-assert_eq "implement_pr_state outcome: draft → draft (no gh pr ready)"             "draft"          "$(ips_outcome draft 0)"
-assert_eq "implement_pr_state outcome: publish + gh pr ready ok → published"       "published"      "$(ips_outcome ready_for_review 0)"
-assert_eq "implement_pr_state outcome: publish + gh pr ready fails → publish_failed" "publish_failed" "$(ips_outcome ready_for_review 1)"
+assert_eq "implement_pr_state outcome: draft → draft (no gh pr ready)"                  "draft"          "$(ips_outcome draft 0)"
+assert_eq "implement_pr_state outcome: publish + gh pr ready ok → published"            "published"      "$(ips_outcome ready_for_review 0)"
+assert_eq "implement_pr_state outcome: gh fails + PR still draft → publish_failed"      "publish_failed" "$(ips_outcome ready_for_review 1 true)"
+assert_eq "implement_pr_state outcome: gh fails + PR already non-draft → published (idempotent)" "published" "$(ips_outcome ready_for_review 1 false)"
+assert_eq "implement_pr_state outcome: gh fails + state unconfirmed (re-check errored) → publish_failed (fail-safe)" "publish_failed" "$(ips_outcome ready_for_review 1 '')"
 
-# Token pins for the publish_failed failure-capture branch and the outcome-specific
-# finalize wording — the prior pass pinned only the draft note (`left as draft`), leaving
-# the load-bearing "never falsely claim published" path uncovered.
+# Token pins for the publish_failed failure-capture branch, the idempotent re-run arm, and
+# the outcome-specific finalize wording — the prior pass pinned only the draft note
+# (`left as draft`), leaving the load-bearing "never falsely claim published" path and the
+# idempotent re-check uncovered (a refactor dropping the isDraft arm would stay green).
 assert_eq "implement_pr_state: SKILL captures the publish_failed outcome (gh pr ready failure not swallowed)" "yes" \
   "$(grep -qF 'PR_OUTCOME=publish_failed' "$IMPL_SKILL" && echo yes || echo no)"
 assert_eq "implement_pr_state: SKILL leaves a gh-pr-ready failure breadcrumb" "yes" \
   "$(grep -qF 'gh pr ready FAILED' "$IMPL_SKILL" && echo yes || echo no)"
+assert_eq "implement_pr_state: SKILL keeps the idempotent already-non-draft re-check" "yes" \
+  "$(grep -qF 'gh pr view --json isDraft' "$IMPL_SKILL" && echo yes || echo no)"
+assert_eq "implement_pr_state: SKILL labels the idempotent re-run breadcrumb" "yes" \
+  "$(grep -qF 'idempotent re-run' "$IMPL_SKILL" && echo yes || echo no)"
 assert_eq "implement_pr_state: SKILL has a distinct published-outcome note" "yes" \
   "$(grep -qF 'PR published (gh pr ready)' "$IMPL_SKILL" && echo yes || echo no)"
 assert_eq "implement_pr_state: draft case posts no extra PR-thread comment (AC7)" "yes" \

--- a/lib/test/run.sh
+++ b/lib/test/run.sh
@@ -485,7 +485,8 @@ assert_eq "implement_pr_state: SKILL has draft-aware finalize wording" "yes" \
 # comparison (semantically mirrors `[ "$PR_STATE" = "draft" ]`; `$1` stands in for
 # `$PR_STATE`) so the dry-trace matrix {draft, ready_for_review, "", published} is
 # exercised as behavior, not just asserted as prose (the absent/default row is the
-# resolver matrix above feeding `ready_for_review` into this guard).
+# resolver matrix above feeding `ready_for_review` into this guard; the publish arm's
+# success/failure split is modeled separately by `ips_outcome` below).
 ips_publishes() {
   [ "$1" = "draft" ] && { printf 'draft\n'; return; }
   printf 'publish\n'
@@ -548,6 +549,22 @@ IPS_BACKSTOP_LN=$(grep -nF 'git status --porcelain' "$IMPL_SKILL" | head -1 | cu
 IPS_GATE_LN=$(grep -nF '[ "$PR_STATE" = "draft" ]' "$IMPL_SKILL" | head -1 | cut -d: -f1)
 assert_eq "implement_pr_state: clean-tree backstop precedes the publish gate (runs in both cases)" "yes" \
   "$([ -n "$IPS_BACKSTOP_LN" ] && [ -n "$IPS_GATE_LN" ] && [ "$IPS_BACKSTOP_LN" -lt "$IPS_GATE_LN" ] && echo yes || echo no)"
+
+# Cross-file Progress-label consistency. The Phase 4.3 finalize `--tick-progress` label
+# in implement/SKILL.md MUST match the `## Progress` row label that scripts/workpad.py
+# OWNS (its cmd_new_body template + _PROGRESS_PHASES tuple + _STATUS_TO_PROGRESS_PHASE
+# 'complete' map) — workpad.py both renders the row and ticks it by substring, so if the
+# two sides drift the finalize finds no matching unticked row and the Phase 4.3 update
+# ABORTS. (This guards the exact desync a mid-review rename of the row to "PR finalized"
+# introduced: SKILL renamed, workpad.py not.) Both sides are pinned to the same literal,
+# so renaming one without the other goes red here.
+WP_PY="$LIB/../scripts/workpad.py"
+# NB: `--` ends grep's option parsing — the pattern begins with `--tick-progress`, which
+# grep would otherwise treat as an (invalid) long option.
+assert_eq "implement finalize: SKILL ticks the workpad.py-owned 'PR marked ready' label" "yes" \
+  "$(grep -qF -- '--tick-progress "PR marked ready"' "$IMPL_SKILL" && echo yes || echo no)"
+assert_eq "implement finalize: workpad.py owns the 'PR marked ready' label (template + _PROGRESS_PHASES agree)" "yes" \
+  "$(grep -qF '**PR marked ready**' "$WP_PY" && grep -qF "'PR marked ready'" "$WP_PY" && echo yes || echo no)"
 
 # ────────────────────────────────────────────────────────────────────────────
 echo "scaffold-config.sh"

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -888,8 +888,7 @@ If it is non-empty, **do not** finalize yet. The run began from a clean base-bra
 **Publish decision — `implement_pr_state`.** Whether the run publishes the PR or leaves it the draft created in Phase 3.1 is a per-consumer config choice. Read it (default `ready_for_review`), then publish **only** when it is not the exact literal `draft` — default-to-publish is the safe direction, so a missing key, empty string, or any unrecognized value publishes, and a hard read failure (malformed config) falls back to publishing:
 
 ```bash
-PR_STATE=$(${CLAUDE_SKILL_DIR}/../../scripts/config-get.sh .devflow_implement.implement_pr_state ready_for_review) || PR_STATE=""
-[ -n "$PR_STATE" ] || PR_STATE=ready_for_review
+PR_STATE=$(${CLAUDE_SKILL_DIR}/../../scripts/config-get.sh .devflow_implement.implement_pr_state ready_for_review) || PR_STATE=ready_for_review
 if [ "$PR_STATE" = "draft" ]; then
     echo "devflow: implement_pr_state=draft — leaving PR as a draft (skipping gh pr ready)" >&2
 else

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -88,7 +88,7 @@ The always-visible region (marker line, header, `Status`, links, `## Progress`, 
   - [ ] `review-and-fix`
   - [ ] acceptance-criteria gate
 - [ ] **Documentation**
-- [ ] **PR finalized** (published, or left a draft per `implement_pr_state`)
+- [ ] **PR marked ready**
 
 ## Plan
 - [ ] {step}
@@ -885,7 +885,7 @@ git status --porcelain
 
 If it is non-empty, **do not** finalize yet. The run began from a clean base-branch checkout (`origin/` + the configured `base_branch`), so anything dirty here is this run's own work an earlier phase failed to commit. Commit the part that belongs to this PR with the right prefix (`feat:`/`fix:`/`docs:`/`chore:`) and push, and record in `Devflow Reflection` which phase under-committed — surface the gap, don't paper over it. Surface (do not blindly `git add`) any unexpected untracked file. When the tree is already clean this is a no-op — create no empty commit.
 
-**Publish decision — `implement_pr_state`.** Whether the run publishes the PR or leaves it the draft created in Phase 3.1 is a per-consumer config choice. Read it (default `ready_for_review`), then publish **only** when it is not the exact literal `draft` — default-to-publish is the safe direction, so a missing key, empty string, or any unrecognized value publishes, and a hard read failure (malformed config) falls back to publishing. **Capture whether `gh pr ready` actually succeeded** so the finalize wording reflects the *real* end state — a bare `gh pr ready` whose failure (auth scope, GitHub 5xx, rate limit, a race that already merged/closed the PR) fell through would otherwise leave the workpad falsely claiming the PR was published when it is still a draft:
+**Publish decision — `implement_pr_state`.** Whether the run publishes the PR or leaves it the draft created in Phase 3.1 is a per-consumer config choice. Read it (default `ready_for_review`), then publish **only** when it is not the exact literal `draft` — default-to-publish is the safe direction, so a missing key, empty string, or any unrecognized value publishes, and a hard read failure (malformed config) falls back to publishing. **Capture whether `gh pr ready` actually succeeded** so the finalize wording reflects the *real* end state — a bare `gh pr ready` whose failure (the `else` arm catches *any* non-zero exit — e.g. auth scope, GitHub 5xx, rate limit, a race that already merged/closed the PR) fell through would otherwise leave the workpad falsely claiming the PR was published when it is still a draft:
 
 ```bash
 PR_STATE=$(${CLAUDE_SKILL_DIR}/../../scripts/config-get.sh .devflow_implement.implement_pr_state ready_for_review) || PR_STATE=ready_for_review
@@ -894,6 +894,13 @@ if [ "$PR_STATE" = "draft" ]; then
     echo "devflow: implement_pr_state=draft — leaving PR as a draft (skipping gh pr ready)" >&2
 elif gh pr ready; then
     PR_OUTCOME=published
+elif [ "$(gh pr view --json isDraft --jq '.isDraft' 2>/dev/null)" = "false" ]; then
+    # `gh pr ready` exited non-zero but the PR is NOT a draft — the benign already-ready
+    # case (a Phase 4.3 re-run after context recovery; `gh pr ready` on a non-draft PR
+    # returns non-zero). Treat as published, not a failure, so a re-run doesn't emit a
+    # spurious "publish failed" reflection contradicting reality.
+    PR_OUTCOME=published
+    echo "devflow: gh pr ready returned non-zero but PR is already non-draft — treating as published (idempotent re-run)" >&2
 else
     PR_OUTCOME=publish_failed
     echo "devflow: gh pr ready FAILED — PR is still a draft despite implement_pr_state=$PR_STATE; do NOT finalize the workpad as 'marked ready'" >&2
@@ -910,9 +917,13 @@ Then finalize the workpad in one call — tick the final `## Progress` item and 
 
 ```bash
 # Substitute the PR_OUTCOME-specific --note (and, for publish_failed, the extra --reflection) above.
+# `--tick-progress "PR marked ready"` MUST match the `## Progress` row label verbatim — that
+# label is owned by scripts/workpad.py (cmd_new_body template + _PROGRESS_PHASES +
+# _STATUS_TO_PROGRESS_PHASE); do NOT rename it here without renaming it there (and in the
+# python tests), or this tick finds no matching row and the finalize update aborts.
 workpad.py update $ISSUE_NUMBER \
     --status Complete \
-    --tick-progress "PR finalized" \
+    --tick-progress "PR marked ready" \
     --note "{PR_OUTCOME-specific note above}" \
     [--reflection "{noteworthy event}" ...repeat per event]
 ```

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -916,7 +916,7 @@ Then finalize the workpad in one call — tick the final `## Progress` item and 
 
 - **`PR_OUTCOME=draft`** → `--note "/devflow:implement run finished, PR left as draft per implement_pr_state=draft: <PR_URL>"`
 - **`PR_OUTCOME=published`** → `--note "/devflow:implement run finished, PR published (gh pr ready): <PR_URL>"`
-- **`PR_OUTCOME=publish_failed`** → `--note "/devflow:implement run finished, but gh pr ready FAILED — PR is still a draft: <PR_URL>"` **and** add `--reflection "gh pr ready failed at Phase 4.3 — PR left unpublished despite implement_pr_state=$PR_STATE; publish it manually (gh pr ready) so the cloud review and CI ready_for_review listener fire"`.
+- **`PR_OUTCOME=publish_failed`** → `--note "/devflow:implement run finished, but gh pr ready FAILED — PR is still a draft, or its state could not be confirmed: <PR_URL>"` **and** add `--reflection "gh pr ready failed at Phase 4.3 — PR left unpublished despite implement_pr_state=$PR_STATE; publish it manually (gh pr ready) so the cloud review and CI ready_for_review listener fire"` (the durable note mirrors the stderr breadcrumb's wording — it must not assert "still a draft" as fact on the unconfirmed-state path where the `isDraft` re-check itself errored).
 
 ```bash
 # Substitute the PR_OUTCOME-specific --note (and, for publish_failed, the extra --reflection) above.

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -875,21 +875,41 @@ gh pr view --json body --jq '.body' | grep -q "Work in progress — automated re
 ```
 
 
-### 4.3 Mark PR as Ready and Finalize Workpad
+### 4.3 Finalize the PR (publish or leave draft) and Finalize Workpad
 
-**Clean-tree backstop (before marking ready).** Assert nothing uncommitted reaches `gh pr ready`:
+**Clean-tree backstop (always, before the publish decision).** Assert nothing uncommitted survives the run — this runs **unconditionally**, independent of whether the PR will be published or left a draft:
 
 ```bash
 git status --porcelain
 ```
 
-If it is non-empty, **do not** mark the PR ready yet. The run began from a clean base-branch checkout (`origin/` + the configured `base_branch`), so anything dirty here is this run's own work an earlier phase failed to commit. Commit the part that belongs to this PR with the right prefix (`feat:`/`fix:`/`docs:`/`chore:`) and push, and record in `Devflow Reflection` which phase under-committed — surface the gap, don't paper over it. Surface (do not blindly `git add`) any unexpected untracked file. When the tree is already clean this is a no-op — create no empty commit. Only then:
+If it is non-empty, **do not** finalize yet. The run began from a clean base-branch checkout (`origin/` + the configured `base_branch`), so anything dirty here is this run's own work an earlier phase failed to commit. Commit the part that belongs to this PR with the right prefix (`feat:`/`fix:`/`docs:`/`chore:`) and push, and record in `Devflow Reflection` which phase under-committed — surface the gap, don't paper over it. Surface (do not blindly `git add`) any unexpected untracked file. When the tree is already clean this is a no-op — create no empty commit.
+
+**Publish decision — `implement_pr_state`.** Whether the run publishes the PR or leaves it the draft created in Phase 3.1 is a per-consumer config choice. Read it (default `ready_for_review`), then publish **only** when it is not the exact literal `draft` — default-to-publish is the safe direction, so a missing key, empty string, or any unrecognized value publishes, and a hard read failure (malformed config) falls back to publishing:
 
 ```bash
-gh pr ready
+PR_STATE=$(${CLAUDE_SKILL_DIR}/../../scripts/config-get.sh .devflow_implement.implement_pr_state ready_for_review) || PR_STATE=""
+[ -n "$PR_STATE" ] || PR_STATE=ready_for_review
+if [ "$PR_STATE" = "draft" ]; then
+    echo "devflow: implement_pr_state=draft — leaving PR as a draft (skipping gh pr ready)" >&2
+else
+    gh pr ready
+fi
 ```
 
-Then finalize the workpad in one call — tick the final `## Progress` item and flip `Status` to `Complete` (the helper swaps the glyph to 🎉):
+When `PR_STATE` is `draft` the PR is **left as the draft** from Phase 3.1: no `gh pr ready`, and **no additional comment** is posted to the PR thread. The downstream consequence is documented in [`docs/implement-skill.md`](../../docs/implement-skill.md) — the cloud review (`devflow-review.yml`'s `ready_for_review` event) and CI's `ready_for_review` listener do not auto-fire until a human publishes the PR.
+
+Then finalize the workpad in one call — tick the final `## Progress` item and flip `Status` to `Complete` (the helper swaps the glyph to 🎉) in **both** cases; only the `--note` wording differs so it never falsely claims the PR was marked ready. When `PR_STATE` is `draft`:
+
+```bash
+workpad.py update $ISSUE_NUMBER \
+    --status Complete \
+    --tick-progress "PR marked ready" \
+    --note "/devflow:implement run finished, PR left as draft per implement_pr_state=draft: <PR_URL>" \
+    [--reflection "{noteworthy event}" ...repeat per event]
+```
+
+Otherwise (the default publish path):
 
 ```bash
 workpad.py update $ISSUE_NUMBER \
@@ -901,7 +921,7 @@ workpad.py update $ISSUE_NUMBER \
 
 Add one `--reflection` flag per noteworthy event a human should know for troubleshooting: a failed step that was skipped, a subagent that returned no useful output, a permission denial, a test you couldn't run, an ambiguity you resolved with an assumption, or any deviation from the planned flow. `--reflection` is repeatable so all events land in a single atomic update. (No separate "Notes from /devflow:implement run" comment is posted — the workpad replaces it.)
 
-Finally, emit the 🎉 outcome reaction on the triggering comment (`REACTION=hooray`; see *Outcome reaction* in the Workpad Reference), then output the PR URL and a one- or two-line summary of what was accomplished.
+Finally, emit the 🎉 outcome reaction on the triggering comment (`REACTION=hooray`; see *Outcome reaction* in the Workpad Reference) in both cases — the run completed regardless of the publish decision — then output the PR URL and a one- or two-line summary of what was accomplished (note whether the PR was published or left a draft).
 
 ---
 
@@ -912,11 +932,11 @@ Before reporting completion, verify ALL phases executed:
 - Phase 1: issue fetched; workpad created before the branch with run link, `## Progress` checklist, and Acceptance Criteria mirrored; branch exists and the workpad `Branch` line filled; Setup ticked
 - Phase 2: reproduction signal recorded for `bug`-labelled issues; if the issue spans multiple PRs, the 2.2.5 scope-adjustment was applied and the Acceptance Criteria section holds only in-scope items; the 2.3.0 changed-contract and 2.3.4 boundary-assumption sweeps both ran over the diff, each cross-boundary claim verified or routed to `(post-merge)`; code committed and pushed
 - Phase 3: draft PR created; `/simplify` ran; `/devflow:review-and-fix` ran; acceptance-criteria gate passed (PR still draft)
-- Phase 4: follow-up issue(s) filed in 4.0 for any 2.2.5-deferred criteria; follow-up issue(s) filed in 4.0.5 and the manifest hydrated if /devflow:review-and-fix emitted a deferrals manifest; docs updated and the `Documented` label applied; PR description generated via `/pr-description`; working tree asserted clean (4.3 backstop) and any remainder committed; PR marked ready; every applicable `## Progress` item ticked; workpad finalized with `Status: Complete` (🎉) and the 🎉 outcome reaction emitted on the triggering comment
+- Phase 4: follow-up issue(s) filed in 4.0 for any 2.2.5-deferred criteria; follow-up issue(s) filed in 4.0.5 and the manifest hydrated if /devflow:review-and-fix emitted a deferrals manifest; docs updated and the `Documented` label applied; PR description generated via `/pr-description`; working tree asserted clean (4.3 backstop, runs in both publish and draft cases) and any remainder committed; PR published via `gh pr ready` **unless** `devflow_implement.implement_pr_state` is `draft` (then left as the Phase 3.1 draft, with no extra PR-thread comment); every applicable `## Progress` item ticked; workpad finalized with `Status: Complete` (🎉) — draft-aware `--note` wording — and the 🎉 outcome reaction emitted on the triggering comment
 
 Verify each `Status` PATCH actually landed at the time it was issued (see the Update protocol's "Always verify a PATCH that changes `Status` actually landed" rule). If a phase was skipped or a `Status` PATCH didn't land, go back and complete it now. In particular:
 
-- **Do not stop after the PR is created or after review approves** — the PR stays a draft until Phase 4.3.
+- **Do not stop after the PR is created or after review approves** — the PR stays a draft until Phase 4.3, which then publishes it (or, when `implement_pr_state` is `draft`, deliberately leaves it a draft after still finalizing the workpad and reaction).
 - **Do not stop because acceptance criteria are unchecked when the issue itself is multi-PR** — apply the 2.2.5 scope-adjustment rule first, then re-run the gate. The "Status: Blocked, stop the run" path in Phase 3.4 is only for genuinely-failing in-scope criteria, never for scope mismatches.
 
 ---

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -889,21 +889,24 @@ If it is non-empty, **do not** finalize yet. The run began from a clean base-bra
 
 ```bash
 PR_STATE=$(${CLAUDE_SKILL_DIR}/../../scripts/config-get.sh .devflow_implement.implement_pr_state ready_for_review) || PR_STATE=ready_for_review
-PR_OUTCOME=draft   # one of: draft | published | publish_failed
+PR_OUTCOME=draft   # one of: draft | published | publish_failed (overwritten below unless PR_STATE=draft)
 if [ "$PR_STATE" = "draft" ]; then
     echo "devflow: implement_pr_state=draft — leaving PR as a draft (skipping gh pr ready)" >&2
 elif gh pr ready; then
     PR_OUTCOME=published
 elif [ "$(gh pr view --json isDraft --jq '.isDraft' 2>/dev/null)" = "false" ]; then
-    # `gh pr ready` exited non-zero but the PR is NOT a draft — the benign already-ready
-    # case (a Phase 4.3 re-run after context recovery; `gh pr ready` on a non-draft PR
-    # returns non-zero). Treat as published, not a failure, so a re-run doesn't emit a
-    # spurious "publish failed" reflection contradicting reality.
+    # `gh pr ready` exited non-zero but the PR is NOT a draft — `gh pr ready` returns
+    # non-zero on any non-draft PR, so this is the already-ready case (a Phase 4.3 re-run
+    # after context recovery, or a PR a human/race already published). Treat as published,
+    # not a failure, so a re-run doesn't emit a spurious "publish failed" reflection
+    # contradicting reality. The check fails SAFE: if `gh pr view` itself errors (auth,
+    # 5xx, PR deleted by a race), the substitution is empty, `!= "false"`, so it falls to
+    # the else arm → publish_failed, the conservative direction.
     PR_OUTCOME=published
     echo "devflow: gh pr ready returned non-zero but PR is already non-draft — treating as published (idempotent re-run)" >&2
 else
     PR_OUTCOME=publish_failed
-    echo "devflow: gh pr ready FAILED — PR is still a draft despite implement_pr_state=$PR_STATE; do NOT finalize the workpad as 'marked ready'" >&2
+    echo "devflow: gh pr ready FAILED — PR is still a draft, or its state could not be confirmed (implement_pr_state=$PR_STATE); do NOT finalize the workpad as 'marked ready'" >&2
 fi
 ```
 

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -88,7 +88,7 @@ The always-visible region (marker line, header, `Status`, links, `## Progress`, 
   - [ ] `review-and-fix`
   - [ ] acceptance-criteria gate
 - [ ] **Documentation**
-- [ ] **PR marked ready**
+- [ ] **PR finalized** (published, or left a draft per `implement_pr_state`)
 
 ## Plan
 - [ ] {step}
@@ -885,42 +885,41 @@ git status --porcelain
 
 If it is non-empty, **do not** finalize yet. The run began from a clean base-branch checkout (`origin/` + the configured `base_branch`), so anything dirty here is this run's own work an earlier phase failed to commit. Commit the part that belongs to this PR with the right prefix (`feat:`/`fix:`/`docs:`/`chore:`) and push, and record in `Devflow Reflection` which phase under-committed — surface the gap, don't paper over it. Surface (do not blindly `git add`) any unexpected untracked file. When the tree is already clean this is a no-op — create no empty commit.
 
-**Publish decision — `implement_pr_state`.** Whether the run publishes the PR or leaves it the draft created in Phase 3.1 is a per-consumer config choice. Read it (default `ready_for_review`), then publish **only** when it is not the exact literal `draft` — default-to-publish is the safe direction, so a missing key, empty string, or any unrecognized value publishes, and a hard read failure (malformed config) falls back to publishing:
+**Publish decision — `implement_pr_state`.** Whether the run publishes the PR or leaves it the draft created in Phase 3.1 is a per-consumer config choice. Read it (default `ready_for_review`), then publish **only** when it is not the exact literal `draft` — default-to-publish is the safe direction, so a missing key, empty string, or any unrecognized value publishes, and a hard read failure (malformed config) falls back to publishing. **Capture whether `gh pr ready` actually succeeded** so the finalize wording reflects the *real* end state — a bare `gh pr ready` whose failure (auth scope, GitHub 5xx, rate limit, a race that already merged/closed the PR) fell through would otherwise leave the workpad falsely claiming the PR was published when it is still a draft:
 
 ```bash
 PR_STATE=$(${CLAUDE_SKILL_DIR}/../../scripts/config-get.sh .devflow_implement.implement_pr_state ready_for_review) || PR_STATE=ready_for_review
+PR_OUTCOME=draft   # one of: draft | published | publish_failed
 if [ "$PR_STATE" = "draft" ]; then
     echo "devflow: implement_pr_state=draft — leaving PR as a draft (skipping gh pr ready)" >&2
+elif gh pr ready; then
+    PR_OUTCOME=published
 else
-    gh pr ready
+    PR_OUTCOME=publish_failed
+    echo "devflow: gh pr ready FAILED — PR is still a draft despite implement_pr_state=$PR_STATE; do NOT finalize the workpad as 'marked ready'" >&2
 fi
 ```
 
 When `PR_STATE` is `draft` the PR is **left as the draft** from Phase 3.1: no `gh pr ready`, and **no additional comment** is posted to the PR thread. The downstream consequence is documented in [`docs/implement-skill.md`](../../docs/implement-skill.md) — the cloud review (`devflow-review.yml`'s `ready_for_review` event) and CI's `ready_for_review` listener do not auto-fire until a human publishes the PR.
 
-Then finalize the workpad in one call — tick the final `## Progress` item and flip `Status` to `Complete` (the helper swaps the glyph to 🎉) in **both** cases; only the `--note` wording differs so it never falsely claims the PR was marked ready. When `PR_STATE` is `draft`:
+Then finalize the workpad in one call — tick the final `## Progress` item and flip `Status` to `Complete` (the helper swaps the glyph to 🎉) in **every** case; only the `--note` wording differs, and on a publish failure a `--reflection` is added, so the workpad never falsely claims a PR was published. Pick the `--note` by `PR_OUTCOME`:
+
+- **`PR_OUTCOME=draft`** → `--note "/devflow:implement run finished, PR left as draft per implement_pr_state=draft: <PR_URL>"`
+- **`PR_OUTCOME=published`** → `--note "/devflow:implement run finished, PR published (gh pr ready): <PR_URL>"`
+- **`PR_OUTCOME=publish_failed`** → `--note "/devflow:implement run finished, but gh pr ready FAILED — PR is still a draft: <PR_URL>"` **and** add `--reflection "gh pr ready failed at Phase 4.3 — PR left unpublished despite implement_pr_state=$PR_STATE; publish it manually (gh pr ready) so the cloud review and CI ready_for_review listener fire"`.
 
 ```bash
+# Substitute the PR_OUTCOME-specific --note (and, for publish_failed, the extra --reflection) above.
 workpad.py update $ISSUE_NUMBER \
     --status Complete \
-    --tick-progress "PR marked ready" \
-    --note "/devflow:implement run finished, PR left as draft per implement_pr_state=draft: <PR_URL>" \
+    --tick-progress "PR finalized" \
+    --note "{PR_OUTCOME-specific note above}" \
     [--reflection "{noteworthy event}" ...repeat per event]
 ```
 
-Otherwise (the default publish path):
+Add one `--reflection` flag per noteworthy event a human should know for troubleshooting: a failed step that was skipped, a subagent that returned no useful output, a permission denial, a test you couldn't run, an ambiguity you resolved with an assumption, or any deviation from the planned flow (the `publish_failed` reflection above is one such event). `--reflection` is repeatable so all events land in a single atomic update. (No separate "Notes from /devflow:implement run" comment is posted — the workpad replaces it.)
 
-```bash
-workpad.py update $ISSUE_NUMBER \
-    --status Complete \
-    --tick-progress "PR marked ready" \
-    --note "/devflow:implement run finished, PR marked ready: <PR_URL>" \
-    [--reflection "{noteworthy event}" ...repeat per event]
-```
-
-Add one `--reflection` flag per noteworthy event a human should know for troubleshooting: a failed step that was skipped, a subagent that returned no useful output, a permission denial, a test you couldn't run, an ambiguity you resolved with an assumption, or any deviation from the planned flow. `--reflection` is repeatable so all events land in a single atomic update. (No separate "Notes from /devflow:implement run" comment is posted — the workpad replaces it.)
-
-Finally, emit the 🎉 outcome reaction on the triggering comment (`REACTION=hooray`; see *Outcome reaction* in the Workpad Reference) in both cases — the run completed regardless of the publish decision — then output the PR URL and a one- or two-line summary of what was accomplished (note whether the PR was published or left a draft).
+Finally, emit the 🎉 outcome reaction on the triggering comment (`REACTION=hooray`; see *Outcome reaction* in the Workpad Reference) — the implement lifecycle completed regardless of the publish decision (`draft`, `published`, or `publish_failed`; the publish failure is surfaced via the `--reflection` above, not by suppressing the reaction) — then output the PR URL and a one- or two-line summary of what was accomplished (state whether the PR was published, left a draft, or whether `gh pr ready` failed).
 
 ---
 


### PR DESCRIPTION
<!-- PR_BODY_START -->
## Summary
- Adds a `devflow_implement.implement_pr_state` config key so consumers can choose whether a `/devflow:implement` run **publishes** its PR (default, unchanged) or **leaves it a draft** for a human to publish on their own cadence.
- Default-to-publish is the safe direction: only the exact literal `draft` suppresses `gh pr ready`; a missing key, empty string, unrecognized value, or even a malformed config all resolve to `ready_for_review`.
- The gate lives once in the shared `skills/implement/SKILL.md` Phase 4.3 (no workflow fork) and additionally hardens the existing publish step — it now captures whether `gh pr ready` actually succeeded so the workpad never falsely reports a PR as published.

## Changes
**Config schema/example**: New `devflow_implement.implement_pr_state` property (`enum: ["ready_for_review", "draft"]`, `default: "ready_for_review"`, with a description); the example config carries the default.

**Implement skill (Phase 4.3)**: Reads the key via `config-get.sh` and gates `gh pr ready` on a single literal-`draft` comparison. The clean-tree backstop now runs unconditionally above the publish decision (both cases). The publish path captures a `PR_OUTCOME` (`draft` / `published` / `publish_failed`), with an idempotent re-run re-check (a non-zero `gh pr ready` on an already-non-draft PR is treated as `published`, not a failure), and draft-/failure-aware workpad note wording so a publish failure is surfaced via a reflection rather than falsely finalized as "marked ready".

**Docs**: `docs/implement-skill.md` gains a Phase 4.3 section documenting the setting, both values, the default, and the consequence that `draft` suppresses the cloud review (`devflow-review.yml` `ready_for_review` event) and CI's `ready_for_review` listener until a human publishes; `docs/DEVFLOW_SYSTEM_OVERVIEW.md` §4.3 updated to match.

**Tests**: `lib/test/run.sh` adds a full `implement_pr_state` block — schema/example contract, the `config-get.sh` resolver matrix (`draft` / `ready_for_review` / absent / empty / unrecognized / missing-file / malformed), executable guards mirroring the four-arm Phase 4.3 gate, a positional clean-tree-backstop check, and a cross-file guard asserting the finalize `--tick-progress` label matches the label `scripts/workpad.py` owns.

**Version**: `.claude-plugin/plugin.json` bumped `2.8.3` → `2.8.4` with a matching `CHANGELOG.md` entry.

## Resolves
Resolves #116

## Test Plan
- [ ] `lib/test/run.sh` passes (full suite green, incl. the new `implement_pr_state` assertions)
- [ ] With `implement_pr_state: "draft"` in `.devflow/config.json`, a `/devflow:implement` run leaves its PR a draft and the workpad note reads "left as draft"
- [ ] With the key unset (or any non-`draft` value), a run publishes the PR exactly as before
- [ ] `config-get.sh .devflow_implement.implement_pr_state ready_for_review` returns `draft` only for a literal `draft` value, and the default otherwise (including malformed config)

## Visual Changes
N/A

## Breaking Changes
None — the default preserves today's publish behavior for every consumer that does not set the key.

<!-- PR_BODY_END -->