### PR TITLE
audit(devflow): require standalone review on clean shadow over engine gate-logic diffs

### DIFF
--- a/docs/shadow-review.md
+++ b/docs/shadow-review.md
@@ -234,6 +234,51 @@ the exhaustiveness check. A clean shadow *raises confidence* in that gate's outc
 criterion for *waiving* it. Treat the separate independent review as the default, not as something a
 clean shadow makes optional.
 
+### The highest-risk clean shadow: a diff that changes the review/coverage/gate logic itself
+
+The generic calibration above has a sharpest edge, and it is the one this loop keeps getting wrong:
+**when the diff is `engine_self_modifying` and what it modifies is the review engine's own
+coverage-, gate-, or shadow-pass logic, a clean in-loop shadow is the *least* trustworthy clean
+shadow there is — never read it as sufficient, and require a separate standalone `/devflow:review`
+before merge.** The "shared blind spot" of the two bullets above is not a constant here; it is
+maximal precisely on this diff shape, because the reviewers are being asked to audit the very
+gate/coverage logic the change is rewriting, using a roster that shares whatever blind spot the new
+logic is supposed to close. A fail-open hole in a new tripwire, an under-specified verdict-precedence
+rule, a coverage join that reads `"full"` over a roster that silently shrank — these are exactly the
+defects a clean shadow is structurally weakest at catching, because catching them requires reasoning
+*about* the gate rather than *through* it.
+
+This is not hypothetical and not a one-off:
+
+- **PR #62 (issue #61), the hardening spec for the shadow-coverage invariants themselves.** The
+  in-loop shadow reported clean; a subsequent standalone `/devflow:review` returned **REJECT** on a
+  Critical fail-open — the roster too-narrow tripwire keyed on the wrong persisted signal (it
+  compared `diff_profile`, which never stored the test-relevance predicate, so a narrowed
+  `pr-test-analyzer` gate read `coverage: "full"` over a shrunken roster). It took twelve substantive
+  human follow-up commits across two review cycles to actually defend `coverage: "full"`. The clean
+  shadow was honest about what it asserts (the in-loop re-sample found nothing new) and useless as a
+  merge signal for this diff shape.
+- **PR #104 (issue #100), the `scan.sh` retrospectives-decode hardening.** A finding *both* review
+  passes flagged — the `_decode_existing` zero-record breadcrumb over-claims "from non-empty content"
+  on the `download_url` transport, which has no non-empty precondition — was parked as a non-blocking
+  advisory and shipped unfixed, with no test pinning the `download_url` empty/whitespace-body shape.
+  Parking advisories is legitimate by design (see "Advisory findings" in the skill), but on an
+  engine-self-modifying diff a *repeatedly-flagged* breadcrumb-accuracy defect in the engine's own
+  best-effort parser is the bug class CLAUDE.md singles out — it warrants fixing or an explicit
+  standalone-review pass, not silent advisory carry-through.
+
+So the rule, stated operationally: **a clean in-loop shadow does not clear an `engine_self_modifying`
+diff that touches review/coverage/gate logic for merge — schedule the separate standalone
+`/devflow:review` and resolve its findings first.** The standalone review is mandatory here, not
+"default but waivable on a clean shadow." (This narrows nothing for ordinary product-code diffs,
+where the shared-blind-spot risk is lower and the standalone review remains the *recommended*
+default rather than a hard pre-merge gate — see the Counterfactual note this calibration was
+strengthened under.) The two sub-patterns above share the coarse `review-gate-bypass` category; this
+calibration addresses the dominant one (the engine-self-modifying clean shadow that a real gate later
+caught). It does **not** change the advisory-parking mechanics themselves — a repeatedly-flagged
+advisory on an engine diff is surfaced here as a case the mandatory standalone review must catch, not
+re-litigated as a new auto-fix rule.
+
 ## Cost
 
 The shadow pass roughly **doubles** the cost of a converging run — one full engine pass that does


### PR DESCRIPTION
## Pattern
review-gate-bypass · first seen 2026-05-27T13:35:11Z · last seen 2026-06-03T19:03:29Z · 2 occurrences · status: open

## Motivating PRs
- The01Geek/devflow-autopilot#62 — *Harden the shadow review pass: defend coverage invariants the in-loop shadow itself missed (follow-up to #57)* (issue #61)
- The01Geek/devflow-autopilot#104 — *fix: harden scan.sh retrospectives.jsonl decode against silent collapse* (issue #100)

## Root cause (re-derived from primary sources)
Both occurrences are the same shape: the in-loop `/devflow:review-and-fix` shadow pass reported **clean** (full coverage / no new Critical/Important), yet a *real* gate later caught a fail-open the shadow had structurally missed — and the diff in both cases was `engine_self_modifying`, modifying the review engine's own coverage/gate/parser logic. On **PR #62** the in-loop shadow agreed full coverage on a spec that was *itself* the hardening of the shadow-coverage invariants; a subsequent standalone `/devflow:review` returned **REJECT** on a Critical fail-open (the roster too-narrow tripwire compared the persisted `diff_profile`, which never stored the test-relevance predicate, so a narrowed `pr-test-analyzer` gate read `coverage: "full"` over a shrunken roster). It took twelve substantive human follow-up commits across two review cycles to actually defend `coverage: "full"`. On **PR #104** a finding *both* review passes flagged — the `_decode_existing` zero-record breadcrumb over-claims "from non-empty content" on the `download_url` transport, which has no non-empty precondition — was parked as a non-blocking advisory and shipped unfixed, with no test pinning the `download_url` empty/whitespace-body shape. The common driver: a clean in-loop shadow is **least** trustworthy exactly when the diff rewrites the gate/coverage logic the reviewers are being asked to audit, because the roster shares whatever blind spot the new logic is meant to close.

**Divergence from the retrospective summaries:** none material. The `review-gate-bypass` category and the descriptors match the primary sources (the REJECT report on PR #62, the advisory-parked findings and zero post-bot commits on PR #104). One clarification the descriptors under-state: the *mechanics* the descriptors enumerate (tripwire re-keyed to `phase3_dispatched`, the checklist-axis narrowing tripwire, the 1:1 join, the AWUSF render-time precedence) were all eventually fixed in-tree — so this PR does **not** re-fix mechanics. The recurring, still-open gap is a **decision-discipline** one: nothing binds the existing "shadow narrows, never closes; standalone review is the default" calibration to its highest-risk case as a *hard pre-merge gate*.

## Proposed change
Single file, `docs/shadow-review.md` — strengthen the existing **Calibration** section (rather than add a competing rule). A new subsection, *"The highest-risk clean shadow: a diff that changes the review/coverage/gate logic itself"*, is appended directly after the existing practical-consequence paragraph. It states operationally that on an `engine_self_modifying` diff touching review/coverage/gate logic, a clean in-loop shadow does **not** clear the PR for merge — a separate standalone `/devflow:review` is **mandatory** (not "default but waivable on a clean shadow"), and its findings must be resolved first. It cites both occurrences (PR #62's Critical fail-open and the 12 follow-up commits; PR #104's repeatedly-flagged advisory that shipped) as the evidence, and explicitly scopes the hard gate to the engine-self-modifying-gate-logic case while leaving ordinary product-code diffs at the existing recommended-default posture.

## Conflict check
No rule contradicts this; it **strengthens** the existing one. `docs/shadow-review.md`'s Calibration section and `docs/DEVFLOW_SYSTEM_OVERVIEW.md` already say "a separate `/devflow:review` remains the default exhaustiveness check; a clean shadow raises confidence but never waives it" — generically. The change sharpens that generic default into a hard pre-merge gate for the one diff shape (engine-self-modifying gate/coverage logic) the evidence shows the loop keeps getting wrong; it does not weaken the generic default elsewhere. It deliberately does **not** touch the engine surfaces on the exclusion list (`skills/**`, the advisory-parking mechanics in `skills/review-and-fix/SKILL.md`, the `coverage`/tripwire logic) — those mechanics were already fixed in-tree and re-editing them would be both out of scope and design-review-gated. The Evidence paragraph already references PR #58 → issue #61 (the source of PR #62), so the new subsection extends an existing, consistent narrative rather than introducing a conflicting one.

## Counterfactual analysis
Applied too broadly, a "mandatory standalone review before merge" rule would tax every converging run with a second full review and erode the loop's value on ordinary product-code PRs, where a clean shadow's shared-blind-spot risk is genuinely lower and the standalone review is rightly a recommendation, not a hard gate. There is also a real case where a clean shadow on a small engine diff is adequate — a one-line typo fix in a helper carries little gate-logic risk. The change is scoped to avoid both: the hard gate fires only on `engine_self_modifying` diffs whose subject is the review/coverage/gate/shadow logic itself (the maximal-shared-blind-spot case the two occurrences share), and the subsection explicitly preserves the recommended-default posture for all other diffs. It changes no auto-fix mechanics and no advisory-parking behavior, so it cannot cause spurious REJECTs or loop non-termination — it is a calibration/discipline rule a human reviewer (and the orchestrator's merge decision) reads, not an automated gate that could misfire.

## Blast radius
One documentation file (`docs/shadow-review.md`); no code, no skills, no config, no tests. Affects the human reviewer and orchestrator deciding when an engine-self-modifying PR is merge-ready, and any future maintainer reading the shadow-pass calibration. No CI, lint, or runtime behavior changes.

This PR addresses the **dominant** sub-pattern under `review-gate-bypass` (PR #62: the engine-self-modifying clean shadow a real standalone gate later caught as Critical). It does **not** change the **advisory-parking mechanics** themselves (PR #104's second sub-pattern) — a repeatedly-flagged advisory on an engine diff is surfaced here as a case the now-mandatory standalone review must catch, not re-litigated as a new auto-fix rule. A future run that re-flags the advisory-parking sub-pattern specifically would target `skills/review-and-fix/SKILL.md`'s Step 2.5 advisory flow (an exclusion-list, design-review-gated surface).

Fixes pattern: review-gate-bypass
