### PR TITLE
skills: sync §2 canonical exclusion list with check-excluded-path.sh (#136)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devflow",
-  "version": "2.8.10",
+  "version": "2.8.11",
   "description": "Make agentic coding work on real codebases: DevFlow takes a one-line request to a complete, tested, reviewed, documented PR that's ready for your final review, and improves itself weekly. Includes /devflow:implement (4-phase orchestrator), /devflow:review and /devflow:review-and-fix (a verification-checklist review engine that audits its own approval), the /devflow:docs suite, /devflow:create-issue, plus the self-improving retrospective loop (/devflow:retrospective per-PR + /devflow:retrospective-audit weekly).",
   "author": {
     "name": "Daniel Radman",

--- a/.devflow/logs/efficiency/pr-138-local-20260626T175300Z-1.json
+++ b/.devflow/logs/efficiency/pr-138-local-20260626T175300Z-1.json
@@ -1,0 +1,73 @@
+{
+  "schema_version": 1,
+  "slug": "pr-138",
+  "generated_at": "2026-06-26T18:02:33Z",
+  "source": "review-and-fix",
+  "cut_candidate_min_dispatch": 3,
+  "iterations": 1,
+  "per_iteration": [
+    {
+      "iter": 1,
+      "phase3_dispatched": [
+        "pr-review-toolkit:code-reviewer",
+        "pr-review-toolkit:silent-failure-hunter",
+        "pr-review-toolkit:comment-analyzer",
+        "pr-review-toolkit:pr-test-analyzer",
+        "superpowers:requesting-code-review"
+      ],
+      "phase3_dispatched_count": 5,
+      "phase3_dispatched_present": true,
+      "diff_profile": {
+        "small_diff": true,
+        "config_only": false,
+        "has_new_types": false,
+        "engine_self_modifying": true,
+        "checklist_skipped": null
+      },
+      "verification_posture": "lite-only",
+      "checklist_lite_count": 2,
+      "checklist_agent_count": 0,
+      "fixes_applied": 0,
+      "added_nothing": true,
+      "agent_verdicts": [
+        {
+          "agent": "pr-review-toolkit:code-reviewer",
+          "verdict": null
+        },
+        {
+          "agent": "pr-review-toolkit:comment-analyzer",
+          "verdict": null
+        },
+        {
+          "agent": "pr-review-toolkit:pr-test-analyzer",
+          "verdict": "noise"
+        },
+        {
+          "agent": "pr-review-toolkit:silent-failure-hunter",
+          "verdict": null
+        },
+        {
+          "agent": "superpowers:requesting-code-review",
+          "verdict": null
+        }
+      ]
+    }
+  ],
+  "telemetry": [
+    {
+      "iter": 1,
+      "phases": {
+        "phase_3": {
+          "calls": 5,
+          "tokens": 195000,
+          "wall_clock_s": 200
+        },
+        "step_2_6": {
+          "calls": 5,
+          "tokens": 192000,
+          "wall_clock_s": 130
+        }
+      }
+    }
+  ]
+}

--- a/.devflow/logs/review/pr-138/local-20260626T175300Z-1/iter-1.json
+++ b/.devflow/logs/review/pr-138/local-20260626T175300Z-1/iter-1.json
@@ -1,0 +1,38 @@
+{
+  "iter": 1,
+  "started_at": "2026-06-26T18:02:14Z",
+  "fix_commit_sha": "79c3efe16189dee1c93a791513e3940439d60bfb",
+  "fix_files": [],
+  "checklist": [
+    {"id":"VC-1","claim":"SKILL.md §2 canonical block lists the same .devflow/config*.json siblings the helper matches","file":"skills/retrospective-audit/SKILL.md","verification_mode":"lite","claim_signature":"sync:skill-block-vs-helper:config-siblings","verdict":"PASS","evidence":"both derive {config.json,config.example.json,config.schema.json}","reused_from_iter_prev":false},
+    {"id":"VC-2","claim":"version 2.8.11 has a matching CHANGELOG entry","file":"CHANGELOG.md","verification_mode":"lite","claim_signature":"api_contract:changelog:version-match","verdict":"PASS","evidence":"## [2.8.11] entry present","reused_from_iter_prev":false}
+  ],
+  "phase3_dispatched": ["pr-review-toolkit:code-reviewer","pr-review-toolkit:silent-failure-hunter","pr-review-toolkit:comment-analyzer","pr-review-toolkit:pr-test-analyzer","superpowers:requesting-code-review"],
+  "diff_profile": {"small_diff": true, "config_only": false, "has_new_types": false, "engine_self_modifying": true, "checklist_skipped": null},
+  "phase3_findings": [
+    {"agent":"pr-review-toolkit:pr-test-analyzer","severity":"Suggestion","description":"drift-guard intentionally covers only .devflow/config*.json siblings; structural-dir entries remain review-enforced","defect_signature":{"file":"lib/test/run.sh","line_range":[3076,3100],"kind":"coverage-scope-note"},"corroboration_count":1,"step25_classification":"codebase","fix_decision":"advisory"}
+  ],
+  "fix_decisions": [],
+  "convergence_inputs": {"fixes_applied": 0, "fix_diff_lines": 0, "new_corroborated_critical_count": 0},
+  "cap_drops": {"count": 0, "by_category": {}},
+  "shadow": {
+    "ran_at": "2026-06-26T18:02:14Z",
+    "reviewed_sha": "79c3efe16189dee1c93a791513e3940439d60bfb",
+    "verdict": "APPROVE",
+    "coverage": "full",
+    "reviewers_dispatched": ["pr-review-toolkit:code-reviewer","pr-review-toolkit:silent-failure-hunter","pr-review-toolkit:comment-analyzer","pr-review-toolkit:pr-test-analyzer","superpowers:requesting-code-review"],
+    "expected_reviewers": ["pr-review-toolkit:code-reviewer","pr-review-toolkit:silent-failure-hunter","pr-review-toolkit:comment-analyzer","pr-review-toolkit:pr-test-analyzer","superpowers:requesting-code-review"],
+    "reason": null,
+    "checklist_skipped": null,
+    "phase3_findings": [
+      {"agent":"pr-review-toolkit:silent-failure-hunter","severity":"Suggestion","description":"regex delimiter asymmetry [^|) ]* (helper) vs [^ ]* (SKILL); fails closed","defect_signature":{"file":"lib/test/run.sh","line_range":[51,55],"kind":"regex-delimiter-asymmetry"}}
+    ],
+    "phase2_fails": [],
+    "comparison": {"shadow_total": 2, "overlap_with_iter_N": 1, "new": 1, "new_critical": 0, "new_important": 0},
+    "promoted_to_iter_next": false
+  },
+  "telemetry": {
+    "phase_3": {"calls": 5, "tokens": 195000, "wall_clock_s": 200},
+    "step_2_6": {"calls": 5, "tokens": 192000, "wall_clock_s": 130}
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to DevFlow are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project aims
 to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.8.11] — 2026-06-26
+
+### Fixed
+- **Synced the §2 canonical exclusion-list block in `skills/retrospective-audit/SKILL.md` with `lib/check-excluded-path.sh`.** The block omitted `.devflow/config.schema.json`, which the helper already matches and the §2 gating prose already names — a doc/code drift that no test caught. Added the missing entry, plus a `lib/test/run.sh` drift-guard that derives the helper's `.devflow/config*.json` sibling set at test time and asserts the SKILL.md block lists exactly the same siblings, so the `CLAUDE.md` must-stay-in-sync invariant is now enforced mechanically rather than by review alone. (#138, closes #136)
+
 ## [2.8.10] — 2026-06-24
 
 ### Changed

--- a/lib/test/run.sh
+++ b/lib/test/run.sh
@@ -3073,6 +3073,31 @@ assert_eq "mixed all-allowed → exit 1"    "1" "$(ex "CLAUDE.md" ".claude/skill
 assert_eq "prints the excluded path"      ".devflow/learnings/x.json" "$(bash "$LIB/check-excluded-path.sh" "CLAUDE.md" ".devflow/learnings/x.json")"
 
 # ────────────────────────────────────────────────────────────────────────────
+echo "exclusion-list sync: SKILL.md §2 canonical block ⇄ check-excluded-path.sh (config siblings)"
+# ────────────────────────────────────────────────────────────────────────────
+# CLAUDE.md mandates the §2 canonical exclusion list in skills/retrospective-audit/
+# SKILL.md stay in sync with lib/check-excluded-path.sh. The drift-prone part is the
+# exact .devflow/config*.json sibling set — three literals enumerated in BOTH places in
+# identical format, so an exact-string guard is precise (no glob */** normalization). The
+# set is derived from the helper at test time, so a new sibling added to one place but not
+# the other fails here (issue #136: config.schema.json was matched by the helper but
+# missing from the SKILL.md block — a doc/code drift no test caught).
+RA_SKILL="$LIB/../skills/retrospective-audit/SKILL.md"
+EXCL_HELPER="$LIB/check-excluded-path.sh"
+# Helper siblings: every .devflow/config*.json literal in the case arms (the char class
+# stops each token at the `|`/`)`/space that delimits it inside the case pattern).
+HELPER_CFG=$(grep -oE '\.devflow/config[^|) ]*\.json' "$EXCL_HELPER" | sort -u)
+# SKILL.md siblings: the same literals as bare lines inside the canonical fenced block.
+# Anchoring at ^ excludes the mid-line/backticked prose mentions (§2 lines), matching only
+# the fenced-block enumeration.
+SKILL_CFG=$(grep -oE '^\.devflow/config[^ ]*\.json' "$RA_SKILL" | sort -u)
+assert_eq "exclusion-sync: SKILL.md config siblings match the helper" "$HELPER_CFG" "$SKILL_CFG"
+# Non-vacuity: guard a future refactor that drops the literals (which would make BOTH
+# sides empty and the equality pass blindly).
+assert_eq "exclusion-sync: helper enumerates config siblings (non-vacuous)" "yes" \
+  "$([ -n "$HELPER_CFG" ] && echo yes || echo no)"
+
+# ────────────────────────────────────────────────────────────────────────────
 echo "meta-issue.sh"
 # ────────────────────────────────────────────────────────────────────────────
 MI_TMP="$(mktemp -d)"

--- a/skills/retrospective-audit/SKILL.md
+++ b/skills/retrospective-audit/SKILL.md
@@ -93,6 +93,7 @@ scripts/**
 .github/actions/**
 .devflow/config.json
 .devflow/config.example.json
+.devflow/config.schema.json
 ```
 
 The exclusion limit is **design-review**, not writability. Locally all paths are writable; these route to a meta GitHub issue because they need a human to think about second-order effects on the self-improvement loop.


### PR DESCRIPTION
<!-- PR_BODY_START -->
## Summary
- The §2 "Canonical exclusion list" block in `skills/retrospective-audit/SKILL.md` omitted `.devflow/config.schema.json`, a doc/code drift versus `lib/check-excluded-path.sh` (which already matches that path) and the §2 prose (which already names the `.schema` sibling).
- Adds the missing entry and a `lib/test/run.sh` drift-guard so the `CLAUDE.md` "must stay in sync" invariant is enforced mechanically rather than by review alone.

## Changes
**Retrospective-audit skill**: Add `.devflow/config.schema.json` to the §2 canonical exclusion-list fenced block so it mirrors `lib/check-excluded-path.sh` and the §2 gating prose.
**Test suite**: Add an `exclusion-list sync` drift-guard in `lib/test/run.sh` that derives the helper's `.devflow/config*.json` sibling set at test time and asserts the SKILL.md block lists exactly the same siblings, plus a non-vacuity assertion guarding the both-empty refactor case.
**Versioning**: Patch bump `2.8.10` → `2.8.11` in `.claude-plugin/plugin.json` with the matching `CHANGELOG.md` entry under `### Fixed`.

## Resolves
Resolves #136

## Test Plan
- [ ] `bash lib/test/run.sh` passes, including the two new `exclusion-sync` assertions (full suite: 1380 passed, 0 failed)
- [ ] `git ls-files '*.sh' | grep -v '^lib/test/' | xargs -r shellcheck --severity=warning -e SC1091` clean
- [ ] Mutation check: removing `.devflow/config.schema.json` from the SKILL.md block turns the `exclusion-sync` equality assertion RED (confirmed during implementation)

## Visual Changes
N/A

## Breaking Changes
None

<!-- PR_BODY_END -->