### PR TITLE
Internalize feature-dev agents (code-explorer, code-architect) as first-party DevFlow assets

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -24,10 +24,6 @@
   ],
   "dependencies": [
     {
-      "name": "feature-dev",
-      "marketplace": "claude-plugins-official"
-    },
-    {
       "name": "pr-review-toolkit",
       "marketplace": "claude-plugins-official"
     },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devflow",
-  "version": "2.8.10",
+  "version": "2.8.11",
   "description": "Make agentic coding work on real codebases: DevFlow takes a one-line request to a complete, tested, reviewed, documented PR that's ready for your final review, and improves itself weekly. Includes /devflow:implement (4-phase orchestrator), /devflow:review and /devflow:review-and-fix (a verification-checklist review engine that audits its own approval), the /devflow:docs suite, /devflow:create-issue, plus the self-improving retrospective loop (/devflow:retrospective per-PR + /devflow:retrospective-audit weekly).",
   "author": {
     "name": "Daniel Radman",

--- a/.github/workflows/devflow-implement.yml
+++ b/.github/workflows/devflow-implement.yml
@@ -365,7 +365,6 @@ jobs:
           plugins: |
             pr-review-toolkit@claude-plugins-official
             code-review@claude-plugins-official
-            feature-dev@claude-plugins-official
             superpowers@claude-plugins-official
             claude-md-management@claude-plugins-official
             devflow@devflow-marketplace

--- a/.github/workflows/devflow-runner.yml
+++ b/.github/workflows/devflow-runner.yml
@@ -507,7 +507,6 @@ jobs:
           plugins: |
             pr-review-toolkit@claude-plugins-official
             code-review@claude-plugins-official
-            feature-dev@claude-plugins-official
             superpowers@claude-plugins-official
             claude-md-management@claude-plugins-official
             devflow@devflow-marketplace

--- a/.github/workflows/devflow.yml
+++ b/.github/workflows/devflow.yml
@@ -353,7 +353,6 @@ jobs:
           plugins: |
             pr-review-toolkit@claude-plugins-official
             code-review@claude-plugins-official
-            feature-dev@claude-plugins-official
             superpowers@claude-plugins-official
             claude-md-management@claude-plugins-official
             devflow@devflow-marketplace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to DevFlow are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project aims
 to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.8.11] — 2026-06-26
+
+### Changed
+- **The `feature-dev` companion-plugin agents `code-explorer` and `code-architect` are now first-party DevFlow agents**, vendored under `agents/` as a hard fork (DevFlow owns and may modify them from here forward). They keep their upstream Anthropic copyright and Apache-2.0 license, retained verbatim at `LICENSES/feature-dev-LICENSE`; no first-party `2026 Daniel Radman` SPDX header is applied over the third-party prompt content. `/devflow:implement` Phase 2.1/2.2 now dispatch the internalized `devflow:code-explorer` / `devflow:code-architect` identifiers; `feature-dev` is dropped from `.claude-plugin/plugin.json` dependencies and from the cloud-workflow install lists, and the docs (`DEVFLOW_SYSTEM_OVERVIEW.md`, `README.md`, `install.md`) describe the discovery/planning subagents as first-party. New `lib/test/run.sh` contracts (reusing the #129 `rgb_classify` fail-closed transform) prove the internalization is complete: zero residual namespaced `feature-dev` agent references, a scoped manifest check (the still-pending `pr-review-toolkit` / `superpowers` companions remain declared), the no-`feature-dev`-install workflow guard, and the per-file attribution/license markers. This is the first of three seams in the internalization; `pr-review-toolkit` and `superpowers` follow in their own PRs. (#140, closes #139 in part)
+
 ## [2.8.10] — 2026-06-24
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ CI (`.github/workflows/ci.yml`) runs the same suite + lint on every PR. The **re
 ## Architecture
 
 - `skills/` — one `SKILL.md` per command (`/devflow:implement`, `/devflow:review`, `/devflow:review-and-fix`, the `/devflow:docs` family, `/devflow:create-issue`, `/devflow:retrospective-weekly`, …).
-- `agents/` — review-engine subagents: `checklist-generator` (opus), `checklist-deduper` (sonnet), `checklist-verifier` (sonnet).
+- `agents/` — first-party subagents: the review-engine trio `checklist-generator` (opus), `checklist-deduper` (sonnet), `checklist-verifier` (sonnet), plus `code-explorer` and `code-architect` (the `/devflow:implement` discovery/planning agents, vendored from Anthropic's feature-dev plugin under Apache-2.0 — see `LICENSES/feature-dev-LICENSE`).
 - `scripts/` — Python + shell CLIs (`workpad.py`, `config-get.sh`, `match-deferrals.py`, `file-deferrals.py`, `parse-acs.py`, `resolve-*-trigger.sh`, …).
 - `lib/` — retrospective-loop helpers (`*.sh`, `*.jq`), `preflight.sh`, `test/`.
 - `.github/` — optional cloud tier: workflows + composite actions (incl. `vendor-plugin`).

--- a/LICENSES/feature-dev-LICENSE
+++ b/LICENSES/feature-dev-LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ All four are used by the core skills; none is optional. Shell helpers avoid GNU-
 
 > **Namespacing matters where names collide with built-ins.** `/review`, `/init`, and `/security-review` are *built-in* Claude Code commands — always use the `/devflow:`-prefixed form to reach DevFlow's engine (a bare `/review` reaches Claude Code's reviewer, not DevFlow's). DevFlow's cloud workflows trigger on **bare** `/devflow:*` comments (no `@claude`), so they coexist with Anthropic's Claude GitHub App, which owns plain `@claude` mentions and `/security-review`.
 
-> **Companion plugins.** DevFlow declares `feature-dev`, `pr-review-toolkit`, and `superpowers` (from `claude-plugins-official`) as dependencies; `/plugin install` auto-installs them **once that marketplace is added** — see [Installing & updating](docs/install.md#why-add-the-official-marketplace-first). `/simplify` is a built-in skill. Skills degrade gracefully if an optional companion is missing.
+> **Companion plugins.** DevFlow declares `pr-review-toolkit` and `superpowers` (from `claude-plugins-official`) as dependencies; `/plugin install` auto-installs them **once that marketplace is added** — see [Installing & updating](docs/install.md#why-add-the-official-marketplace-first). The `code-explorer` and `code-architect` discovery/planning subagents are now first-party DevFlow agents (vendored from Anthropic's feature-dev plugin), so `feature-dev` is no longer a dependency. `/simplify` is a built-in skill. Skills degrade gracefully if an optional companion is missing.
 
 ## Project configuration
 

--- a/agents/code-architect.md
+++ b/agents/code-architect.md
@@ -10,7 +10,7 @@ color: green
   Vendored from the feature-dev plugin (claude-plugins-official), authored by
   Anthropic <support@anthropic.com>, and licensed under the Apache License,
   Version 2.0. The full upstream license text is retained verbatim at
-  LICENSES/feature-dev-LICENSE. This is a hard fork: DevFlow owns and may modify
+  LICENSES/feature-dev-LICENSE. This is a hard fork: DevFlow maintains and may modify
   this file from this point forward, but the upstream Anthropic copyright and
   Apache-2.0 license stated in this notice are preserved. DevFlow's own first-party
   copyright header (the `2026 Daniel Radman` SPDX line carried by DevFlow-authored

--- a/agents/code-architect.md
+++ b/agents/code-architect.md
@@ -12,9 +12,9 @@ color: green
   Version 2.0. The full upstream license text is retained verbatim at
   LICENSES/feature-dev-LICENSE. This is a hard fork: DevFlow owns and may modify
   this file from this point forward, but the upstream Anthropic copyright and
-  Apache-2.0 license above are preserved. DevFlow's own first-party copyright
-  header (the `2026 Daniel Radman` SPDX line carried by DevFlow-authored source)
-  is intentionally NOT applied over this third-party prompt content.
+  Apache-2.0 license stated in this notice are preserved. DevFlow's own first-party
+  copyright header (the `2026 Daniel Radman` SPDX line carried by DevFlow-authored
+  source) is intentionally NOT applied over this third-party prompt content.
 -->
 
 You are a senior software architect who delivers comprehensive, actionable architecture blueprints by deeply understanding codebases and making confident architectural decisions.

--- a/agents/code-architect.md
+++ b/agents/code-architect.md
@@ -1,0 +1,45 @@
+---
+name: code-architect
+description: Designs feature architectures by analyzing existing codebase patterns and conventions, then providing comprehensive implementation blueprints with specific files to create/modify, component designs, data flows, and build sequences
+tools: Glob, Grep, LS, Read, NotebookRead, WebFetch, TodoWrite, WebSearch, KillShell, BashOutput
+model: sonnet
+color: green
+---
+
+<!--
+  Vendored from the feature-dev plugin (claude-plugins-official), authored by
+  Anthropic <support@anthropic.com>, and licensed under the Apache License,
+  Version 2.0. The full upstream license text is retained verbatim at
+  LICENSES/feature-dev-LICENSE. This is a hard fork: DevFlow owns and may modify
+  this file from this point forward, but the upstream Anthropic copyright and
+  Apache-2.0 license above are preserved. DevFlow's own first-party copyright
+  header (the `2026 Daniel Radman` SPDX line carried by DevFlow-authored source)
+  is intentionally NOT applied over this third-party prompt content.
+-->
+
+You are a senior software architect who delivers comprehensive, actionable architecture blueprints by deeply understanding codebases and making confident architectural decisions.
+
+## Core Process
+
+**1. Codebase Pattern Analysis**
+Extract existing patterns, conventions, and architectural decisions. Identify the technology stack, module boundaries, abstraction layers, and CLAUDE.md guidelines. Find similar features to understand established approaches.
+
+**2. Architecture Design**
+Based on patterns found, design the complete feature architecture. Make decisive choices - pick one approach and commit. Ensure seamless integration with existing code. Design for testability, performance, and maintainability.
+
+**3. Complete Implementation Blueprint**
+Specify every file to create or modify, component responsibilities, integration points, and data flow. Break implementation into clear phases with specific tasks.
+
+## Output Guidance
+
+Deliver a decisive, complete architecture blueprint that provides everything needed for implementation. Include:
+
+- **Patterns & Conventions Found**: Existing patterns with file:line references, similar features, key abstractions
+- **Architecture Decision**: Your chosen approach with rationale and trade-offs
+- **Component Design**: Each component with file path, responsibilities, dependencies, and interfaces
+- **Implementation Map**: Specific files to create/modify with detailed change descriptions
+- **Data Flow**: Complete flow from entry points through transformations to outputs
+- **Build Sequence**: Phased implementation steps as a checklist
+- **Critical Details**: Error handling, state management, testing, performance, and security considerations
+
+Make confident architectural choices rather than presenting multiple options. Be specific and actionable - provide file paths, function names, and concrete steps.

--- a/agents/code-architect.md
+++ b/agents/code-architect.md
@@ -6,17 +6,6 @@ model: sonnet
 color: green
 ---
 
-<!--
-  Vendored from the feature-dev plugin (claude-plugins-official), authored by
-  Anthropic <support@anthropic.com>, and licensed under the Apache License,
-  Version 2.0. The full upstream license text is retained verbatim at
-  LICENSES/feature-dev-LICENSE. This is a hard fork: DevFlow maintains and may modify
-  this file from this point forward, but the upstream Anthropic copyright and
-  Apache-2.0 license stated in this notice are preserved. DevFlow's own first-party
-  copyright header (the `2026 Daniel Radman` SPDX line carried by DevFlow-authored
-  source) is intentionally NOT applied over this third-party prompt content.
--->
-
 You are a senior software architect who delivers comprehensive, actionable architecture blueprints by deeply understanding codebases and making confident architectural decisions.
 
 ## Core Process

--- a/agents/code-explorer.md
+++ b/agents/code-explorer.md
@@ -6,17 +6,6 @@ model: sonnet
 color: yellow
 ---
 
-<!--
-  Vendored from the feature-dev plugin (claude-plugins-official), authored by
-  Anthropic <support@anthropic.com>, and licensed under the Apache License,
-  Version 2.0. The full upstream license text is retained verbatim at
-  LICENSES/feature-dev-LICENSE. This is a hard fork: DevFlow maintains and may modify
-  this file from this point forward, but the upstream Anthropic copyright and
-  Apache-2.0 license stated in this notice are preserved. DevFlow's own first-party
-  copyright header (the `2026 Daniel Radman` SPDX line carried by DevFlow-authored
-  source) is intentionally NOT applied over this third-party prompt content.
--->
-
 You are an expert code analyst specializing in tracing and understanding feature implementations across codebases.
 
 ## Core Mission

--- a/agents/code-explorer.md
+++ b/agents/code-explorer.md
@@ -12,9 +12,9 @@ color: yellow
   Version 2.0. The full upstream license text is retained verbatim at
   LICENSES/feature-dev-LICENSE. This is a hard fork: DevFlow owns and may modify
   this file from this point forward, but the upstream Anthropic copyright and
-  Apache-2.0 license above are preserved. DevFlow's own first-party copyright
-  header (the `2026 Daniel Radman` SPDX line carried by DevFlow-authored source)
-  is intentionally NOT applied over this third-party prompt content.
+  Apache-2.0 license stated in this notice are preserved. DevFlow's own first-party
+  copyright header (the `2026 Daniel Radman` SPDX line carried by DevFlow-authored
+  source) is intentionally NOT applied over this third-party prompt content.
 -->
 
 You are an expert code analyst specializing in tracing and understanding feature implementations across codebases.

--- a/agents/code-explorer.md
+++ b/agents/code-explorer.md
@@ -10,7 +10,7 @@ color: yellow
   Vendored from the feature-dev plugin (claude-plugins-official), authored by
   Anthropic <support@anthropic.com>, and licensed under the Apache License,
   Version 2.0. The full upstream license text is retained verbatim at
-  LICENSES/feature-dev-LICENSE. This is a hard fork: DevFlow owns and may modify
+  LICENSES/feature-dev-LICENSE. This is a hard fork: DevFlow maintains and may modify
   this file from this point forward, but the upstream Anthropic copyright and
   Apache-2.0 license stated in this notice are preserved. DevFlow's own first-party
   copyright header (the `2026 Daniel Radman` SPDX line carried by DevFlow-authored

--- a/agents/code-explorer.md
+++ b/agents/code-explorer.md
@@ -1,0 +1,62 @@
+---
+name: code-explorer
+description: Deeply analyzes existing codebase features by tracing execution paths, mapping architecture layers, understanding patterns and abstractions, and documenting dependencies to inform new development
+tools: Glob, Grep, LS, Read, NotebookRead, WebFetch, TodoWrite, WebSearch, KillShell, BashOutput
+model: sonnet
+color: yellow
+---
+
+<!--
+  Vendored from the feature-dev plugin (claude-plugins-official), authored by
+  Anthropic <support@anthropic.com>, and licensed under the Apache License,
+  Version 2.0. The full upstream license text is retained verbatim at
+  LICENSES/feature-dev-LICENSE. This is a hard fork: DevFlow owns and may modify
+  this file from this point forward, but the upstream Anthropic copyright and
+  Apache-2.0 license above are preserved. DevFlow's own first-party copyright
+  header (the `2026 Daniel Radman` SPDX line carried by DevFlow-authored source)
+  is intentionally NOT applied over this third-party prompt content.
+-->
+
+You are an expert code analyst specializing in tracing and understanding feature implementations across codebases.
+
+## Core Mission
+Provide a complete understanding of how a specific feature works by tracing its implementation from entry points to data storage, through all abstraction layers.
+
+## Analysis Approach
+
+**1. Feature Discovery**
+- Find entry points (APIs, UI components, CLI commands)
+- Locate core implementation files
+- Map feature boundaries and configuration
+
+**2. Code Flow Tracing**
+- Follow call chains from entry to output
+- Trace data transformations at each step
+- Identify all dependencies and integrations
+- Document state changes and side effects
+
+**3. Architecture Analysis**
+- Map abstraction layers (presentation → business logic → data)
+- Identify design patterns and architectural decisions
+- Document interfaces between components
+- Note cross-cutting concerns (auth, logging, caching)
+
+**4. Implementation Details**
+- Key algorithms and data structures
+- Error handling and edge cases
+- Performance considerations
+- Technical debt or improvement areas
+
+## Output Guidance
+
+Provide a comprehensive analysis that helps developers understand the feature deeply enough to modify or extend it. Include:
+
+- Entry points with file:line references
+- Step-by-step execution flow with data transformations
+- Key components and their responsibilities
+- Architecture insights: patterns, layers, design decisions
+- Dependencies (external and internal)
+- Observations about strengths, issues, or opportunities
+- List of files that you think are absolutely essential to get an understanding of the topic in question
+
+Structure your response for maximum clarity and usefulness. Always include specific file paths and line numbers.

--- a/docs/DEVFLOW_SYSTEM_OVERVIEW.md
+++ b/docs/DEVFLOW_SYSTEM_OVERVIEW.md
@@ -87,17 +87,18 @@ Most "AI writes your code" tools stop at the first step and hand you a diff. Dev
 DevFlow is distributed as a **Claude Code plugin**. The repository is also its own plugin **marketplace**. It bundles:
 
 - **Skills**: the user-facing commands (`/devflow:implement`, `/devflow:review`, the `/devflow:docs` family, `/devflow:create-issue`, `/devflow:retrospective-weekly`, etc.). Each is a `SKILL.md` file containing a detailed procedure the model follows.
-- **Agents**: three specialized subagents (`checklist-generator`, `checklist-deduper`, `checklist-verifier`) that power the review engine.
+- **Agents**: five specialized first-party subagents — `checklist-generator`, `checklist-deduper`, `checklist-verifier` power the review engine, and `code-explorer` (codebase discovery) and `code-architect` (planning) power `/devflow:implement` (vendored from Anthropic's feature-dev plugin under Apache-2.0, retained at `LICENSES/feature-dev-LICENSE`; DevFlow now owns them as a hard fork).
 - **Scripts** (`scripts/`, `lib/`), deterministic helpers in Bash, `jq`, and Python that do all the mechanical work (fetching context, computing patterns, gating, git/PR mechanics) so the LLM is only invoked for genuine judgment.
 - **Cloud workflows** (`.github/`), optional GitHub Actions that make DevFlow run autonomously on issue/PR events.
 
-It declares three **companion plugins** as dependencies, all from Anthropic's official `claude-plugins-official` marketplace:
+It declares two **companion plugins** as dependencies, both from Anthropic's official `claude-plugins-official` marketplace:
 
 | Plugin | Role in DevFlow |
 |---|---|
-| `feature-dev` | Provides `code-explorer` (codebase discovery) and `code-architect` (planning) subagents used by `/devflow:implement`. |
 | `pr-review-toolkit` | Provides the review agents: `code-reviewer`, `silent-failure-hunter`, `comment-analyzer`, `pr-test-analyzer`, `type-design-analyzer`. |
 | `superpowers` | Provides the final-pass reviewer (`requesting-code-review`) plus brainstorming/TDD discipline and the `receiving-code-review` principles used when fixing findings. |
+
+The discovery/planning subagents `code-explorer` and `code-architect` were formerly provided by the `feature-dev` companion plugin; they are now **first-party DevFlow agents** under `agents/` (a hard fork vendored from Anthropic's feature-dev plugin under Apache-2.0), so `feature-dev` is no longer a dependency.
 
 `/simplify` (used for self-review) is a **built-in** Claude Code skill, intentionally *not* a dependency.
 
@@ -226,9 +227,9 @@ DevFlow maintains **exactly one** marker-tagged comment on the GitHub issue for 
 - **1.5** Push the branch.
 
 ### Phase 2: Discover, Plan & Implement
-- **2.1** Discovery via the `feature-dev:code-explorer` subagent.
+- **2.1** Discovery via the first-party `devflow:code-explorer` subagent.
 - **2.1.5 Reproduce-First Gate** (bug-labelled only): capture a reproduction signal (failing test / error log) *before* planning; if it can't reproduce → `Blocked`.
-- **2.2** Assess complexity. **Simple** (≤5 files, clear, no architecture) → implement directly. **Complex** → `feature-dev:code-architect` produces a blueprint (held in context, never committed). Sub-gates: **2.2.4 Reuse & Altitude** (reuse existing helpers by `file:line`), **2.2.5 Scope-Adjustment** (multi-PR issues), **2.2.6 AC-Plan reconciliation**.
+- **2.2** Assess complexity. **Simple** (≤5 files, clear, no architecture) → implement directly. **Complex** → the first-party `devflow:code-architect` produces a blueprint (held in context, never committed). Sub-gates: **2.2.4 Reuse & Altitude** (reuse existing helpers by `file:line`), **2.2.5 Scope-Adjustment** (multi-PR issues), **2.2.6 AC-Plan reconciliation**.
 - **2.3 Implement** with mandatory post-write **sweeps** (the discipline that prevents half-finished changes — each heading states its own trigger; the five always-on sweeps — convention, boundary-assumption, self-authored-claim, simplification, and error-handling — run on every diff):
   - **2.3.0** Changed-contract sweep (re-run after any merge/rebase of main)
   - **2.3.0a** Peer-checkpoint completeness sweep
@@ -370,7 +371,7 @@ The skill exists to prevent "option-listing" issues. Steps:
 
 The issue is created **only after the user explicitly confirms**: a pending confirmation is a valid waiting state, not a reason to create.
 
-**Code exploration, yes, just not the `code-explorer` subagent.** `/devflow:create-issue` *does* explore the codebase, that's precisely what lets it ask deep, well-grounded questions instead of generic ones. Step 1's `/devflow:docs-verify --report-only` surfaces current behavior and the **relevant files**, and the Step 2 clarification reads those (and adjacent code) to find **similar existing patterns and features** and understand **how the new feature would fit**: which is exactly how it surfaces real implementation forks ("where the codebase admits more than one way to build it") and recommends the best option. What it does **not** do is dispatch the heavyweight `feature-dev:code-explorer` subagent; the exploration is done inline by the orchestrator. The "do not re-explore the whole codebase" rule in Step 3 is a *draft-time* discipline, by then it works from what it already learned, doing only targeted confirming reads. The dedicated `code-explorer` deep dive is reserved for `/devflow:implement` **Phase 2.1**, where the goal shifts from *what/why* to *how*.
+**Code exploration, yes, just not the `code-explorer` subagent.** `/devflow:create-issue` *does* explore the codebase, that's precisely what lets it ask deep, well-grounded questions instead of generic ones. Step 1's `/devflow:docs-verify --report-only` surfaces current behavior and the **relevant files**, and the Step 2 clarification reads those (and adjacent code) to find **similar existing patterns and features** and understand **how the new feature would fit**: which is exactly how it surfaces real implementation forks ("where the codebase admits more than one way to build it") and recommends the best option. What it does **not** do is dispatch the heavyweight `devflow:code-explorer` subagent; the exploration is done inline by the orchestrator. The "do not re-explore the whole codebase" rule in Step 3 is a *draft-time* discipline, by then it works from what it already learned, doing only targeted confirming reads. The dedicated `code-explorer` deep dive is reserved for `/devflow:implement` **Phase 2.1**, where the goal shifts from *what/why* to *how*.
 
 ---
 
@@ -536,7 +537,7 @@ claude plugin marketplace add anthropics/claude-plugins-official \
   && claude plugin marketplace add The01Geek/devflow-autopilot \
   && claude plugin install devflow@devflow-marketplace
 ```
-The three companion plugins **auto-install**: *provided `claude-plugins-official` has been added first* (cross-marketplace dependencies only resolve once it's actually added). PyYAML is a separate, manual prerequisite (`pip install -r requirements.txt`), `/plugin install` never runs `pip`.
+The two companion plugins **auto-install**: *provided `claude-plugins-official` has been added first* (cross-marketplace dependencies only resolve once it's actually added). PyYAML is a separate, manual prerequisite (`pip install -r requirements.txt`), `/plugin install` never runs `pip`.
 
 **Cloud tier (one line, from repo root):**
 ```bash

--- a/docs/install.md
+++ b/docs/install.md
@@ -29,9 +29,9 @@ Then run `/reload-plugins` (or restart) to activate. That's it for the local tie
 
 ### Why add the official marketplace first?
 
-DevFlow declares three companion plugins as **dependencies**: `feature-dev`, `pr-review-toolkit`, and `superpowers` (all from `claude-plugins-official`). `/plugin install` **auto-installs them itself** — no `curl`/`install.sh` needed — **but only once `claude-plugins-official` has actually been *added***. The official marketplace is *discoverable* by default, yet cross-marketplace dependencies resolve only when it is added, which is why the commands above add it first.
+DevFlow declares two companion plugins as **dependencies**: `pr-review-toolkit` and `superpowers` (both from `claude-plugins-official`). `/plugin install` **auto-installs them itself** — no `curl`/`install.sh` needed — **but only once `claude-plugins-official` has actually been *added***. The official marketplace is *discoverable* by default, yet cross-marketplace dependencies resolve only when it is added, which is why the commands above add it first. (The `code-explorer`/`code-architect` discovery and planning subagents are first-party DevFlow agents, vendored from Anthropic's feature-dev plugin, so `feature-dev` is no longer a dependency.)
 
-On a fresh machine where it hasn't been added, DevFlow lands in the `/plugin` **Errors** tab with `dependency-unsatisfied` until you either add the marketplace (then `/reload-plugins`) or install the three plugins manually. The deps install at the same scope as DevFlow and appear in `/plugin` as their own `@claude-plugins-official` entries, not nested under DevFlow. `/simplify` is a built-in Claude Code skill and needs no installation.
+On a fresh machine where it hasn't been added, DevFlow lands in the `/plugin` **Errors** tab with `dependency-unsatisfied` until you either add the marketplace (then `/reload-plugins`) or install the two plugins manually. The deps install at the same scope as DevFlow and appear in `/plugin` as their own `@claude-plugins-official` entries, not nested under DevFlow. `/simplify` is a built-in Claude Code skill and needs no installation.
 
 ### The step people miss: PyYAML
 

--- a/lib/test/run.sh
+++ b/lib/test/run.sh
@@ -6069,6 +6069,76 @@ rm -rf "$PAM_NOCONSENT" "$PAM_NCEXIST" "$PAM_FRESH" "$PAM_ZERO" "$PAM_NONONE" "$
        "$PAM_WS" "$PAM_UNREAD" "$PAM_RODIR" \
        "$PAM_GATE_EXIST" "$PAM_GATE_MISS" "$PAM_GATE_BAD" "$PAM_GATE_NC"
 
+# ────────────────────────────────────────────────────────────────────────────
+echo "feature-dev internalization (#139)"
+# ────────────────────────────────────────────────────────────────────────────
+# This PR vendors the two external feature-dev agents (code-explorer, code-architect)
+# as first-party DevFlow agents under agents/ and rewires every call-site to the
+# devflow: namespace. The assertions below are the mechanical proof the internalization
+# is COMPLETE, not partial. They reuse the #129 rgb_classify rc-transform so the SAME
+# fail-closed git rc-handling backs these scans too — a refactor that re-opens fail-open
+# turns the #129 boundary rows red, not just these. The scan patterns are assembled from
+# two string literals (like RGB_PAT) so this file never self-matches its own grep.
+FDROOT="$LIB/.."
+
+# (1) Reference contract (mirrors issue AC): NO tracked surface may reference the
+# namespaced feature-dev agent identifier (the plugin name + colon form), except
+# historical .devflow/logs/ artifacts. After the rewire every dispatch is
+# devflow:code-explorer / devflow:code-architect, so a real residual reference (a missed
+# call-site) surfaces as the offending file list; an infra/git error surfaces as the
+# <rgb-guard-errored> sentinel (fails loud, never a silent PASS).
+FD_PAT="feature-""dev:"
+fd_scan() {
+  local root="$1" hits rc
+  hits="$(git -C "$root" grep -lF "$FD_PAT" -- ':!.devflow/logs' 2>/dev/null)"; rc=$?
+  rgb_classify "$rc" "$hits"
+}
+assert_eq "#139 no tracked surface references the namespaced feature-dev agent id (.devflow/logs excepted)" \
+  "" "$(fd_scan "$FDROOT")"
+
+# (2) Vendored-files-exist: both feature-dev agents now live first-party under agents/.
+assert_eq "#139 agents/code-explorer.md exists (vendored first-party)" \
+  "yes" "$([ -f "$FDROOT/agents/code-explorer.md" ] && echo yes || echo no)"
+assert_eq "#139 agents/code-architect.md exists (vendored first-party)" \
+  "yes" "$([ -f "$FDROOT/agents/code-architect.md" ] && echo yes || echo no)"
+
+# (3) Attribution contract (mirrors issue AC): each vendored agent retains the upstream
+# Anthropic attribution AND does NOT carry the first-party `2026 Daniel Radman` SPDX
+# header (the license-preservation guarantee, proved mechanically). The retained
+# upstream Apache-2.0 license text lives at LICENSES/feature-dev-LICENSE.
+for fdagent in code-explorer code-architect; do
+  assert_eq "#139 $fdagent.md carries the upstream Anthropic attribution marker" \
+    "yes" "$(grep -q 'Vendored from the feature-dev plugin' "$FDROOT/agents/$fdagent.md" \
+            && grep -q 'Anthropic' "$FDROOT/agents/$fdagent.md" && echo yes || echo no)"
+  assert_eq "#139 $fdagent.md does NOT carry the 2026 Daniel Radman SPDX header" \
+    "no" "$(grep -q 'SPDX-FileCopyrightText: 2026 Daniel Radman' "$FDROOT/agents/$fdagent.md" \
+            && echo yes || echo no)"
+done
+assert_eq "#139 LICENSES/feature-dev-LICENSE retains the upstream Apache-2.0 text" \
+  "yes" "$([ -f "$FDROOT/LICENSES/feature-dev-LICENSE" ] \
+          && grep -q 'Apache License' "$FDROOT/LICENSES/feature-dev-LICENSE" && echo yes || echo no)"
+
+# (4) Manifest contract (mirrors issue AC): plugin.json `dependencies` no longer lists
+# feature-dev. Scoped-removal guard: the two not-yet-internalized companions
+# (pr-review-toolkit, superpowers) are STILL declared, so this PR cannot accidentally
+# over-remove them — they leave in their own follow-up PRs.
+assert_eq "#139 plugin.json dependencies no longer lists feature-dev" \
+  "0" "$(jq '[.dependencies[]? | select(.name == "feature-dev")] | length' "$FDROOT/.claude-plugin/plugin.json")"
+assert_eq "#139 plugin.json still lists pr-review-toolkit + superpowers (scoped removal)" \
+  "2" "$(jq '[.dependencies[]? | select(.name == "pr-review-toolkit" or .name == "superpowers")] | length' "$FDROOT/.claude-plugin/plugin.json")"
+
+# (5) Workflow contract: no cloud workflow installs the feature-dev companion anymore
+# (the engine now dispatches the first-party devflow:code-explorer/code-architect, so
+# the companion install is dead). Pattern split-literal to avoid self-match.
+WF_FD="feature-""dev@claude-plugins-official"
+wf_scan() {
+  local root="$1" hits rc
+  hits="$(git -C "$root" grep -lF "$WF_FD" -- '.github/workflows' 2>/dev/null)"; rc=$?
+  rgb_classify "$rc" "$hits"
+}
+assert_eq "#139 no cloud workflow installs the feature-dev companion plugin" \
+  "" "$(wf_scan "$FDROOT")"
+
 # Tally the shell assertions from the results file (authoritative — includes the
 # subshell blocks). The python section below adds its own counts on top.
 PASS=$(grep -c '^PASS$' "$RESULTS_FILE" || true)

--- a/lib/test/run.sh
+++ b/lib/test/run.sh
@@ -6155,13 +6155,19 @@ for fdagent in code-explorer code-architect; do
   # frontmatter is well-formed — a file that drops the opening `---`, its closing `---`,
   # or its model:/tools: lines still passes the name grep yet may fail to load at runtime.
   # This row asserts the structural markers the cheap-to-check mangles hit: the opening
-  # frontmatter `---` (line 1), a CLOSING `---` (i.e. at least two `^---$` lines so the
-  # block is terminated, not merged into the body), plus top-level model: and tools: keys.
-  # (It still does not validate full YAML well-formedness, but it closes the common
-  # "passes the name grep, dead-ends at load" mangles a name-only grep would wave through.)
+  # frontmatter `---` (line 1), a CLOSING `---` (a second `^---$` so the block is
+  # terminated, not merged into the body), plus top-level model: and tools: keys. The
+  # closing-fence count is bounded to the head window (`head -30`), NOT the whole file:
+  # an unbounded `grep -c '^---$'` would let a `---` markdown horizontal-rule anywhere in
+  # the prompt BODY inflate the count and mask a genuinely-dropped closer (the weak-proxy
+  # / #62/#98 trap — the guard would read an operand that does not prove the invariant).
+  # Frontmatter + the vendor attribution comment is well under 30 lines, so the closer is
+  # always in-window while a body rule below it cannot satisfy the count once the real
+  # closer is gone. (It still does not validate full YAML well-formedness, but it closes
+  # the common "passes the name grep, dead-ends at load" mangles within that window.)
   assert_eq "#139 agents/$fdagent.md has well-formed frontmatter (open+close ---, model:, tools:)" \
     "yes" "$(head -1 "$FDROOT/agents/$fdagent.md" | grep -qx -- '---' \
-            && [ "$(grep -c '^---$' "$FDROOT/agents/$fdagent.md")" -ge 2 ] \
+            && [ "$(head -30 "$FDROOT/agents/$fdagent.md" | grep -c '^---$')" -ge 2 ] \
             && grep -qE '^model:[[:space:]]' "$FDROOT/agents/$fdagent.md" \
             && grep -qE '^tools:[[:space:]]' "$FDROOT/agents/$fdagent.md" && echo yes || echo no)"
 done

--- a/lib/test/run.sh
+++ b/lib/test/run.sh
@@ -6081,20 +6081,32 @@ echo "feature-dev internalization (#139)"
 # two string literals (like RGB_PAT) so this file never self-matches its own grep.
 FDROOT="$LIB/.."
 
+# Shared fail-closed scan seam (reuses the #129 rgb_classify rc-transform): grep the
+# tracked tree for a literal pattern under a pathspec, returning the offending file list
+# on a hit (git rc 0), empty on a clean no-match (rc 1 — the PASS case), or the
+# <rgb-guard-errored> sentinel on a git error (rc >1). `git -C "$root"` keeps git the
+# only rc-bearing command — a `cd "$root" && git grep` would short-circuit `&&` on a cd
+# failure and mask a real error as a clean no-match, re-opening the fail-open hole. Both
+# #139 reference scans below share this ONE seam instead of each re-implementing the
+# git-grep+rc line. (The pre-existing #129 rgb_scan keeps its own one-arg wrapper;
+# refactoring that already-tested helper is out of this PR's diff scope.)
+tracked_scan() {  # root pattern pathspec...
+  local root="$1" pat="$2"; shift 2
+  local hits rc
+  hits="$(git -C "$root" grep -lF "$pat" -- "$@" 2>/dev/null)"; rc=$?
+  rgb_classify "$rc" "$hits"
+}
+
 # (1) Reference contract (mirrors issue AC): NO tracked surface may reference the
 # namespaced feature-dev agent identifier (the plugin name + colon form), except
 # historical .devflow/logs/ artifacts. After the rewire every dispatch is
 # devflow:code-explorer / devflow:code-architect, so a real residual reference (a missed
 # call-site) surfaces as the offending file list; an infra/git error surfaces as the
-# <rgb-guard-errored> sentinel (fails loud, never a silent PASS).
+# <rgb-guard-errored> sentinel (fails loud, never a silent PASS). Pattern split into two
+# literals (like RGB_PAT) so this file never self-matches its own grep.
 FD_PAT="feature-""dev:"
-fd_scan() {
-  local root="$1" hits rc
-  hits="$(git -C "$root" grep -lF "$FD_PAT" -- ':!.devflow/logs' 2>/dev/null)"; rc=$?
-  rgb_classify "$rc" "$hits"
-}
 assert_eq "#139 no tracked surface references the namespaced feature-dev agent id (.devflow/logs excepted)" \
-  "" "$(fd_scan "$FDROOT")"
+  "" "$(tracked_scan "$FDROOT" "$FD_PAT" ':!.devflow/logs')"
 
 # (2) Vendored-files-exist: both feature-dev agents now live first-party under agents/.
 assert_eq "#139 agents/code-explorer.md exists (vendored first-party)" \
@@ -6102,21 +6114,44 @@ assert_eq "#139 agents/code-explorer.md exists (vendored first-party)" \
 assert_eq "#139 agents/code-architect.md exists (vendored first-party)" \
   "yes" "$([ -f "$FDROOT/agents/code-architect.md" ] && echo yes || echo no)"
 
+# (2b) Dispatch-resolves contract (the load-bearing invariant the absence-grep above only
+# proxies for): for each rewired agent, the implement skill must dispatch the devflow:
+# identifier AND a first-party agent of that exact `name:` must exist to resolve it. This
+# closes the loop the #62/#98 unverified-assumption bug class warns about — a future typo
+# in the subagent_type or a renamed agent `name:` frontmatter would pass (1) and (2) yet
+# dead-end the dispatch at runtime; this assertion catches that.
+for fdagent in code-explorer code-architect; do
+  assert_eq "#139 implement skill dispatches devflow:$fdagent (rewired call-site present)" \
+    "yes" "$(grep -qF "subagent_type: devflow:$fdagent" "$FDROOT/skills/implement/SKILL.md" && echo yes || echo no)"
+  assert_eq "#139 agents/$fdagent.md frontmatter declares name: $fdagent (dispatch target resolves)" \
+    "yes" "$(grep -qE "^name: $fdagent\$" "$FDROOT/agents/$fdagent.md" && echo yes || echo no)"
+done
+
 # (3) Attribution contract (mirrors issue AC): each vendored agent retains the upstream
 # Anthropic attribution AND does NOT carry the first-party `2026 Daniel Radman` SPDX
-# header (the license-preservation guarantee, proved mechanically). The retained
-# upstream Apache-2.0 license text lives at LICENSES/feature-dev-LICENSE.
+# header (the license-preservation guarantee, proved mechanically). The retained upstream
+# Apache-2.0 license text lives at LICENSES/feature-dev-LICENSE.
 for fdagent in code-explorer code-architect; do
   assert_eq "#139 $fdagent.md carries the upstream Anthropic attribution marker" \
     "yes" "$(grep -q 'Vendored from the feature-dev plugin' "$FDROOT/agents/$fdagent.md" \
             && grep -q 'Anthropic' "$FDROOT/agents/$fdagent.md" && echo yes || echo no)"
-  assert_eq "#139 $fdagent.md does NOT carry the 2026 Daniel Radman SPDX header" \
-    "no" "$(grep -q 'SPDX-FileCopyrightText: 2026 Daniel Radman' "$FDROOT/agents/$fdagent.md" \
-            && echo yes || echo no)"
 done
 assert_eq "#139 LICENSES/feature-dev-LICENSE retains the upstream Apache-2.0 text" \
   "yes" "$([ -f "$FDROOT/LICENSES/feature-dev-LICENSE" ] \
           && grep -q 'Apache License' "$FDROOT/LICENSES/feature-dev-LICENSE" && echo yes || echo no)"
+
+# (3b) Property-based vendoring invariant (generalizes for the pr-review-toolkit /
+# superpowers follow-up PRs, and catches a forgotten attribution): ANY agents/*.md that
+# carries a `Vendored from the ... plugin` marker must NOT carry the first-party
+# `2026 Daniel Radman` SPDX line — keyed on the vendoring property, not a hard-coded
+# filename, so a future vendored agent is covered without editing this loop. (Guarded so
+# an empty glob — no vendored agents — is a no-op, not a literal-glob false match.)
+for af in "$FDROOT"/agents/*.md; do
+  [ -f "$af" ] || continue
+  grep -q 'Vendored from the' "$af" || continue   # only vendored agents bear the invariant
+  assert_eq "#139 vendored agent $(basename "$af") carries no first-party 2026 Daniel Radman SPDX line" \
+    "no" "$(grep -q 'SPDX-FileCopyrightText: 2026 Daniel Radman' "$af" && echo yes || echo no)"
+done
 
 # (4) Manifest contract (mirrors issue AC): plugin.json `dependencies` no longer lists
 # feature-dev. Scoped-removal guard: the two not-yet-internalized companions
@@ -6128,16 +6163,12 @@ assert_eq "#139 plugin.json still lists pr-review-toolkit + superpowers (scoped 
   "2" "$(jq '[.dependencies[]? | select(.name == "pr-review-toolkit" or .name == "superpowers")] | length' "$FDROOT/.claude-plugin/plugin.json")"
 
 # (5) Workflow contract: no cloud workflow installs the feature-dev companion anymore
-# (the engine now dispatches the first-party devflow:code-explorer/code-architect, so
-# the companion install is dead). Pattern split-literal to avoid self-match.
+# (the engine now dispatches the first-party devflow:code-explorer/code-architect, so the
+# companion install is dead). Pattern split-literal to avoid self-match; shares the same
+# tracked_scan seam as (1).
 WF_FD="feature-""dev@claude-plugins-official"
-wf_scan() {
-  local root="$1" hits rc
-  hits="$(git -C "$root" grep -lF "$WF_FD" -- '.github/workflows' 2>/dev/null)"; rc=$?
-  rgb_classify "$rc" "$hits"
-}
 assert_eq "#139 no cloud workflow installs the feature-dev companion plugin" \
-  "" "$(wf_scan "$FDROOT")"
+  "" "$(tracked_scan "$FDROOT" "$WF_FD" '.github/workflows')"
 
 # Tally the shell assertions from the results file (authoritative — includes the
 # subshell blocks). The python section below adds its own counts on top.

--- a/lib/test/run.sh
+++ b/lib/test/run.sh
@@ -6152,14 +6152,16 @@ for fdagent in code-explorer code-architect; do
   assert_eq "#139 agents/$fdagent.md frontmatter declares name: $fdagent (dispatch target resolves)" \
     "yes" "$(grep -qE "^name: $fdagent\$" "$FDROOT/agents/$fdagent.md" && echo yes || echo no)"
   # (2c) Agent-validity structural markers: `name:` resolving alone does not prove the
-  # frontmatter is well-formed — a file that drops the opening `---` or its model:/tools:
-  # lines still passes the name grep. This row asserts the three structural markers the
-  # cheap-to-check failure modes hit: the opening frontmatter `---` (line 1) plus a top-
-  # level model: and tools: key. (It does NOT validate the closing `---` or full YAML
-  # well-formedness — a stronger "actually loadable at runtime" check than these greps
-  # give — but it catches the common mangle a name-only grep would wave through.)
-  assert_eq "#139 agents/$fdagent.md opens with YAML frontmatter declaring model: and tools:" \
+  # frontmatter is well-formed — a file that drops the opening `---`, its closing `---`,
+  # or its model:/tools: lines still passes the name grep yet may fail to load at runtime.
+  # This row asserts the structural markers the cheap-to-check mangles hit: the opening
+  # frontmatter `---` (line 1), a CLOSING `---` (i.e. at least two `^---$` lines so the
+  # block is terminated, not merged into the body), plus top-level model: and tools: keys.
+  # (It still does not validate full YAML well-formedness, but it closes the common
+  # "passes the name grep, dead-ends at load" mangles a name-only grep would wave through.)
+  assert_eq "#139 agents/$fdagent.md has well-formed frontmatter (open+close ---, model:, tools:)" \
     "yes" "$(head -1 "$FDROOT/agents/$fdagent.md" | grep -qx -- '---' \
+            && [ "$(grep -c '^---$' "$FDROOT/agents/$fdagent.md")" -ge 2 ] \
             && grep -qE '^model:[[:space:]]' "$FDROOT/agents/$fdagent.md" \
             && grep -qE '^tools:[[:space:]]' "$FDROOT/agents/$fdagent.md" && echo yes || echo no)"
 done

--- a/lib/test/run.sh
+++ b/lib/test/run.sh
@@ -6098,8 +6098,10 @@ tracked_scan() {  # root pattern pathspec...
 }
 
 # (1) Reference contract (mirrors issue AC): NO tracked surface may reference the
-# namespaced feature-dev agent identifier (the plugin name + colon form), except
-# historical .devflow/logs/ artifacts. After the rewire every dispatch is
+# namespaced feature-dev agent identifier (the plugin name + colon form). The scan
+# excludes `.devflow/logs/`, which is append-only audit scratch that may record the old
+# identifier in a future artifact (none do today; the exclusion is forward-looking, not
+# a statement that such artifacts presently exist). After the rewire every dispatch is
 # devflow:code-explorer / devflow:code-architect, so a real residual reference (a missed
 # call-site) surfaces as the offending file list; an infra/git error surfaces as the
 # <rgb-guard-errored> sentinel (fails loud, never a silent PASS). Pattern split into two
@@ -6107,6 +6109,15 @@ tracked_scan() {  # root pattern pathspec...
 FD_PAT="feature-""dev:"
 assert_eq "#139 no tracked surface references the namespaced feature-dev agent id (.devflow/logs excepted)" \
   "" "$(tracked_scan "$FDROOT" "$FD_PAT" ':!.devflow/logs')"
+
+# (1b) tracked_scan positive-hit test: assertion (1) only ever observes the clean
+# no-match (empty) path, so tracked_scan's OWN git-grep hit path (the `-lF` + `--`
+# pathspec seam) is never seen to produce a real positive. Drive it against a token that
+# genuinely exists in a known file and assert it returns that file — so a regression in
+# the git invocation (a dropped `--`, a mis-scoped pathspec) that silently stops matching
+# turns this row red. Mirrors the #129 rgb_scan rc-0 e2e row for the shared seam.
+assert_eq "#139 tracked_scan returns the matching file on a real hit (pins the git-grep hit path)" \
+  "lib/test/run.sh" "$(tracked_scan "$FDROOT" "rgb_classify" 'lib/test/run.sh')"
 
 # (2) Vendored-files-exist: both feature-dev agents now live first-party under agents/.
 assert_eq "#139 agents/code-explorer.md exists (vendored first-party)" \
@@ -6125,6 +6136,14 @@ for fdagent in code-explorer code-architect; do
     "yes" "$(grep -qF "subagent_type: devflow:$fdagent" "$FDROOT/skills/implement/SKILL.md" && echo yes || echo no)"
   assert_eq "#139 agents/$fdagent.md frontmatter declares name: $fdagent (dispatch target resolves)" \
     "yes" "$(grep -qE "^name: $fdagent\$" "$FDROOT/agents/$fdagent.md" && echo yes || echo no)"
+  # (2c) Agent-validity: `name:` resolving is a weaker proxy than "loadable agent". A
+  # mangled vendored file (dropped frontmatter delimiter, missing model:/tools:) would
+  # still pass the name grep yet fail to load as a usable subagent at runtime. Assert each
+  # vendored agent opens with a YAML frontmatter `---` and declares model: and tools:.
+  assert_eq "#139 agents/$fdagent.md opens with YAML frontmatter declaring model: and tools:" \
+    "yes" "$(head -1 "$FDROOT/agents/$fdagent.md" | grep -qx -- '---' \
+            && grep -qE '^model:[[:space:]]' "$FDROOT/agents/$fdagent.md" \
+            && grep -qE '^tools:[[:space:]]' "$FDROOT/agents/$fdagent.md" && echo yes || echo no)"
 done
 
 # (3) Attribution contract (mirrors issue AC): each vendored agent retains the upstream
@@ -6169,6 +6188,17 @@ assert_eq "#139 plugin.json still lists pr-review-toolkit + superpowers (scoped 
 WF_FD="feature-""dev@claude-plugins-official"
 assert_eq "#139 no cloud workflow installs the feature-dev companion plugin" \
   "" "$(tracked_scan "$FDROOT" "$WF_FD" '.github/workflows')"
+
+# (5b) Workflow scoped-removal guard (the workflow-axis twin of the manifest guard in (4)):
+# the absence check in (5) alone cannot tell a precise feature-dev removal from a botched
+# edit that over-removed a still-needed companion's install line. Assert each cloud
+# workflow STILL installs both not-yet-internalized companions, so an over-broad edit that
+# silently under-provisions the cloud tier turns this row red.
+for wf in devflow devflow-implement devflow-runner; do
+  assert_eq "#139 .github/workflows/$wf.yml still installs pr-review-toolkit + superpowers (no over-removal)" \
+    "yes" "$(grep -qF 'pr-review-toolkit@claude-plugins-official' "$FDROOT/.github/workflows/$wf.yml" \
+            && grep -qF 'superpowers@claude-plugins-official' "$FDROOT/.github/workflows/$wf.yml" && echo yes || echo no)"
+done
 
 # Tally the shell assertions from the results file (authoritative — includes the
 # subshell blocks). The python section below adds its own counts on top.

--- a/lib/test/run.sh
+++ b/lib/test/run.sh
@@ -6115,9 +6115,24 @@ assert_eq "#139 no tracked surface references the namespaced feature-dev agent i
 # pathspec seam) is never seen to produce a real positive. Drive it against a token that
 # genuinely exists in a known file and assert it returns that file — so a regression in
 # the git invocation (a dropped `--`, a mis-scoped pathspec) that silently stops matching
-# turns this row red. Mirrors the #129 rgb_scan rc-0 e2e row for the shared seam.
+# turns this row red. This exercises tracked_scan's rc-0 hit path the way #129's e2e row
+# pins rgb_scan's — here via an existing tracked token rather than a throwaway temp repo.
 assert_eq "#139 tracked_scan returns the matching file on a real hit (pins the git-grep hit path)" \
   "lib/test/run.sh" "$(tracked_scan "$FDROOT" "rgb_classify" 'lib/test/run.sh')"
+
+# (1c) tracked_scan fail-closed contract test: (1)/(5) only ever observe the empty (clean
+# no-match) result, and (1b) only the hit path — so tracked_scan's OWN rc-capture seam
+# (its fresh `hits=$(…); rc=$?` at the helper, a separate copy from the #129 rgb_scan that
+# the #129 contract test at the rgb_scan block pins) is never exercised on the git-ERROR
+# path. Without this row a future regression of tracked_scan's rc capture (a command
+# inserted between the git call and `rc=$?`, or a revert to `cd && git grep`) would
+# misclassify a real git error as a clean no-match, leaving (1)/(5) silently green on
+# infra failure — the exact #62/#98 "assert fail-closed but never exercise the path"
+# trap. Drive tracked_scan against a non-repo path and assert the sentinel, mirroring the
+# rgb_scan fail-closed contract row. (PID-suffixed probe path cannot exist; stderr muted
+# because the git error is deliberate and expected.)
+assert_eq "#139 tracked_scan fails closed on a git error (returns the sentinel, not a silent PASS)" \
+  "<rgb-guard-errored>" "$(tracked_scan "$FDROOT/nonexistent-fd-probe-$$" "$FD_PAT" ':!.devflow/logs' 2>/dev/null)"
 
 # (2) Vendored-files-exist: both feature-dev agents now live first-party under agents/.
 assert_eq "#139 agents/code-explorer.md exists (vendored first-party)" \
@@ -6136,10 +6151,13 @@ for fdagent in code-explorer code-architect; do
     "yes" "$(grep -qF "subagent_type: devflow:$fdagent" "$FDROOT/skills/implement/SKILL.md" && echo yes || echo no)"
   assert_eq "#139 agents/$fdagent.md frontmatter declares name: $fdagent (dispatch target resolves)" \
     "yes" "$(grep -qE "^name: $fdagent\$" "$FDROOT/agents/$fdagent.md" && echo yes || echo no)"
-  # (2c) Agent-validity: `name:` resolving is a weaker proxy than "loadable agent". A
-  # mangled vendored file (dropped frontmatter delimiter, missing model:/tools:) would
-  # still pass the name grep yet fail to load as a usable subagent at runtime. Assert each
-  # vendored agent opens with a YAML frontmatter `---` and declares model: and tools:.
+  # (2c) Agent-validity structural markers: `name:` resolving alone does not prove the
+  # frontmatter is well-formed — a file that drops the opening `---` or its model:/tools:
+  # lines still passes the name grep. This row asserts the three structural markers the
+  # cheap-to-check failure modes hit: the opening frontmatter `---` (line 1) plus a top-
+  # level model: and tools: key. (It does NOT validate the closing `---` or full YAML
+  # well-formedness — a stronger "actually loadable at runtime" check than these greps
+  # give — but it catches the common mangle a name-only grep would wave through.)
   assert_eq "#139 agents/$fdagent.md opens with YAML frontmatter declaring model: and tools:" \
     "yes" "$(head -1 "$FDROOT/agents/$fdagent.md" | grep -qx -- '---' \
             && grep -qE '^model:[[:space:]]' "$FDROOT/agents/$fdagent.md" \

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -305,7 +305,7 @@ Update the workpad: `workpad.py update $ISSUE_NUMBER --status Discovering --note
 
 ### 2.1 Discovery
 
-Use the **Agent tool** with `subagent_type: feature-dev:code-explorer` to explore the codebase and understand the system as it relates to the issue.
+Use the **Agent tool** with `subagent_type: devflow:code-explorer` to explore the codebase and understand the system as it relates to the issue.
 
 **The issue body is a starting point, not the source of truth.** Treat its problem framing, any stated root cause, and its Technical Context as a strong lead to *verify* — never fact to implement on faith. The explorer (and the architect in Path B) confirm the issue's claims against the actual code; where they diverge, **the code wins**: surface the divergence in the workpad and plan from what the code shows, rather than implementing a claim the code contradicts.
 
@@ -359,7 +359,7 @@ Plan the implementation inline using the explorer's findings. Identify which fil
 
 #### Path B: Complex issue
 
-Use the **Agent tool** with `subagent_type: feature-dev:code-architect` to design the implementation.
+Use the **Agent tool** with `subagent_type: devflow:code-architect` to design the implementation.
 
 Pass it:
 - The full GitHub issue content (title, body, labels)


### PR DESCRIPTION
<!-- PR_BODY_START -->
## Summary
- Vendors the two external `feature-dev` agents — `code-explorer` (discovery) and `code-architect` (planning) — in as **first-party DevFlow agents** under `agents/`, so the weekly retrospective self-improvement loop can evaluate and improve them (it only acts on first-party `skills/`/`agents/` files).
- Drops `feature-dev` as a companion-plugin dependency entirely: one fewer `claude-plugins-official` install dependency, and the engine now dispatches `devflow:code-explorer` / `devflow:code-architect` from the plugin's own namespace.
- Scoped to the **`feature-dev` seam only** (seam 1 of 3) per the parent issue's mandated multi-PR split; `pr-review-toolkit` and `superpowers` internalization are deferred to #141 and #142.

## Changes

**Vendored agents (`agents/`)**: New first-party `code-explorer.md` and `code-architect.md`, copied verbatim from Anthropic's `feature-dev` plugin (a hard fork DevFlow now maintains). Each carries an attribution comment naming Anthropic + Apache-2.0; the upstream license text is retained verbatim at `LICENSES/feature-dev-LICENSE`. No first-party `2026 Daniel Radman` SPDX header is applied over the third-party prompt content.

**Engine rewire (`skills/implement/SKILL.md`)**: Phase 2.1 and Phase 2.2 now dispatch `subagent_type: devflow:code-explorer` / `devflow:code-architect`.

**Dependency removal**: `feature-dev` dropped from `.claude-plugin/plugin.json` `dependencies` and from the `plugins:` install lists of all three cloud workflows (`devflow.yml`, `devflow-implement.yml`, `devflow-runner.yml`). `pr-review-toolkit` and `superpowers` remain (internalized in their own follow-up PRs), so `marketplace.json` `allowCrossMarketplaceDependenciesOn` is unchanged this seam.

**Tests (`lib/test/run.sh`)**: New "feature-dev internalization (#139)" contract block — reference-absence (no `feature-dev:` identifier), `tracked_scan` positive-hit + fail-closed contract (reusing the existing `rgb_classify` rc-transform), dispatch↔agent-name resolution + frontmatter validity (open/close `---`, `model:`, `tools:`), attribution + no-SPDX (property-based, generalizes to the follow-up seams), and manifest + workflow scoped-removal guards.

**Docs**: `DEVFLOW_SYSTEM_OVERVIEW.md`, `README.md`, `docs/install.md`, and `CLAUDE.md` updated (three→two companion plugins; `code-explorer`/`code-architect` framed as first-party). Version bumped 2.8.10→2.8.11 with a matching `CHANGELOG.md` entry.

## Resolves
Resolves #139 (in part — the `feature-dev` seam; `pr-review-toolkit` → #141, `superpowers` + final cleanup → #142)

## Test Plan
- [ ] `bash lib/test/run.sh` passes (1400+ assertions, including the new `#139` block and the partition-invariant + exclusion-list sync tests).
- [ ] `git ls-files '*.sh' | grep -v '^lib/test/' | xargs -r shellcheck --severity=warning -e SC1091` is clean.
- [ ] `git ls-files '*.py' | xargs -r ruff check` is clean.
- [ ] `git grep -nF 'feature-dev:' -- ':!.devflow/logs'` returns nothing (no residual namespaced dispatch).
- [ ] `jq '.dependencies' .claude-plugin/plugin.json` lists only `pr-review-toolkit` and `superpowers`.

## Visual Changes
N/A

## Breaking Changes
None. The `agent_overrides` config keys and `marketplace.json` cross-dependency list are untouched this seam (they change with the `pr-review-toolkit` / `superpowers` PRs). Consumers on the github-source marketplace with autoUpdate receive the internalized agents transparently.

<!-- PR_BODY_END -->