### PR TITLE
audit(devflow): calibrate review-and-fix park-and-ship severity grading

### DIFF
--- a/.devflow/prompt-extensions/review-and-fix.md
+++ b/.devflow/prompt-extensions/review-and-fix.md
@@ -1,0 +1,72 @@
+# DevFlow repo — calibration policy for `/devflow:review-and-fix`
+
+This repository (the DevFlow plugin itself) is the loop's own subject. Three times the
+in-loop review-and-fix pass concluded with an APPROVE-family verdict after **parking** a
+substantive finding as a Suggestion / advisory non-blocking note, and a later standalone
+`/devflow:review` (or a re-review on the same PR) re-raised that exact point as **Important
+or Critical** — forcing human follow-up commits the loop should have made itself. The loop's
+machinery (shadow pass, coverage tripwires, post-shadow edit gate) is not the gap; the gap is
+the loop's own **severity self-grading at the moment it decides to park-and-ship** rather than
+fix. This extension raises that bar. It is **additive** — it adds a calibration check on top
+of the existing Step 2.5 demotion and Loop Exit conclude behavior; it overrides nothing, and it
+is review-and-fix-only on purpose (standalone `/devflow:review` already catches these, which is
+the very asymmetry the recurrence exposes).
+
+## The recurring under-grade — three concrete shapes (treat as Important, do not park)
+
+Before you park ANY finding as advisory / Suggestion (Step 2.5 demotion, or the
+Suggestion/Minor-only conclude path in Step 2), and before you let the loop converge on an
+APPROVE-family verdict, check each surviving-but-parked finding against these three shapes drawn
+from this repo's own re-review history. A finding matching any of them is **Important, not
+advisory** — route it to Step 2.5 → Step 3 (fix it, or push it back through the structured
+`skip_category` flow with evidence), do **not** park it and conclude:
+
+1. **Fail-open guard / coverage hole in code or spec this PR itself added.** A guard, tripwire,
+   coverage-invariant, or contract clause whose comparand can be absent, keyed on the wrong
+   signal, or under-specified vs. the issue's acceptance criteria — so it *asserts* an invariant
+   but passes on the inputs it was added to catch (the `unverified-assumption` class in
+   `CLAUDE.md`). This is what PR 62's standalone re-review flagged Critical (the roster tripwire
+   keyed on the wrong signal; the AWUSF re-review contract left fail-open holes) after the in-loop
+   shadow reported clean. A new guard in this PR's own diff is **in-scope by definition** — never
+   park it as "pre-existing" or "future polish."
+
+2. **A breadcrumb / error message that overclaims relative to the path that emits it.** A
+   diagnostic that states a precondition the emitting path does not actually guarantee (e.g. a
+   zero-record breadcrumb that says "from non-empty content" on a transport that has no non-empty
+   precondition), so a real input fails loud with a *misdirected* message — the misleading-breadcrumb
+   bug class `CLAUDE.md` holds best-effort parsers to. PR 104 shipped exactly this parked as a
+   non-blocking advisory after **both** Devflow Review passes flagged it (one Important). If both
+   the engine pass and the shadow name a breadcrumb/error-accuracy finding, that corroboration
+   alone disqualifies it from advisory parking.
+
+3. **A deferral the gate will not actually honor, or named-but-unreconciled prose/code drift.**
+   Do not record a finding as a Scope-Acknowledged deferral (and do not let the workpad/reflection
+   claim it "stays deferred") unless the deferral would actually be **honored** by
+   `/devflow:review`'s Phase 4.0 matcher: in this repo the PR author (`The01Geek`) is **not** in
+   `devflow.allowed_bots`, so every deferral filed on such a PR is rejected `untrusted-filer` and
+   is **inert** — the finding flows through at full severity. A reflection that presents an inert
+   deferral as honored is a false convergence signal. Before parking anything as "deferred,"
+   confirm the author is a trusted filer; if not, the finding is **not deferrable here** — fix it
+   or push it back, and never let the reflection assert it was honored.
+
+## Conclude-gate: the parked list must survive its own re-read
+
+When the loop is about to exit on any APPROVE-family verdict (`APPROVE`,
+`APPROVE WITH ADVISORY NOTES`, `APPROVE WITH CAVEAT`, `APPROVE WITH UNRESOLVED SHADOW FINDINGS`),
+re-read every parked advisory / Suggestion finding (from `fix_decisions` rows whose
+`skip_category` is `advisory-parked`, plus any Suggestion/Minor not actioned) against the three
+shapes above **and** against the shadow pass's own findings. If any parked finding matches a
+shape, or the shadow re-raised it at any severity, it is **mis-graded**: re-route it through
+Step 2.5 → Step 3 within the remaining iteration budget rather than concluding. Only when no
+parked finding matches may the loop conclude. Record the conclude-gate outcome as an explicit
+`## Devflow Reflection` bullet naming each re-graded finding (or stating "conclude-gate clean:
+no parked finding matched a known under-grade shape") — written as evidence you ran the check,
+never as a bare assertion.
+
+## Honest-verdict guardrail
+
+Do not let chat output or the workpad reflection describe the in-loop shadow as having
+"converged with" or "matching" a standalone `/devflow:review`. The shadow **narrows** the gap to
+a standalone pass; it does not close it (these recurrences are the proof). State coverage exactly
+as the `{shadow status}` template prescribes — and when a finding was re-graded by the
+conclude-gate above, say so plainly rather than presenting the run as having been clean all along.


### PR DESCRIPTION
## Pattern
lenient-verdict · first seen 2026-05-27 · last seen 2026-06-26 · 3 occurrences · status: open

## Motivating PRs
- #62 — Harden the shadow review pass: defend coverage invariants the in-loop shadow itself missed (follow-up to #57)
- #104 — fix: harden scan.sh retrospectives.jsonl decode against silent collapse
- #133 — Teach retrospective Stage B to use prompt extensions as an intervention surface

## Root cause (re-derived from primary sources)
Across all three PRs the in-loop `/devflow:review-and-fix` pass concluded with an APPROVE-family verdict after **parking a substantive finding as a Suggestion / advisory non-blocking note**, and a later standalone `/devflow:review` (or a re-review on the same PR) re-raised that exact point at **Important or Critical** — forcing human follow-up commits the loop should have made. PR #62's primary sources show this most sharply: the review_verdicts carry a REJECT (Critical) at 2026-05-27T00:55:37Z after two prior APPROVEs, and the human post-bot diff is the human re-keying the roster tripwire to `phase3_dispatched` and closing the AWUSF re-review contract's fail-open holes — i.e. the in-loop shadow had reported clean on a guard that asserted an invariant but read the wrong signal. PR #104's reflections explicitly park the `_decode_existing` zero-record breadcrumb (which overclaims "from non-empty content" on the `download_url` transport that has no such precondition) as a non-blocking advisory **even though both Devflow Review passes flagged it, one as Important**. PR #133's adjacent failure is a deferral-contract one: a Scope-Acknowledged deferral for the `config.schema.json` canonical-list drift was claimed honored in the workpad/reflection, but both standalone reviews rejected it `untrusted-filer` (author `The01Geek` is not in `devflow.allowed_bots`) — the deferral was inert, masking that the gate never honored it. The common mechanism is **the loop's own severity self-grading at the park-and-ship decision being systematically too lenient** — not a defect in the shadow/coverage machinery, which is already extensive.

This is a coarse-category grab-bag. The dominant, most-occurring sub-pattern (under-grading a finding the loop should have fixed) is fixed here. Two adjacent sub-patterns under `lenient-verdict` are **not** addressed by this PR: (a) the asymmetric test matrices noted in PR #104 (download_url empty/whitespace-body and unparseable-JSON shapes had no pinning test); (b) rot-prone positional cross-references / under-counting header comments in test blocks. Those are test-coverage and comment-hygiene fixes, not verdict-calibration, and a future run that re-flags them is expected.

Divergence from the retrospective summaries: none material — the descriptors are corroborated by the primary sources (PR #62's human post-bot diff and the parked-advisory reflections in #104/#133). The one nuance the raw summaries undersell is that the shadow/coverage *machinery* was already hardened (PR #62 itself); the residual gap is the human-judgment severity grade at parking time, which is why the fix targets calibration, not more machinery.

## Proposed change
One file, additive, in-scope (not on `lib/check-excluded-path.sh`'s exclusion list — verified `rc=1`):

- **`.devflow/prompt-extensions/review-and-fix.md`** (new) — a consumer-local prompt extension appended verbatim to the `/devflow:review-and-fix` prompt by `scripts/load-prompt-extension.sh review-and-fix` (route confirmed live: `skills/review-and-fix/SKILL.md` invokes the loader, and the loader now emits this file, exit 0). It (1) names the three concrete under-grade shapes from this repo's re-review history — fail-open guard/coverage holes in the PR's own diff, overclaiming breadcrumbs/error messages, and inert/unhonored deferrals — and rules that a parked finding matching any of them is Important (route to fix), not advisory; (2) adds a conclude-gate that re-reads every parked advisory/Suggestion finding against those shapes and the shadow's own findings before the loop may exit on an APPROVE-family verdict, recording the outcome as an explicit reflection bullet; (3) restates the honest-verdict guardrail (the shadow narrows, never closes, the gap to a standalone review).

## Conflict check
No conflict — this strengthens existing behavior rather than adding a contradicting rule. Step 2.5 already demotes findings to advisory and Step 2 already parks Suggestion/Minor; this extension constrains *which* findings may be parked, layering on top without overriding any existing prose (a prompt extension is append-only by construction). It is consistent with `CLAUDE.md`'s `unverified-assumption` and misleading-breadcrumb gotchas and with the existing "Calibration: shadow agreed is not nothing left to find" section in the skill. It also aligns with the shadow≠standalone honesty guardrail already in the marketing/positioning conventions. Routing as a prompt extension (rather than editing the excluded `skills/review-and-fix/SKILL.md` body or filing a meta-issue) is correct because the fix is purely additive and review-and-fix-only: it must *not* reach `/devflow:review`, which already grades these correctly — that asymmetry is the pattern itself.

## Counterfactual analysis
Applied too broadly, a severity-raising rule risks turning genuinely-minor nits into fix-loop churn or spurious non-convergence. Three scopings bound that: the rule fires only on findings matching three *specific* shapes (not "treat every Suggestion as Important"), each tied to a documented bug class with a concrete prior occurrence, so an ordinary style/polish Suggestion is untouched and still parks. The conclude-gate re-routes a mis-graded finding through the existing Step 2.5 → Step 3 flow with its structured `skip_category` pushback — so a finding the loop genuinely cannot fix can still be pushed back with evidence rather than forced, and the existing `$MAX_ITERS` cap plus the "same `(source_file, claim_text)` skipped twice → escalate" rule prevent spin. And because the extension is consumer-local to this repo, a mis-tuned shape only affects DevFlow's own dogfooding runs, not adopters, until promoted upstream.

## Blast radius
One new file under `.devflow/prompt-extensions/` (consumer-owned, upgrade-safe; marketplace updates never touch it). Affects only `/devflow:review-and-fix` runs **in this repo** — the loader returns the no-op empty path for any consumer that has not committed this file, so adopters are unaffected. No engine, agent, lib, script, workflow, or config change; no test or CI surface touched. Process impact: the loop now spends slightly more on re-routing mis-graded findings (bounded by the existing iteration cap) in exchange for fewer human follow-up commits after conclusion.

Fixes pattern: lenient-verdict