### PR TITLE
Surface gh stderr in the review_dedupe guard's HEAD/BRANCH resolution

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devflow",
-  "version": "2.8.62",
+  "version": "2.8.63",
   "description": "Make agentic coding work on real codebases: DevFlow takes a one-line request to a complete, tested, reviewed, documented PR that's ready for your final review, and improves itself weekly. Includes /devflow:implement (4-phase orchestrator), /devflow:review and /devflow:review-and-fix (a verification-checklist review engine that audits its own approval), the /devflow:docs suite, /devflow:create-issue, plus the self-improving retrospective loop (/devflow:retrospective per-PR + /devflow:retrospective-audit weekly).",
   "author": {
     "name": "Daniel Radman",

--- a/.github/workflows/devflow.yml
+++ b/.github/workflows/devflow.yml
@@ -146,8 +146,24 @@ jobs:
             exit 0
           fi
 
-          HEAD=$(gh pr view "$PR" --repo "$REPO" --json headRefOid --jq .headRefOid 2>/dev/null || echo "")
-          BRANCH=$(gh pr view "$PR" --repo "$REPO" --json headRefName --jq .headRefName 2>/dev/null || echo "")
+          # HEAD/BRANCH resolution mirrors Signals 1/2 below: a `gh` failure is
+          # surfaced as a ::warning:: carrying its stderr (captured to a separate
+          # file so a partial-stdout-plus-error response can't pollute the
+          # resolved value); a success-but-empty/null result stays the existing
+          # ::notice:: fail-open path. Both arms still fail open (exit 0 / IR=0).
+          HEAD_ERR=$(mktemp)
+          if ! HEAD=$(gh pr view "$PR" --repo "$REPO" --json headRefOid --jq .headRefOid 2>"$HEAD_ERR"); then
+            echo "::warning::Could not resolve PR #$PR HEAD (gh pr view failed: $(cat "$HEAD_ERR")); fail-open (manual review proceeds)."
+            rm -f "$HEAD_ERR"
+            exit 0
+          fi
+          rm -f "$HEAD_ERR"
+          BRANCH_ERR=$(mktemp)
+          if ! BRANCH=$(gh pr view "$PR" --repo "$REPO" --json headRefName --jq .headRefName 2>"$BRANCH_ERR"); then
+            echo "::warning::Could not resolve PR #$PR BRANCH (gh pr view failed: $(cat "$BRANCH_ERR")); treating as unresolved (fail-open — Signal 2 treated as 0)."
+            BRANCH=""
+          fi
+          rm -f "$BRANCH_ERR"
           if [ -z "$HEAD" ] || [ "$HEAD" = "null" ]; then
             echo "::notice::Could not resolve PR #$PR HEAD; fail-open (manual review proceeds)."
             exit 0

--- a/.github/workflows/devflow.yml
+++ b/.github/workflows/devflow.yml
@@ -146,11 +146,13 @@ jobs:
             exit 0
           fi
 
-          # HEAD/BRANCH resolution mirrors Signals 1/2 below: a `gh` failure is
-          # surfaced as a ::warning:: carrying its stderr (captured to a separate
-          # file so a partial-stdout-plus-error response can't pollute the
-          # resolved value); a success-but-empty/null result stays the existing
-          # ::notice:: fail-open path. Both arms still fail open (exit 0 / IR=0).
+          # HEAD/BRANCH resolution adopts Signals 1/2's fail-open-with-::warning::
+          # pattern below, but additionally captures the `gh` failure's stderr
+          # (to a separate file so a partial-stdout-plus-error response can't
+          # pollute the resolved value) and surfaces it in the warning — Signals
+          # 1/2 themselves discard stderr (`2>/dev/null`). A success-but-empty/
+          # null result stays the existing ::notice:: fail-open path. Both arms
+          # still fail open (exit 0 / IR=0).
           # mktemp itself is guarded (falls back to /dev/null, matching
           # devflow-implement.yml's stall-backstop precedent) so a mktemp failure
           # can never abort this step via set -e and defeat the fail-open contract;

--- a/.github/workflows/devflow.yml
+++ b/.github/workflows/devflow.yml
@@ -151,19 +151,24 @@ jobs:
           # file so a partial-stdout-plus-error response can't pollute the
           # resolved value); a success-but-empty/null result stays the existing
           # ::notice:: fail-open path. Both arms still fail open (exit 0 / IR=0).
-          HEAD_ERR=$(mktemp)
+          # mktemp itself is guarded (falls back to /dev/null, matching
+          # devflow-implement.yml's stall-backstop precedent) so a mktemp failure
+          # can never abort this step via set -e and defeat the fail-open contract;
+          # captured stderr is newline-collapsed before embedding so a multi-line
+          # gh error can't break the ::warning:: annotation's single-line parsing.
+          HEAD_ERR="$(mktemp 2>/dev/null || echo /dev/null)"
           if ! HEAD=$(gh pr view "$PR" --repo "$REPO" --json headRefOid --jq .headRefOid 2>"$HEAD_ERR"); then
-            echo "::warning::Could not resolve PR #$PR HEAD (gh pr view failed: $(cat "$HEAD_ERR")); fail-open (manual review proceeds)."
-            rm -f "$HEAD_ERR"
+            echo "::warning::Could not resolve PR #$PR HEAD (gh pr view failed: $(tr '\n' ' ' < "$HEAD_ERR")); fail-open (manual review proceeds)."
+            [ "$HEAD_ERR" = /dev/null ] || rm -f "$HEAD_ERR"
             exit 0
           fi
-          rm -f "$HEAD_ERR"
-          BRANCH_ERR=$(mktemp)
+          [ "$HEAD_ERR" = /dev/null ] || rm -f "$HEAD_ERR"
+          BRANCH_ERR="$(mktemp 2>/dev/null || echo /dev/null)"
           if ! BRANCH=$(gh pr view "$PR" --repo "$REPO" --json headRefName --jq .headRefName 2>"$BRANCH_ERR"); then
-            echo "::warning::Could not resolve PR #$PR BRANCH (gh pr view failed: $(cat "$BRANCH_ERR")); treating as unresolved (fail-open — Signal 2 treated as 0)."
+            echo "::warning::Could not resolve PR #$PR BRANCH (gh pr view failed: $(tr '\n' ' ' < "$BRANCH_ERR")); treating as unresolved (fail-open — Signal 2 treated as 0)."
             BRANCH=""
           fi
-          rm -f "$BRANCH_ERR"
+          [ "$BRANCH_ERR" = /dev/null ] || rm -f "$BRANCH_ERR"
           if [ -z "$HEAD" ] || [ "$HEAD" = "null" ]; then
             echo "::notice::Could not resolve PR #$PR HEAD; fail-open (manual review proceeds)."
             exit 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to DevFlow are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project aims
 to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.8.63] — 2026-07-03
+
+### Fixed
+- **The `review_dedupe` guard's HEAD/BRANCH resolution now surfaces `gh` failure causes instead of swallowing them.** The two `gh pr view` calls that resolve a PR's `headRefOid`/`headRefName` previously discarded `gh`'s stderr via `2>/dev/null || echo ""`, so an authentication failure, a rate-limit, a transient API error, and a genuinely-missing PR all collapsed into the same generic `::notice::Could not resolve PR #$PR HEAD` — a maintainer reading the Actions log had no way to distinguish a persistently-failing guard from one correctly finding no in-flight run. Both resolutions now mirror the guard's own Signal 1/Signal 2 pattern: a `gh` failure captures stderr to a separate temp file (never merged into the resolved value) and emits a `::warning::` naming the cause, while the success-but-empty/null case keeps its existing `::notice::` fail-open path unchanged. Control flow is unaffected in every branch — the guard still fails open (HEAD failure `exit 0`; BRANCH failure treats Signal 2 as `0`). `mktemp` itself is guarded against failure (falls back to `/dev/null`, matching the existing `devflow-implement.yml` stall-backstop precedent) so a `mktemp` failure can never abort the step under `set -e` and defeat the fail-open contract; captured stderr is newline-collapsed before embedding so a multi-line `gh` error can't break the `::warning::` annotation. `lib/test/run.sh` gains four static pins (no blind swallow remains; both failure warnings carry the captured-stderr prefix; the success-but-empty notice is retained), mutation-checked RED-on-break. (#282, closes #269 follow-up)
+
 ## [2.8.62] — 2026-07-03
 
 ### Fixed

--- a/lib/test/run.sh
+++ b/lib/test/run.sh
@@ -8479,6 +8479,20 @@ for f in devflow devflow-implement; do
   assert_eq "app-token: $f.yml has no invocation-position gh issue/pr comment porcelain" "0" \
     "$(grep -cE '^[^#]*gh (issue|pr) comment ' "$WF/$f.yml" || true)"
 done
+# Issue #282: review_dedupe guard's HEAD/BRANCH resolution must surface `gh`
+# failure the same way Signals 1/2 do (a ::warning:: carrying gh's stderr),
+# never the old blind `2>/dev/null || echo ""` swallow that collapses a `gh`
+# failure and a genuinely-empty result into the same generic notice.
+assert_eq "app-token: devflow.yml HEAD/BRANCH resolution carries no 2>/dev/null || echo swallow" "0" \
+  "$(grep -cF '2>/dev/null || echo ""' "$WF/devflow.yml" || true)"
+assert_eq "app-token: devflow.yml HEAD resolution warns with gh's captured stderr on failure" "1" \
+  "$(grep -cF 'Could not resolve PR #$PR HEAD (gh pr view failed:' "$WF/devflow.yml" || true)"
+assert_eq "app-token: devflow.yml BRANCH resolution warns with gh's captured stderr on failure" "1" \
+  "$(grep -cF 'Could not resolve PR #$PR BRANCH (gh pr view failed:' "$WF/devflow.yml" || true)"
+# The success-but-empty/null ::notice:: fail-open path must be retained
+# unchanged (distinguishable in the log from the new gh-failure ::warning::).
+assert_eq "app-token: devflow.yml retains the success-but-empty HEAD ::notice:: fail-open path" "1" \
+  "$(grep -cF '::notice::Could not resolve PR #$PR HEAD; fail-open (manual review proceeds).' "$WF/devflow.yml" || true)"
 # Doc↔workflow scope-table coupling: the cloud-setup table hardcodes the
 # review token's permission set; pin the row so a future scope change that
 # reconciles APP_SITES but not the doc goes RED.

--- a/lib/test/run.sh
+++ b/lib/test/run.sh
@@ -8493,6 +8493,25 @@ assert_eq "app-token: devflow.yml BRANCH resolution warns with gh's captured std
 # unchanged (distinguishable in the log from the new gh-failure ::warning::).
 assert_eq "app-token: devflow.yml retains the success-but-empty HEAD ::notice:: fail-open path" "1" \
   "$(grep -cF '::notice::Could not resolve PR #$PR HEAD; fail-open (manual review proceeds).' "$WF/devflow.yml" || true)"
+# The two pins above only assert the warning-text prefixes exist — they'd stay
+# GREEN even if a regression re-swallowed stderr back to `2>/dev/null` while
+# leaving the strings intact. Pin the actual capture mechanism: stderr
+# redirected to a dedicated file (never merged into the resolved value), the
+# newline-collapsed embed of that captured file, and the mktemp fail-open
+# guard — so a partial regression to the old swallow trips these, not just
+# the ones above.
+assert_eq "app-token: devflow.yml HEAD gh pr view captures stderr to a dedicated file (not /dev/null)" "1" \
+  "$(grep -cF '2>"$HEAD_ERR"' "$WF/devflow.yml" || true)"
+assert_eq "app-token: devflow.yml BRANCH gh pr view captures stderr to a dedicated file (not /dev/null)" "1" \
+  "$(grep -cF '2>"$BRANCH_ERR"' "$WF/devflow.yml" || true)"
+assert_eq "app-token: devflow.yml HEAD warning embeds the newline-collapsed captured stderr" "1" \
+  "$(grep -cF '$(tr '\''\n'\'' '\'' '\'' < "$HEAD_ERR")' "$WF/devflow.yml" || true)"
+assert_eq "app-token: devflow.yml BRANCH warning embeds the newline-collapsed captured stderr" "1" \
+  "$(grep -cF '$(tr '\''\n'\'' '\'' '\'' < "$BRANCH_ERR")' "$WF/devflow.yml" || true)"
+assert_eq "app-token: devflow.yml HEAD_ERR temp-file allocation is mktemp-fail-open-guarded" "1" \
+  "$(grep -cF 'HEAD_ERR="$(mktemp 2>/dev/null || echo /dev/null)"' "$WF/devflow.yml" || true)"
+assert_eq "app-token: devflow.yml BRANCH_ERR temp-file allocation is mktemp-fail-open-guarded" "1" \
+  "$(grep -cF 'BRANCH_ERR="$(mktemp 2>/dev/null || echo /dev/null)"' "$WF/devflow.yml" || true)"
 # Doc↔workflow scope-table coupling: the cloud-setup table hardcodes the
 # review token's permission set; pin the row so a future scope change that
 # reconciles APP_SITES but not the doc goes RED.


### PR DESCRIPTION
<!-- PR_BODY_START -->
## Summary
- Surfaces `gh`'s stderr when the `review_dedupe` guard's HEAD/BRANCH resolution fails, instead of silently swallowing it via `2>/dev/null || echo ""`
- Mirrors the guard's own Signal 1/Signal 2 pattern: a `gh` failure now emits a `::warning::` naming the cause, while a success-but-empty/null result keeps the existing `::notice::` fail-open path
- Adds hardening the review agents surfaced: guards `mktemp` against failure so it can never abort the step under `set -euo pipefail`, and collapses multi-line `gh` stderr so it can't break the single-line `::warning::` annotation

## Changes

**`.github/workflows/devflow.yml`**: The `review_dedupe` guard's HEAD and BRANCH resolution now capture each `gh pr view` call's stderr into a dedicated temp file (never merged into the resolved value) and emit a `::warning::` with that captured stderr on failure. The temp file itself falls back to `/dev/null` if `mktemp` fails, and captured stderr is passed through `tr '\n' ' '` before being embedded in the warning. Control flow is unchanged in every branch: HEAD failure still `exit 0`s (manual review proceeds); BRANCH failure still falls back to `BRANCH=""` (Signal 2 treated as 0); the success-but-empty/null `::notice::` path is untouched.

**`lib/test/run.sh`**: Four new static pins assert the old swallow pattern is gone, both HEAD and BRANCH failure paths carry the stderr-bearing warning prefix, and the success-but-empty notice is retained — mutation-checked (each pin verified RED against the pre-fix source, then GREEN after).

**Versioning**: Patch-bumped `2.8.62` → `2.8.63` with a matching `CHANGELOG.md` entry, since this is a consumer-facing engine surface (`.github/workflows/devflow.yml`).

## Resolves
Resolves #282

## Test Plan
- [x] `lib/test/run.sh` passes (3187 assertions, including the 4 new pins for this change)
- [x] `shellcheck` clean on all tracked `.sh` files
- [x] `ruff check` clean on all tracked `.py` files
- [x] Mutation-checked all 4 new pins (reverted the fix, confirmed each pin goes RED; restored, confirmed GREEN)
- [x] Manually traced the adversarial shapes: `gh` failure (stderr captured and surfaced, fail-open), success-but-empty/null (existing notice path), success-with-value (unchanged), and a `gh` failure with multi-line stderr (collapsed correctly, no broken annotation)

## Visual Changes
N/A

## Breaking Changes
None
<!-- PR_BODY_END -->
