### PR TITLE
fix(ci): push the version bump with a DevFlow App token (completes #294 AC2/AC3)

### DIFF
--- a/.github/workflows/version-consolidate.yml
+++ b/.github/workflows/version-consolidate.yml
@@ -37,10 +37,29 @@ jobs:
     # below; this `if` just avoids even booting the runner for the bump commit's own push.)
     if: "${{ !startsWith(github.event.head_commit.message, 'chore: bump version') }}"
     steps:
+      # Mint a DevFlow App installation token to push the bump commit. The default
+      # GITHUB_TOKEN cannot bypass main's required-checks ruleset (GitHub rejects the
+      # first-party github-actions app as a bypass actor — "must be part of the ruleset
+      # source or owner organization"), so a direct `git push origin HEAD:main` with it is
+      # declined (GH013). The DevFlow App IS a valid org integration and is added to the
+      # ruleset's bypass list, so its token's push is exempt. Same app-id/private-key pair
+      # the other DevFlow cloud workflows mint from. (#294 post-merge follow-up.)
+      - name: Mint DevFlow App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.DEVFLOW_APP_ID }}
+          private-key: ${{ secrets.DEVFLOW_APP_PRIVATE_KEY }}
+          permission-contents: write
+
       - uses: actions/checkout@v6
         with:
           # Fetch enough history that the commit lands on a real main tip.
           fetch-depth: 0
+          # Persist the App token as the git remote credential so the consolidate step's
+          # `git push origin HEAD:main` authenticates as the DevFlow App (the bypass actor),
+          # not the default GITHUB_TOKEN.
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/lib/test/run.sh
+++ b/lib/test/run.sh
@@ -12145,8 +12145,10 @@ assert_pin_unique "#290 workflow triggers on push to main" \
   'branches: [main]' "$CS_WF"
 assert_pin_unique "#290 workflow runs the consolidator by path" \
   'python3 scripts/consolidate-changesets.py' "$CS_WF"
+# Anchor on the 2-space-indented workflow-permissions line so this stays unique after the
+# app-token step added `permission-contents: write` (which also contains `contents: write`).
 assert_pin_unique "#290 workflow grants contents: write for the bump push" \
-  'contents: write' "$CS_WF"
+  '  contents: write' "$CS_WF"
 # Self-trigger loop guard: the job skips its own `chore: bump version` head commit.
 assert_pin_unique "#290 workflow guards against its own bump commit re-triggering (no loop)" \
   "startsWith(github.event.head_commit.message, 'chore: bump version')" "$CS_WF"


### PR DESCRIPTION
## Summary
- Post-merge follow-up to #294. The `version-consolidate` workflow pushed the `chore: bump version` commit with the default `GITHUB_TOKEN`, which **cannot bypass `main`'s required-checks ruleset** — so the bump commit is rejected (`GH013`) and never lands (verified live: run 28695254343 failed all 5 push attempts; `main` still at 2.8.68 with the #290 changeset pending).
- GitHub refuses to add the first-party `github-actions` app as a ruleset bypass actor (`422: must be part of the ruleset source or owner organization`), so the default token can't be exempted. This mints a **DevFlow App installation token** (the same `vars.DEVFLOW_APP_ID` / `secrets.DEVFLOW_APP_PRIVATE_KEY` pair the other cloud workflows use) and pushes with it.

## Changes
**`.github/workflows/version-consolidate.yml`**: add an `actions/create-github-app-token@v3` step (`permission-contents: write`) and pass its token to `actions/checkout` so the consolidate step's `git push origin HEAD:main` authenticates as the DevFlow App (the bypass actor), not the default token.
**`lib/test/run.sh`**: repoint the `#290` `contents: write` pin to the 2-space-indented workflow-permissions line — the new `permission-contents: write` input also contains the substring, which would break `assert_pin_unique`.

## Resolves
Completes the AC2/AC3 activation of #294 (no new issue).

## Test Plan
- [ ] `lib/test/run.sh` passes (the repointed `#290` pins resolve) — verified locally: 3327 passed, 0 failed.
- [ ] Workflow YAML parses / actionlint clean.

## Post-Merge Verification
- [ ] The **DevFlow App** is added to the `main-protected` ruleset bypass list (maintainer action, UI or API).
- [ ] After merge, the `version-consolidate` run pushes the `chore: bump version` commit to `main` (→ `plugin.json` at 2.8.69, the pending changeset consumed), confirming AC2/AC3.

## Breaking Changes
None. Internal CI/release-automation only; no `.changeset/*.md` added.