### PR TITLE
revert: restore repo-root marketplace.json (fixes red CI on main)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,14 +1,14 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "devflow-marketplace",
-  "description": "Local marketplace for the vendored DevFlow plugin (.devflow/vendor/devflow). Installed by devflow-autopilot/install.sh.",
+  "description": "DevFlow makes agentic coding work on real codebases, a one-line request becomes a complete, tested, reviewed, documented PR that's ready for your final review, and it improves itself weekly. Includes /devflow:implement orchestrator, /devflow:review + /devflow:review-and-fix engines (which audit their own approval), the /devflow:docs suite, /devflow:create-issue, plus a self-improving retrospective loop.",
   "owner": { "name": "Daniel Radman", "email": "daniel@radman.ai" },
-  "allowCrossMarketplaceDependenciesOn": ["claude-plugins-official"],
+  "allowCrossMarketplaceDependenciesOn": [],
   "plugins": [
     {
       "name": "devflow",
-      "source": "./.devflow/vendor/devflow",
-      "description": "End-to-end dev workflow: /devflow:implement, /devflow:review + /devflow:review-and-fix, the /devflow:docs suite, /devflow:create-issue, plus the retrospective loop.",
+      "source": "./",
+      "description": "Make agentic coding work on real codebases, a one-line request becomes a complete, tested, reviewed, documented PR that's ready for your final review, and DevFlow improves itself weekly. /devflow:implement orchestrator, /devflow:review + /devflow:review-and-fix engines (which audit their own approval), the /devflow:docs suite, /devflow:create-issue, plus the per-PR + weekly retrospective loop.",
       "author": { "name": "Daniel Radman", "email": "daniel@radman.ai" },
       "homepage": "https://github.com/The01Geek/devflow-autopilot",
       "category": "development"


### PR DESCRIPTION
## Summary
Reverts the `.claude-plugin/marketplace.json` half of 1d84d2b, which copied `install.sh`'s stale pre-#142 consumer template over the repo-root manifest and turned main's CI red (the `#142 marketplace.json allowCrossMarketplaceDependenciesOn is now empty` pin in `lib/test/run.sh`).

## Why the revert is the correct side
- `allowCrossMarketplaceDependenciesOn` is functionally inert for DevFlow: `plugin.json` declares `"dependencies": []` since #142 internalized every companion plugin (superpowers skills, feature-dev agents, pr-review-toolkit agents — all first-party under `skills/`/`agents/` with licenses in `LICENSES/`).
- The cloud workflows install `code-review@claude-plugins-official` etc. via explicit action inputs, not marketplace dependency resolution, so the allowlist plays no role there either.
- 1d84d2b also pointed `source` at `./.devflow/vendor/devflow`, which has **zero tracked files** in this repo — breaking the "repo is its own marketplace" contract. Restored to `./`.
- The unrelated `.devflow/config.json` change from 1d84d2b is **kept**.

## Verification
Full local suite: **4133 passed, 0 failed** (`lib/test/run.sh`).

## Follow-up (not in this PR)
`install.sh`'s embedded consumer-marketplace heredoc still writes the stale `["claude-plugins-official"]` allowlist into consumer repos — the pre-#142 leftover that caused this confusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)