### PR TITLE
config: route /devflow:implement through OpenRouter (GLM-5.2)

### DIFF
--- a/.devflow/config.json
+++ b/.devflow/config.json
@@ -2,6 +2,19 @@
   "$schema": "./config.schema.json",
   "base_branch": "main",
   "claude_model": "claude-opus-4-8",
+  "providers": {
+    "openrouter": {
+      "base_url": "https://openrouter.ai/api",
+      "auth": "bearer",
+      "timeout_ms": 3000000,
+      "env": {
+        "ANTHROPIC_DEFAULT_HAIKU_MODEL": "z-ai/glm-5.2",
+        "CLAUDE_CODE_SUBAGENT_MODEL": "z-ai/glm-5.2",
+        "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1",
+        "CLAUDE_CODE_ATTRIBUTION_HEADER": "0"
+      }
+    }
+  },
   "devflow_version": "main",
   "devflow": {
     "allowed_bots": "claude,dependabot,devflow-autopilot",
@@ -18,6 +31,8 @@
     "execution_transcript_artifact_enabled": true
   },
   "devflow_implement": {
+    "provider": "openrouter",
+    "claude_model": "z-ai/glm-5.2",
     "effort": "medium",
     "implement_pr_state": "ready_for_review",
     "allowed_tools": [


### PR DESCRIPTION
## What

Routes this repo's cloud **`/devflow:implement`** through **OpenRouter** (GLM-5.2), using the opt-in third-party provider support shipped in #315.

- Adds a top-level `providers.openrouter` entry — Anthropic-compatible **bearer** gateway, `base_url: https://openrouter.ai/api`, `timeout_ms: 3000000`.
- Points `devflow_implement` at it (`provider: openrouter`, `claude_model: z-ai/glm-5.2`).
- All three model slots (main / subagent / haiku) resolve to `z-ai/glm-5.2`.

## What stays on Claude (deliberate)

- **`devflow_runner`** (the merge-gating review judge) — no `provider`, stays on Claude. Keeps review quality and the frozen judge economics intact.
- **`devflow`** (light `/devflow:*` command path) — no `provider`, stays on Claude.

## Notes

- `effort_supported` omitted → defaults `false`, so `--effort` is dropped for the gateway (gateways 400 on unknown params).
- Requires the `DEVFLOW_PROVIDER_API_KEY` repo secret — **already set**.
- **Config-only** change (not engine surface: `skills/`/`agents/`/`lib/`/`scripts/`/workflows/`config.schema.json`) → **no changeset** per the versioning rule.
- If a real cloud implement run ever throws a `400` naming `thinking`/`adaptive`, add `"CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING": "1"` to the `env` map (separate failure mode from the beta-header toggle already present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
