### PR TITLE
config: revert /devflow:implement to standard Claude (pause OpenRouter)

### DIFF
--- a/.devflow/config.json
+++ b/.devflow/config.json
@@ -31,8 +31,6 @@
     "execution_transcript_artifact_enabled": true
   },
   "devflow_implement": {
-    "provider": "openrouter",
-    "claude_model": "z-ai/glm-5.2",
     "effort": "medium",
     "implement_pr_state": "ready_for_review",
     "allowed_tools": [


### PR DESCRIPTION
## What
Reverts cloud `/devflow:implement` to **standard Anthropic Claude**, pausing the OpenRouter/GLM-5.2 routing added in #492.

- Removes `devflow_implement.provider` (`openrouter`) and `devflow_implement.claude_model` (`z-ai/glm-5.2`).
- Implement now uses the global `claude_model` (`claude-opus-4-8`) via `CLAUDE_CODE_OAUTH_TOKEN`.
- The `providers.openrouter` block is left **dormant** (defined but unreferenced = inactive), so re-enabling is a 2-line add back to `devflow_implement`.

## Why
Pausing to weigh two concerns before investing further:
1. **Is the 200K context cap even a problem?** OpenRouter caps Claude Code's usable context at 200K (structural — the `[1m]` lever is rejected). A `PreCompact` logging hook is planned to measure whether compaction actually fires in real runs before committing to a 1M fix.
2. **Latency.** The OpenRouter endpoint/GLM feels slower than Anthropic-native (the #494 smoke-test run took >1hr). Needs disentangling (gateway vs provider vs model) before it's worth pursuing.

Full option analysis + re-enable recipe live in the local planning doc `.devflow/tmp/openrouter-glm-1m-context-plan.md`.

## Scope
- **Config-only** (not engine surface) → no changeset.
- The local `claude-openrouter` command is untouched (opt-in; used only when explicitly invoked).
- Secret `DEVFLOW_PROVIDER_API_KEY` stays set (harmless while dormant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
