### PR TITLE
fix: restore main — reconcile #467 D2 review-and-fix leg after #539 split

### DIFF
--- a/lib/test/modules/create-issue-contract.sh
+++ b/lib/test/modules/create-issue-contract.sh
@@ -30,7 +30,10 @@ CI_TMPL="$CI_ROOT/skills/create-issue/references/issue-template.md"
 CI_EXT="$CI_ROOT/.devflow/prompt-extensions/create-issue.md"
 CI_OVERVIEW="$CI_ROOT/docs/DEVFLOW_SYSTEM_OVERVIEW.md"
 CI_CLAUDE="$CI_ROOT/CLAUDE.md"
-CI_MAXI_SKILL="$CI_ROOT/skills/review-and-fix/SKILL.md"
+# review-and-fix is a BUNDLE since #530 (thin SKILL.md root + phases in
+# references/*.md); the #467 D2 fix-delta-gate sentence now lives in a reference
+# member, so the leg pins against the assembled CI_MAXI_BUNDLE (built below,
+# after _ci_tmp_root exists) — never the root alone.
 CI_INVENTORY="$CI_ROOT/lib/test/modules/create-issue-contract.inventory.md"
 
 _ci_tmp_root="$(mktemp -d "${TMPDIR:-/tmp}/devflow-create-issue-contract.XXXXXX")" || {
@@ -60,6 +63,25 @@ for _ci_bundle_member in "$CI_ROOT/skills/implement/SKILL.md" "$CI_ROOT"/skills/
     printf '\n' >> "$CI_IMPL_BUNDLE"
   else
     assert_eq "ci module: implement-bundle member usable: $_ci_bundle_member" \
+      "usable" "missing-empty-or-unreadable"
+  fi
+done
+
+# The review-and-fix bundle backs the #467 D2 review-and-fix leg. Since #530 the
+# skill is a thin SKILL.md root plus step references (phases in references/*.md),
+# so the widened fix-delta-gate sentence lives in a reference member, not the
+# root. Assemble root + references member by member with the SAME fail-LOUD-per-
+# member contract as the implement bundle above: a missing/empty/unreadable
+# member records a FAIL naming that member, so a corrupt engine file cannot pass
+# the pin green just because the pinned sentence survives elsewhere.
+CI_MAXI_BUNDLE="$_ci_tmp_root/review-and-fix-skill-bundle.md"
+: > "$CI_MAXI_BUNDLE"
+for _ci_maxi_member in "$CI_ROOT/skills/review-and-fix/SKILL.md" "$CI_ROOT"/skills/review-and-fix/references/*.md; do
+  if [ -r "$_ci_maxi_member" ] && [ -s "$_ci_maxi_member" ]; then
+    cat "$_ci_maxi_member" >> "$CI_MAXI_BUNDLE"
+    printf '\n' >> "$CI_MAXI_BUNDLE"
+  else
+    assert_eq "ci module: review-and-fix-bundle member usable: $_ci_maxi_member" \
       "usable" "missing-empty-or-unreadable"
   fi
 done
@@ -706,7 +728,7 @@ devflow_module_pin_unique "#467 D2 (CLAUDE.md leg): best-effort-parser gotcha wi
 devflow_module_pin_unique "#467 D2 (Phase 2.4 leg): dry-trace rule widened to mutable-markdown/external-format" \
   'The governed surface is broader than config JSON' "$CI_IMPL_BUNDLE"
 devflow_module_pin_unique "#467 D2 (review-and-fix leg): fix-delta matrix widened to mutable-markdown/external-format" \
-  'widens to a parser over agent- or human-mutable markdown and a reader of a new external structured format' "$CI_MAXI_SKILL"
+  'widens to a parser over agent- or human-mutable markdown and a reader of a new external structured format' "$CI_MAXI_BUNDLE"
 devflow_module_pin_unique "#467 D3: extension authoring-discipline dimension demands the input-type-appropriate matrix" \
   'input-type analogue** for the widened surfaces' "$CI_EXT"
 # D3 count guard — the extension's dimension-bullet count is guard-locked. Since issue #548


### PR DESCRIPTION
## Problem

`origin/main` is RED — the required `lib + python tests` CI check fails, which blocks every open PR (they merge main and inherit the failure).

**Failing assertions** (all one root cause):
- `#467 D2 (review-and-fix leg): fix-delta matrix widened to mutable-markdown/external-format` — the `devflow_module_pin_unique` in `lib/test/modules/create-issue-contract.sh` matched its pinned sentence **0** times.
- Cascade: `test_module_runner.py` tests `test_create_issue_contract_module_runs_green_through_the_real_runner`, `test_create_issue_focused_run_fails_closed_on_a_controlled_failure`, and `test_create_issue_module_runs_clean_under_nounset_with_legacy_vars_unset` all failed because the module now reported `205 passed, 1 failed`.

## Root cause

**PR #539 (issue #530), commit `0b1be60c`** — "split review-and-fix into thin root + step references" — moved the fix-delta-gate sentence

> `widens to a parser over agent- or human-mutable markdown and a reader of a new external structured format`

out of `skills/review-and-fix/SKILL.md` and into the new `skills/review-and-fix/references/fix-delta-gate.md`. The `#467 D2 (review-and-fix leg)` pin still targeted `$CI_MAXI_SKILL` (= the root `SKILL.md`), so after #539 merged (and the subsequent `chore: bump version` on `main`) the sentence was no longer in the pinned file — the pin resolved to 0 occurrences and the module went RED.

## Fix

`lib/test/modules/create-issue-contract.sh`:
- Removed the stale `CI_MAXI_SKILL="…/review-and-fix/SKILL.md"` var.
- Added `CI_MAXI_BUNDLE` — assembled from `review-and-fix/SKILL.md` + `references/*.md`, member by member, with the **same fail-LOUD-per-member contract** as the sibling `CI_IMPL_BUNDLE` (a missing/empty/unreadable member records a FAIL naming it, so a corrupt engine file can't pass the pin green just because the sentence survives elsewhere).
- Repointed the `#467 D2 (review-and-fix leg)` pin to `$CI_MAXI_BUNDLE`.

The guard is **preserved, not weakened** — the pinned sentence still occurs exactly once across the bundle, and the pin is now robust to the sentence living in any reference member (mirroring how the implement leg already handles its own SKILL/phases split).

## Verification

- `lib/test/run.sh`: **9334 passed, 0 failed, 1 skipped**. The single skip is the `#434` stale-prose self-scan, which self-skips on a dirty working tree (it grades committed HEAD) and runs live on CI — expected.
- No `.py`/`.sh` outside `lib/test/` touched; tests-only (internal-only) change, so **no changeset** per the versioning convention.

Do not merge without the normal review; this only restores the required check to green.