### PR TITLE
fix(test): pin t15 fixture branch name instead of assuming master

### DIFF
--- a/lib/test/test_prompt_mass_census.py
+++ b/lib/test/test_prompt_mass_census.py
@@ -260,6 +260,9 @@ class PromptMassCensusTests(unittest.TestCase):
         self.write_json("manifest.json", self.manifest(files))
         self.write_json("baseline.json", self.baseline(files))
         self.git("init", "-q")
+        # Pin the unborn branch name: a bare `git init` honors the host's
+        # init.defaultBranch, so the later checkout must not guess it.
+        self.git("checkout", "-qb", "trunk")
         self.git("config", "user.email", "fixture@example.invalid")
         self.git("config", "user.name", "Fixture")
         self.git("add", ".")
@@ -276,7 +279,7 @@ class PromptMassCensusTests(unittest.TestCase):
         self.write_json("baseline.json", self.baseline(files))
         self.git("add", ".")
         self.git("commit", "-qm", "branch b")
-        self.git("checkout", "-q", "master")
+        self.git("checkout", "-q", "trunk")
         merged = self.git("merge", "--no-edit", "branch-b", check=False)
         self.assertEqual(merged.returncode, 0, merged.stderr)
         self.assertEqual(self.run_census().returncode, 0)


### PR DESCRIPTION
## Summary
`test_t15` in `lib/test/test_prompt_mass_census.py` built its git fixture with a bare `git init` and later ran `git checkout -q master`, so the test errored on any machine with `init.defaultBranch=main`. It passed on CI only because GitHub runners still default to `master` — a latent portability bug (reported by a reviewing agent during unrelated PR work).

## Fix
Pin the fixture's unborn branch to a fixed name (`git checkout -qb trunk`) immediately after `git init`, and check out `trunk` by that pinned name later. The branch name is fixture-internal data — nothing under test reads it — so it is pinned in the test, not sourced from config. `checkout -qb` on an unborn HEAD works on every git version, unlike `git init -b` (git 2.28+), matching the repo portability convention.

## Verification
Ran `python3 lib/test/test_prompt_mass_census.py` on a machine with `init.defaultBranch=main`: all 19 tests pass, including t15, which errored before the fix. Test-only change — no changeset needed, and `scripts/devflow-cloud-writer-contract.json` does not pin this file (no regeneration required).

🤖 Generated with [Claude Code](https://claude.com/claude-code)