### PR TITLE
test: harden #720 concurrent-pool coverage + fix stale run.sh comment

### DIFF
--- a/lib/test/module-harness.sh
+++ b/lib/test/module-harness.sh
@@ -1046,7 +1046,16 @@ _devflow_pool_launch_suite() { # name script mode attempt
     printf '  FAIL  pool suite %s — could not allocate private tally\n' "$name" >&2
     return 0
   fi
-  output="$(mktemp "${TMPDIR:-/tmp}/devflow-pool-out.XXXXXX")" || output=/dev/null
+  # A failed output-capture mktemp falls back to /dev/null, which for a self-tally suite
+  # means its `N passed, M failed` summary is never captured — the reap then records a
+  # "#720 ... could not capture its summary line" FAIL that reads like a capture-logic
+  # bug rather than the real cause (output tempfile allocation failed under TMPDIR
+  # exhaustion/quota). Breadcrumb the real cause so that eventual FAIL is actionable
+  # (best-effort: continue with /dev/null; the FAIL is fail-closed over-reporting).
+  if ! output="$(mktemp "${TMPDIR:-/tmp}/devflow-pool-out.XXXXXX")"; then
+    output=/dev/null
+    printf 'devflow-pool: suite %s — output-capture tempfile allocation failed (TMPDIR full/quota?); a self-tally summary will be uncapturable and recorded as a FAIL downstream\n' "$name" >&2
+  fi
   if ! scratch="$(devflow_module_allocate_owned_directory \
     "${TMPDIR:-/tmp}/devflow-module-scratch.XXXXXX")"; then
     printf 'FAIL\n' >> "$RESULTS_FILE"
@@ -1155,8 +1164,9 @@ _devflow_pool_reap() { # pid rc
     # it here would drop the summary and inject a spurious FAIL (issue #720 review).
     if [ -n "$output" ] && [ "$output" != /dev/null ]; then
       : > "$output" 2>/dev/null || :
-    else
-      output="$(mktemp "${TMPDIR:-/tmp}/devflow-pool-out.XXXXXX")" || output=/dev/null
+    elif ! output="$(mktemp "${TMPDIR:-/tmp}/devflow-pool-out.XXXXXX")"; then
+      output=/dev/null
+      printf 'devflow-pool: suite %s — retry output-capture tempfile allocation failed (TMPDIR full/quota?); a self-tally summary will be uncapturable and recorded as a FAIL downstream\n' "$name" >&2
     fi
     _devflow_pool_run_serial "$name" "$script" "$mode" "$tally" "$output"
     rc=$?

--- a/lib/test/run.sh
+++ b/lib/test/run.sh
@@ -50290,6 +50290,34 @@ _POOL720_RDV="$( (
 assert_eq "#720 pool: a forced rendezvous timeout is absorbed by serial retry, tallies unchanged" "2 0" "$_POOL720_RDV"
 assert_eq "#720 pool: the serial-retry path actually RAN for the forced-timeout suite (not a vacuous pass)" "pa" "$(grep -m1 '^pa$' "$_POOL720_RMARK" 2>/dev/null || printf 'no-retry')"
 rm -f "$_POOL720_RMARK"
+# issue #720 review: force the rendezvous timeout on a SELF-TALLY suite (the case above
+# forces it on single-verdict `pa`). The serial-retry's $output-reuse — reap truncating and
+# reusing $output as the retry's capture, and _devflow_pool_run_serial writing the retried
+# suite's combined stdout there — exists SPECIFICALLY so a retried self-tally suite still
+# re-emits its `N passed, M failed` summary line; nulling it would drop the summary and
+# inject a spurious coverage FAIL. Assert BOTH the tally count survives (td = 3 PASS) AND
+# the summary line is recaptured after the retry (the code the single-verdict case cannot
+# exercise, since a single-verdict suite has no summary). A retry MARKER is asserted PRESENT
+# so this cannot pass vacuously if the forced-timeout hook ever regressed to never firing.
+_POOL720_STRMARK="$(mktemp)"
+_POOL720_ST_RDV="$( (
+  export DEVFLOW_TEST_POOL_RETRY_MARKER="$_POOL720_STRMARK" DEVFLOW_POOL_FORCE_RENDEZVOUS_TIMEOUT=td DEVFLOW_POOL_WIDTH=2
+  RESULTS_FILE="$(mktemp)"
+  devflow_pool_open td "$POOL720_FIX/td.py" self-tally pb "$POOL720_FIX/pb.py" single-verdict
+  devflow_pool_join
+  printf 'COUNTS %s %s SUMMARY=%s LINES=%s\n' \
+    "$(grep -c '^PASS$' "$RESULTS_FILE")" "$(grep -c '^FAIL$' "$RESULTS_FILE")" \
+    "${_DEVFLOW_POOL_SELFTALLY_SUMMARY[td]:-MISSING}" "${_DEVFLOW_POOL_SELFTALLY_LINES[td]:-MISSING}"
+  rm -f "$RESULTS_FILE"
+) 2>/dev/null | tail -1 )"
+# td (self-tally, 3 PASS) + pb (single-verdict, 1 PASS) = 4 PASS, 0 FAIL; after the forced
+# timeout on td, its summary ("3 passed, 0 failed") is recaptured and its 3 tally lines are
+# folded into RESULTS_FILE.
+assert_eq "#720 pool: a forced rendezvous timeout on a SELF-TALLY suite re-emits its summary and folds its tally after serial retry" \
+  "COUNTS 4 0 SUMMARY=3 passed, 0 failed LINES=3" "$_POOL720_ST_RDV"
+assert_eq "#720 pool: the serial-retry path actually RAN for the forced-timeout self-tally suite (not a vacuous pass)" \
+  "td" "$(grep -m1 '^td$' "$_POOL720_STRMARK" 2>/dev/null || printf 'no-retry')"
+rm -f "$_POOL720_STRMARK"
 # The pool restores the caller's HUP/INT/TERM traps byte-for-byte and the live-child
 # registry is empty after join (every child deregistered). The pool installs NO EXIT trap
 # of its own — that single-EXIT-trap invariant is pinned structurally by
@@ -50306,7 +50334,7 @@ _POOL720_TRAPS="$( (
 ) 2>/dev/null | tail -1 )"
 assert_eq "#720 pool: caller HUP/INT/TERM traps byte-identical and registry empty after join" "clean" "$_POOL720_TRAPS"
 unset -f _pool720_run
-unset POOL720_FIX _POOL720_CORE _POOL720_W1 _POOL720_W2 _POOL720_CORE_C _POOL720_W1_C _POOL720_W2_C _POOL720_BAD _POOL720_ZERO _POOL720_RDV _POOL720_RMARK _POOL720_TRAPS
+unset POOL720_FIX _POOL720_CORE _POOL720_W1 _POOL720_W2 _POOL720_CORE_C _POOL720_W1_C _POOL720_W2_C _POOL720_BAD _POOL720_ZERO _POOL720_RDV _POOL720_RMARK _POOL720_TRAPS _POOL720_ST_RDV _POOL720_STRMARK
 
 # These integration tests live outside the module whose registration and source
 # boundary they pin, so deleting that boundary cannot delete the test execution.
@@ -52761,12 +52789,13 @@ if ! devflow_tally_is_derivable "$SKIP"; then
   exit 1
 fi
 # PASS and FAIL take the SAME fail-closed guard (#456 round 3): each is a `grep -c` derivation
-# with the same rc>=2 empty-value failure shape. Without the guard an emptied PASS or FAIL is
-# silently coerced to 0 by later arithmetic — the final FAIL-equals-zero exit predicate would
-# abort with a bare `[: -eq` error that names nothing, and a summary over an emptied PASS would
-# render a confident under-count. Unknown is not zero for ANY of the three tallies — refuse
-# loudly, up front. (issue #720 retired the out-of-band `$((PASS + PY_PASS))` python-tally
-# arithmetic this comment once named; test_python_scripts.py now folds through RESULTS_FILE.)
+# with the same rc>=2 empty-value failure shape. Without the guard an emptied FAIL reaches the
+# final FAIL-equals-zero exit predicate, whose `-eq` then aborts on the empty value with a bare
+# `[: -eq` error that names nothing; an emptied PASS is no longer consumed by any arithmetic
+# (issue #720 retired the out-of-band `$((PASS + PY_PASS))` python-tally arithmetic this comment
+# once named — test_python_scripts.py now folds through RESULTS_FILE), so it would instead render
+# a blank, garbled `" passed, N failed"` summary field. Unknown is not zero for ANY of the three
+# tallies — refuse loudly, up front.
 if ! devflow_tally_is_derivable "$PASS"; then
   printf 'ERROR: PASS tally underivable from %s (grep error, not an empty log) — refusing to render a summary over it\n' "$RESULTS_FILE"
   exit 1

--- a/lib/test/test_module_runner.py
+++ b/lib/test/test_module_runner.py
@@ -2020,6 +2020,32 @@ class PoolMembershipCompletenessTests(unittest.TestCase):
         self.assertIn("devflow_pool_open", run_text)
         self.assertIn("devflow_pool_join", run_text)
 
+    def test_pooled_suites_constant_matches_the_run_sh_pool_invocation(self) -> None:
+        # issue #720 review: POOLED_SUITES declares the pool's membership, but the
+        # membership/disjointness checks above pin it only against the FILESYSTEM. That
+        # leaves the removal direction unpinned — dropping a suite from run.sh's real
+        # devflow_pool_open call while leaving it in POOLED_SUITES would pass cleanly, so
+        # a suite could silently stop executing while the completeness guard stayed green.
+        # Pin POOLED_SUITES to the ACTUAL wiring: parse run.sh's real pool invocation —
+        # the triples whose script is a "$LIB/test/test_*.py" path (the fixture opens in
+        # run.sh's #720 test block use "$POOL720_FIX/..." / bare names, so this pattern
+        # excludes them) — and assert the pooled set equals POOLED_SUITES exactly. Now
+        # both drift directions (add-to-run.sh-only, remove-from-run.sh-only) go RED.
+        run_text = (ROOT / "lib/test/run.sh").read_text(encoding="utf-8")
+        triples = re.findall(
+            r'"(test_[A-Za-z0-9_]+\.py)"\s+"\$LIB/test/test_[A-Za-z0-9_]+\.py"\s+'
+            r"(single-verdict|self-tally)",
+            run_text,
+        )
+        pooled_in_run_sh = {name for name, _mode in triples}
+        self.assertEqual(
+            pooled_in_run_sh,
+            set(POOLED_SUITES),
+            "POOLED_SUITES does not match run.sh's real devflow_pool_open invocation "
+            f"(run.sh pools {sorted(pooled_in_run_sh)}, constant declares "
+            f"{sorted(POOLED_SUITES)})",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/lib/test/test_python_scripts.py
+++ b/lib/test/test_python_scripts.py
@@ -88,11 +88,19 @@ def _pool_tally(verdict):
     try:
         with open(_POOL_TALLY_FILE, "a", encoding="utf-8") as _fh:
             _fh.write(verdict + "\n")
-    except OSError:
+    except OSError as _e:
         # Best-effort: a tally-write failure must not abort the suite, but the
         # pool's fail-closed reap (empty/short tally on a non-zero exit) still
-        # catches a suite whose verdicts never landed.
-        pass
+        # catches a suite whose verdicts never landed. Emit a stderr breadcrumb
+        # naming the real cause (the tally path + verdict) so an operator seeing
+        # the downstream "RESULTS_FILE contribution equals summary" mismatch is
+        # pointed at the tally WRITE, not just the symptom — the repo's best-effort
+        # convention (always continue, but leave a breadcrumb; cf. resolve-bin.sh).
+        print(
+            f"devflow-pool: #720 tally write failed for {_POOL_TALLY_FILE!r} "
+            f"(verdict {verdict}): {_e}",
+            file=sys.stderr,
+        )
 
 
 def assert_eq(name, expected, actual):


### PR DESCRIPTION
Follow-up to #733 (issue #720, the bounded concurrent Python-suite pool). **Test-infrastructure only** — every change is under `lib/test/`, nothing reaches consumer repos, so no changeset (per the versioning rule's tests/CI/dev-docs exemption).

These were surfaced by a `/devflow:review-and-fix` pass over #733 *after* it was already approved-with-notes. None fixes a runtime defect (the merged code is correct); they close real coverage/precision gaps a future change could otherwise regress unnoticed.

## Changes

1. **`run.sh` — fix a stale (self-contradicting) guard comment.** The PASS/FAIL derivability-guard comment claimed an emptied `PASS` is "silently coerced to 0 by later arithmetic … render[ing] a confident under-count." #733 deleted the out-of-band `$((PASS + PY_PASS))` arithmetic that made that true, so post-merge **no arithmetic consumes `PASS`** (`devflow_render_test_summary` → `summary.sh` prints it with a bare `%s`). The comment's own parenthetical already admitted the arithmetic was retired. Reworded to the accurate post-#733 failure modes: an emptied `FAIL` aborts the `-eq` exit predicate; an emptied `PASS` renders a blank/garbled summary field.

2. **`run.sh` — add a self-tally forced-rendezvous-timeout test.** The existing forced-timeout test uses a `single-verdict` fixture (`pa`), so the serial-retry `$output`-reuse / summary-recapture code — added *specifically* so a retried **self-tally** suite re-emits its `N passed, M failed` line — was never exercised. New test forces the timeout on a self-tally fixture and asserts both the tally count and the recaptured summary survive. Mutation-checked: nulling the `$output`-reuse → `SUMMARY=MISSING` → RED.

3. **`test_module_runner.py` — pin `POOLED_SUITES` to the real wiring.** `PoolMembershipCompletenessTests` pinned the pooled set only against the filesystem, leaving the **removal direction** unpinned: dropping a suite from `run.sh`'s real `devflow_pool_open` call while leaving it in the constant would pass cleanly, so a suite could silently stop executing while the guard stayed green. New assertion parses `run.sh`'s actual pool invocation (excluding the `#720` test fixtures) and requires equality. Mutation-checked RED in both drift directions.

4. **`module-harness.sh` / `test_python_scripts.py` — best-effort breadcrumbs.** The `output=/dev/null` mktemp fallbacks (both sites) and `_pool_tally`'s `except OSError` swallow now emit a stderr breadcrumb naming the real cause (TMPDIR exhaustion / tally-write failure), so the eventual downstream FAIL is actionable instead of misattributed to "summary capture" — matching the repo's best-effort-plus-breadcrumb convention.

## Verification

- `test_module_runner.py`: 69 tests OK (incl. new pin). `test_python_scripts.py`: 2195/0 standalone (Fix 4 no-op path). `bash -n` clean on both shell files; `ruff` + `shellcheck` clean.
- Both new guards mutation-checked (recorded above).
- Full local `lib/test/run.sh` + lint gate: to be confirmed by CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)