### PR TITLE
fix: reject a dim-key declaration in a non-checklist audit-prompt block (#735)

### DIFF
--- a/.changeset/issue-735-dim-key-non-checklist-block.md
+++ b/.changeset/issue-735-dim-key-non-checklist-block.md
@@ -1,0 +1,13 @@
+---
+bump: patch
+type: Fixed
+---
+
+- **Reject a `<!-- dim-key: … -->` dimension declaration authored outside the checklist
+  block in the create-issue audit-prompt template.** `render-audit-prompt.py` stripped the
+  declaration marker from every rendered block but validated declarations only in the
+  checklist block, so a declaration in a `file`/`embed`/`inline`/`di` block was silently
+  stripped from the auditor-facing prose and never enumerated while its bullet still
+  rendered as a keyless, dimension-shaped instruction. It now fails closed on every render
+  and enumeration path with a breadcrumb naming the block that carries the stray
+  declaration. (#735)

--- a/lib/test/prompt-mass-baseline.json
+++ b/lib/test/prompt-mass-baseline.json
@@ -6,7 +6,7 @@
     ".devflow/prompt-extensions/receiving-code-review.md": 16731,
     ".devflow/prompt-extensions/review-and-fix.md": 27500,
     ".devflow/prompt-extensions/review.md": 6708,
-    "CLAUDE.md": 74508,
+    "CLAUDE.md": 75804,
     "agents/checklist-deduper.md": 5537,
     "agents/checklist-generator.md": 14385,
     "agents/checklist-verifier.md": 6526,

--- a/lib/test/test_render_audit_prompt.py
+++ b/lib/test/test_render_audit_prompt.py
@@ -1308,11 +1308,12 @@ class DeclaredDimensionKeys(unittest.TestCase):
         for r in (rend, enum):
             self.assertNotEqual(r.returncode, 0, r.stdout)
             self.assertEqual(r.stdout, "")
-            # The breadcrumb names the file at fault and the block that carries the
-            # stray declaration, so an operator debugs the right block.
+            # The breadcrumb names the block's arm set, so an operator debugs the
+            # right block. `file` here is that block's arm NAME (`arms: file`), not
+            # a template path — the message carries no path.
             self.assertIn("template malformed", r.stderr)
             self.assertIn("non-checklist render-block", r.stderr)
-            self.assertIn("file", r.stderr)
+            self.assertIn("arms: file", r.stderr)
 
     # ---- Consumer-side declaration defects: symmetric with the generic arm.
     # The consumer extension is the one file in this contract a THIRD PARTY authors,

--- a/lib/test/test_render_audit_prompt.py
+++ b/lib/test/test_render_audit_prompt.py
@@ -1276,6 +1276,44 @@ class DeclaredDimensionKeys(unittest.TestCase):
                               "--template-file", str(p)])
         self.assertEqual(r.returncode, 0, r.stderr)
 
+    def test_a_dim_key_declaration_in_a_non_checklist_block_fails_closed(self):
+        # issue #735: `_assemble` strips `<!-- dim-key: … -->` from EVERY selected
+        # block, but only the checklist block is validated — so a declaration
+        # authored into a file/embed/inline/di block was silently stripped from the
+        # prose AND never enumerated while its bullet still rendered as a
+        # dimension-shaped instruction (the one authoring defect #729's arms miss).
+        # The fix rejects it on every render AND enumeration path, naming the block.
+        tmpl = self._shipped_template()
+        anchor = "<!-- render-block: file -->\n"
+        # Non-vacuity: the file-only (non-checklist) block really exists in the
+        # shipped template, so the injected declaration lands outside the checklist
+        # block — the exact gap this test exercises.
+        self.assertIn(anchor, tmpl)
+        poisoned = tmpl.replace(
+            anchor,
+            anchor
+            + "<!-- dim-key: smuggled-dimension -->\n"
+            + "- **Smuggled dimension** — never enumerated.\n",
+            1,
+        )
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "tmpl.md"
+            p.write_text(poisoned, encoding="utf-8")
+            # The render path (the arm that carries the poisoned block) and the
+            # enumeration path (the operand coverage totality is checked against)
+            # BOTH fail closed, so the two projections cannot silently drift.
+            rend = run_renderer(["file", "--slug", "x", "--draft-path", "/tmp/d.md",
+                                 "--template-file", str(p)])
+            enum = run_renderer(["enumerate-dimensions", "--template-file", str(p)])
+        for r in (rend, enum):
+            self.assertNotEqual(r.returncode, 0, r.stdout)
+            self.assertEqual(r.stdout, "")
+            # The breadcrumb names the file at fault and the block that carries the
+            # stray declaration, so an operator debugs the right block.
+            self.assertIn("template malformed", r.stderr)
+            self.assertIn("non-checklist render-block", r.stderr)
+            self.assertIn("file", r.stderr)
+
     # ---- Consumer-side declaration defects: symmetric with the generic arm.
     # The consumer extension is the one file in this contract a THIRD PARTY authors,
     # so before this table every shape below silently discarded the declaration and

--- a/scripts/render-audit-prompt.py
+++ b/scripts/render-audit-prompt.py
@@ -439,12 +439,61 @@ def consumer_dimensions(ext_path: Path, heading: str) -> tuple[str, str]:
 # --------------------------------------------------------------------------
 # Template parsing / block selection.
 # --------------------------------------------------------------------------
+def _reject_stray_dim_key_declarations(
+    blocks: list[tuple[frozenset[str], str]],
+) -> None:
+    """Fail closed on a `<!-- dim-key: … -->` declaration outside the checklist block.
+
+    The declaration marker is machine data that `_assemble` strips from *every*
+    selected block body, but only the checklist block is *validated* (by
+    `_generic_dimensions`, and only on a render that emits it). A declaration
+    authored into a `file`/`embed`/`inline`/`di` block is therefore silently
+    stripped from the auditor-facing prose AND never enumerated, while the bullet
+    it was meant to key still renders as a dimension-shaped instruction — the one
+    authoring defect #729's fail-closed arms miss (issue #735). Reject it here,
+    naming the block that carries it, so the defect fails closed on every render
+    and enumeration path instead of reaching the auditor keyless.
+
+    Scope is what keeps this off the #729 exemptions: it sees only the template's
+    OWN parsed block bodies, never the substituted-last `{CONSUMER_DIMENSIONS}`
+    value or the consumer `## Evidence axes` section — both reach a render as slot
+    values *after* `_parse_blocks` runs and are validated (or deliberately
+    exempted) by their own dedicated code (`consumer_dimensions` /
+    `_consumer_section_raw`). Running at parse time is what structurally routes
+    this check away from those already-handled surfaces (the issue #735
+    Implementation-risk constraint), and skipping the checklist block leaves its
+    declarations to `_generic_dimensions`, their one legal home. A template with
+    no checklist block carries no declaration to reject, so it keeps rendering.
+    """
+    for arm_set, body in blocks:
+        if "checklist" in arm_set:
+            continue
+        # Fast path keyed on the single-sourced token spelling, mirroring
+        # `_strip_dim_key_markers`: the lines rejected here are exactly the lines
+        # that strip would have silently removed from this block.
+        if _DIM_KEY_TOKEN not in body:
+            continue
+        for raw in body.splitlines():
+            if _DIM_KEY_RE.match(raw.strip()):
+                raise RenderError(
+                    f"template malformed: a dim-key declaration appears in a "
+                    f"non-checklist render-block (arms: "
+                    f"{' '.join(sorted(arm_set))}); dimension-key declarations are "
+                    f"legal only inside the checklist block — a declaration here "
+                    f"is silently stripped from the rendered prose and never "
+                    f"enumerated"
+                )
+
+
 def _parse_blocks(template_text: str) -> list[tuple[frozenset[str], str]]:
     """Parse the template into (arm/mode set, body) blocks in file order.
 
     Text outside any block is ignored (it is the human-facing documentation of
     slots and the extraction rule, for the degraded manual arms). A missing
-    close marker is a template defect -> RenderError.
+    close marker is a template defect -> RenderError. A `<!-- dim-key: … -->`
+    declaration outside the checklist block is likewise a template defect
+    (issue #735) — rejected here so every render and enumeration path that parses
+    the template fails closed on it identically.
     """
     blocks: list[tuple[frozenset[str], str]] = []
     current_set: frozenset[str] | None = None
@@ -473,6 +522,7 @@ def _parse_blocks(template_text: str) -> list[tuple[frozenset[str], str]]:
             current_lines.append(line)
     if current_set is not None:
         raise RenderError("template malformed: unterminated render-block")
+    _reject_stray_dim_key_declarations(blocks)
     return blocks
 
 


### PR DESCRIPTION
<!-- PR_BODY_START -->
## Summary
- Fixes a silent-strip / never-enumerated gap in the create-issue audit-prompt renderer: a `<!-- dim-key: … -->` dimension declaration authored into a **non-checklist** template block was stripped from the rendered prose and absent from `enumerate-dimensions`, while its bullet still reached the auditor as a keyless, dimension-shaped instruction — so per-dimension coverage totality reported `backed` without ever requiring an outcome for it.
- Closes the one authoring mistake #729's fail-closed arms missed, using option (b) (fail closed): reject the stray declaration with a breadcrumb naming the block that carries it.

## Changes
**`scripts/render-audit-prompt.py`**: Add `_reject_stray_dim_key_declarations(blocks)`, called at the end of `_parse_blocks` — the single template-parse chokepoint both the render path (`_assemble`) and the enumerate path (`_generic_dimensions`) funnel through. It rejects any dim-key marker outside the checklist block (matching the exact line set `_strip_dim_key_markers` would have silently removed) with a `template malformed: … non-checklist render-block (arms: …)` breadcrumb. Because it runs at parse time over the template's own block bodies, it is structurally blind to the consumer `## Evidence axes` section and the substituted-last `{CONSUMER_DIMENSIONS}` value — keeping the #729 exemptions intact.

**`lib/test/test_render_audit_prompt.py`**: Add `test_a_dim_key_declaration_in_a_non_checklist_block_fails_closed` — injects a declaration into the shipped template's `file`-only block (with a non-vacuity guard) and asserts both `render --mode file` and `enumerate-dimensions` fail closed with the block-naming breadcrumb.

**`.changeset/`**: `bump: patch`, `type: Fixed`.

## Resolves
Resolves #735

## Test Plan
- [x] New test passes; full renderer suite green (`python3 -m pytest lib/test/test_render_audit_prompt.py` → 77 passed, 22 subtests).
- [x] Mutation evidence: removing the `_reject_stray_dim_key_declarations` call turns the new test RED; restoring it turns it GREEN.
- [x] Both AC2 exemptions stay green: `test_the_evidence_axes_hook_is_exempt_from_dimension_validation` and `test_a_template_with_no_checklist_block_still_renders`.
- [x] `harness-python-guards` (33) and `create-issue-contract` (395) modules green; `ruff` clean.

## Visual Changes
N/A

## Breaking Changes
None

<!-- PR_BODY_END -->
