### PR TITLE
Reconcile the #780 partial-gather test comment and cover a null open_pr_selected_by

### DIFF
--- a/.changeset/issue-780-review-note-followup.md
+++ b/.changeset/issue-780-review-note-followup.md
@@ -1,0 +1,9 @@
+---
+bump: patch
+---
+
+### Fixed
+
+- Corrected a `lib/test/run.sh` comment that claimed the `#780` partial-gather arms kill the `is True`/`is False` identity mutants; those arms assert the gather refusal, which returns before the classifier's identity reads are reached.
+- `scripts/preflight.py` now records which three upstream guards the identity reads' equivalence depends on, so relaxing one is a visible change rather than a silent loss of coverage.
+- Added coverage for a JSON-null `open_pr_selected_by` — a non-string shape `gh pr list --json` can serialize — confirming it is refused by the same named cause as an out-of-enum string.

--- a/lib/test/run.sh
+++ b/lib/test/run.sh
@@ -8975,6 +8975,10 @@ bad_file("iv_prcrossnull", json.dumps({**_B, **_PRB, "open_pr_cross_repository":
 # value is the sole gate operand whose failure is silent.
 bad_file("iv_prbranchnum", json.dumps({**_B, **_PRB, "open_pr_branch": 123}), bwork)
 bad_file("iv_prselectedbad", json.dumps({**_B, **_PRB, "open_pr_selected_by": "search"}), bwork)
+# JSON null is the shape `gh pr list --json` can actually serialize for this operand,
+# and it is a NON-STRING rather than an out-of-enum string — a guard keyed on the enum
+# alone (rather than on the type first) would let it through to the `== "head"` read.
+bad_file("iv_prselectednull", json.dumps({**_B, **_PRB, "open_pr_selected_by": None}), bwork)
 emit("iv_bool_ok", bwork, {**_B, "provenance_established": False})
 # Positive control for the NEW operands specifically: real booleans + a valid
 # selected-by survive every refusal above and reach the classifier, so those arms are
@@ -9077,9 +9081,11 @@ assert_eq "#780: cross-repository (fork-headed) PR → DECISION_BLOCKED/stop" \
   "DECISION_BLOCKED 2" "$(_bs576 pr_cross_repo)"
 assert_eq "#780: a head-branch-query-selected PR vouches without a closing linkage → VALIDATED_RESUME" \
   "VALIDATED_RESUME 0" "$(_bs576 pr_head_query_no_closes)"
-# Each operand omitted in turn is REFUSED, not silently read as an answer. These four
-# are what kill the identity-check mutants (`is True` → `!= False`, `is False` →
-# `!= True`): under either mutant an ungathered field would vouch.
+# Each operand omitted in turn is REFUSED, not silently read as an answer. What these
+# four assert is that refusal — NOT the `is True`/`is False` identity checks, which
+# they never reach: the refusal returns before `_classify_branch_state` runs (see the
+# fixture-side comment on this same population). The mutation-sensitive operand here is
+# the string comparison `open_pr_selected_by == "head"`, covered by its own arms.
 assert_eq "#780 partial gather: an omitted open_pr_branch is refused, not read as an answer" \
   "UNAVAILABLE 3" "$(_bs576 pr_partial_open_pr_branch)"
 assert_eq "#780 partial gather: an omitted open_pr_closes_issue is refused" \
@@ -9194,6 +9200,10 @@ assert_eq "#780 input-val: an out-of-enum 'open_pr_selected_by' is refused" \
   "UNAVAILABLE_state 3" "$(_bs576 iv_prselectedbad)"
 assert_eq "#780 input-val: the out-of-enum selected-by cause names that specific operand" "yes" \
   "$(_bs576err iv_prselectedbad "'open_pr_selected_by' must be the string 'head' or 'body'")"
+assert_eq "#780 input-val: a JSON-null 'open_pr_selected_by' is refused by the same named cause" \
+  "UNAVAILABLE_state 3" "$(_bs576 iv_prselectednull)"
+assert_eq "#780 input-val: the null selected-by cause names that specific operand" "yes" \
+  "$(_bs576err iv_prselectednull "'open_pr_selected_by' must be the string 'head' or 'body'")"
 # Positive control for the NEW operands: real booleans + a valid selected-by still
 # reach the classifier, so the arms above are the new guards firing, not a blanket
 # rejection of any state carrying open_pr_* keys. The verdict is AMBIGUOUS rather

--- a/scripts/preflight.py
+++ b/scripts/preflight.py
@@ -514,6 +514,14 @@ def _classify_branch_state(state: dict) -> tuple[str, str, dict]:
     # It is not forgeable by the wider issue-commenter population either: the
     # conjuncts below still require a same-repo PR whose head is the branch actually
     # in the tree.
+    # The `is True` / `is False` identity reads below are equivalent to `!= False` /
+    # `!= True` ONLY because of three upstream guards: the boolean type-guard (any
+    # PRESENT non-bool operand is refused), the partial-gather refusal (an ABSENT one
+    # is refused before this function runs), and the `isinstance(pr_branch, str)`
+    # conjunct. Between them, `None` — the sole value the two spellings disagree on —
+    # can never reach here. Relax any of the three and these identity reads stop being
+    # equivalent and start needing their own arms; the tests below cover the guards,
+    # not the identity spelling.
     pr_branch = state.get("open_pr_branch")
     wp_vouched = bool(state.get("provenance_established", False))
     pr_issue_linked = (


### PR DESCRIPTION
Follow-up to the round-5 DevFlow review notes on #840, which merged before these could be folded in.

## What

- **Documented falsehood (the blocking-class note, capped at Suggestion as behavior-inert).** The assertion-block comment on the `#780` `pr_partial_*` arms claimed they "are what kill the identity-check mutants (`is True` → `!= False`, `is False` → `!= True`)". They are not: the partial-gather refusal returns `UNAVAILABLE 3` before `_classify_branch_state` runs, so a single identity mutation is never reached. It also directly contradicted the fixture-side comment on the same population. Reworded to match.
- **Unasserted equivalence dependency.** `scripts/preflight.py` now records, at the identity expression itself, the three upstream guards the mutants' equivalence rests on — the boolean type-guard, the partial-gather refusal, and the `isinstance(pr_branch, str)` conjunct — so relaxing any one is a visible change rather than a silent loss of coverage.
- **Uncovered shape.** Added `iv_prselectednull`: a JSON-null `open_pr_selected_by` — a shape `gh pr list --json` can serialize, and a *non-string* rather than an out-of-enum string — is refused by the same named cause.

No behavior change: two comments and one added test arm.

## Verification

- `lib/test/run.sh` — 12192 passed, 0 failed, 0 skipped.
- `ruff check` and `shellcheck` (both scopes) clean.

Writing-skills evidence: not applicable — no prompt-surface (`skills/**`) file is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)