### PR TITLE
Fix two changesets using npm-changesets frontmatter instead of the bump: key

### DIFF
--- a/.changeset/residual-pin-retirement.md
+++ b/.changeset/residual-pin-retirement.md
@@ -1,5 +1,5 @@
 ---
-"devflow-autopilot": patch
+bump: patch
 ---
 
 Retire wording-only residual pin assertions while preserving the audited behavioral

--- a/.changeset/retire-mutation-pin-helpers.md
+++ b/.changeset/retire-mutation-pin-helpers.md
@@ -1,5 +1,5 @@
 ---
-"devflow-autopilot": patch
+bump: patch
 ---
 
 Retire the remaining mutation-taking pin helpers, replace their genuine behavioral


### PR DESCRIPTION
`version-consolidate` has failed on **the last three pushes to main**. Cause:

```
consolidate-changesets.py: .changeset/residual-pin-retirement.md: missing required 'bump:' key (expected one of patch, minor, major)
```

Two pending changesets carry npm-changesets frontmatter (`"devflow-autopilot": patch`) rather than DevFlow's own `bump:` key. The consolidator fails closed on the first malformed file, so **no version bump or CHANGELOG entry has landed** since they were merged, and every subsequent push to main re-fails the job.

## Fix

Rewrite both frontmatters to `bump: patch` — `.changeset/residual-pin-retirement.md` and `.changeset/retire-mutation-pin-helpers.md`. No prose changes.

## Verification

Ran the consolidator locally against this tree (output reverted, not committed — the workflow owns the bump commit):

```
consolidated 6 changeset(s): 2.22.9 -> 2.22.10 (highest bump: patch); prepended CHANGELOG entry and removed consumed files
```

Also swept every pending `.changeset/*.md` for a `bump:` key; these two were the only offenders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)