### PR TITLE
fix: retire adjudication migration bootstrap

### DIFF
--- a/.changeset/remove-adjudication-bootstrap.md
+++ b/.changeset/remove-adjudication-bootstrap.md
@@ -1,0 +1,5 @@
+---
+"devflow-autopilot": patch
+---
+
+Remove the completed one-time legacy adjudication bootstrap from the live pin-corpus gate while retaining its historical migration evidence.

--- a/.changeset/remove-adjudication-bootstrap.md
+++ b/.changeset/remove-adjudication-bootstrap.md
@@ -1,5 +1,5 @@
 ---
-"devflow-autopilot": patch
+"bump": patch
 ---
 
 Remove the completed one-time legacy adjudication bootstrap from the live pin-corpus gate while retaining its historical migration evidence.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,11 +169,10 @@ an executable structural boundary and must carry
 `generated-artifact-identity`, or `cross-file-phase-contract`.
 
 `lib/test/pin-corpus-adjudications.tsv` contains only the current active adjudication
-state. Apart from the one-time legacy-to-current-state migration certified in
-`.devflow/logs/pin-corpus-adjudication-changes/2026-07-26-pr-849/migration.tsv`,
-every addition, removal, or change to that table must be authorized by an exact branch
-change manifest; prior decisions remain available through Git history and the frozen
-retirement manifests rather than event rows in the active table. Prefer an ordinary
+state. Every addition, removal, or change to that table must be authorized by an exact
+branch change manifest; prior decisions remain available through Git history, the
+historical migration certificate, and the frozen retirement manifests rather than
+event rows in the active table. Prefer an ordinary
 executable behavioral test over a static presence pin. Reviving a retired wording
 literal requires both deliberate revival authorization and a genuine declared
 structural boundary; a new boundary row alone does not make the revival valid.

--- a/lib/test/pin-corpus-lint.py
+++ b/lib/test/pin-corpus-lint.py
@@ -1213,26 +1213,6 @@ _RETIREMENT_MANIFEST_SPECS = {
         frozenset({"prose_retire", "redundant_retire"}),
     ),
 }
-_MIGRATION_BUNDLE_ID = "2026-07-26-pr-849"
-_MIGRATION_CERTIFICATE_PATH = (
-    f"{_ADJUDICATION_BUNDLE_ROOT}/{_MIGRATION_BUNDLE_ID}/migration.tsv"
-)
-_LEGACY_ADJUDICATION_SHA256 = (
-    "db13cb2caa85b95c3bcdca6488f87c1b79428de5d4055e2faaf3b9636bc985cd"
-)
-_RESOLVED_ADJUDICATION_SHA256 = (
-    "bc955639aee8f6fa37a8a41cf42202e175254bff95cfb13e5a347bbe527a2aa9"
-)
-_RESOLVED_ADJUDICATION_SEMANTIC_SHA256 = (
-    "63eae0fc7617e23a4ab3ec71e36cac0e81f246515759bbb381557f007707c0c5"
-)
-_MIGRATION_CERTIFICATE_BYTES = (
-    "legacy_sha256\tresolved_sha256\tsemantic_map_sha256\n"
-    f"{_LEGACY_ADJUDICATION_SHA256}\t{_RESOLVED_ADJUDICATION_SHA256}\t"
-    f"{_RESOLVED_ADJUDICATION_SEMANTIC_SHA256}\n"
-).encode("ascii")
-
-
 class RevivalAuthorization(NamedTuple):
     source_path: str
     family: str
@@ -1573,16 +1553,6 @@ def hash_adjudication_table_state(adjudications):
     ).hexdigest()
 
 
-def hash_adjudication_semantic_map(adjudications):
-    """Hash canonical sorted TSV rows without coupling semantics to a header."""
-    canonical_adjudication_table_state(adjudications)
-    payload = "".join(
-        f"{key}\t{adjudications[key][0]}\t{adjudications[key][1]}\n"
-        for key in sorted(adjudications)
-    )
-    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
-
-
 def compute_adjudication_delta(base, current):
     """Return the complete base-to-current state delta, including deletions."""
     canonical_adjudication_table_state(base)
@@ -1656,7 +1626,6 @@ def discover_new_adjudication_delta_manifests(
     repo_root,
     merge_base,
     *,
-    include_migration=False,
     include_revivals=False,
     git_runner=subprocess.run,
 ):
@@ -1726,12 +1695,7 @@ def discover_new_adjudication_delta_manifests(
         revival_path = (
             f"{_ADJUDICATION_BUNDLE_ROOT}/{change_id}/retired-pin-revivals.tsv"
         )
-        is_migration = (
-            include_migration
-            and change_id == _MIGRATION_BUNDLE_ID
-            and path == _MIGRATION_CERTIFICATE_PATH
-        )
-        if path not in {delta_path, revival_path} and not is_migration:
+        if path not in {delta_path, revival_path}:
             raise InfrastructureError(f"adjudication bundle has unexpected bundle path: {path!r}")
         if status != "A" or change_id in historical_ids:
             raise InfrastructureError(
@@ -1739,18 +1703,14 @@ def discover_new_adjudication_delta_manifests(
             )
         new_paths.setdefault(change_id, set()).add(path)
     for change_id, paths in new_paths.items():
-        if change_id == _MIGRATION_BUNDLE_ID:
-            expected_paths = {_MIGRATION_CERTIFICATE_PATH}
-            valid = paths == expected_paths
-        else:
-            delta_path = (
-                f"{_ADJUDICATION_BUNDLE_ROOT}/{change_id}/adjudication-delta.tsv"
-            )
-            revival_path = (
-                f"{_ADJUDICATION_BUNDLE_ROOT}/{change_id}/retired-pin-revivals.tsv"
-            )
-            expected_paths = {delta_path, revival_path}
-            valid = delta_path in paths and paths <= expected_paths
+        delta_path = (
+            f"{_ADJUDICATION_BUNDLE_ROOT}/{change_id}/adjudication-delta.tsv"
+        )
+        revival_path = (
+            f"{_ADJUDICATION_BUNDLE_ROOT}/{change_id}/retired-pin-revivals.tsv"
+        )
+        expected_paths = {delta_path, revival_path}
+        valid = delta_path in paths and paths <= expected_paths
         if not valid:
             unexpected = sorted(paths - expected_paths or paths)
             raise InfrastructureError(
@@ -1758,7 +1718,6 @@ def discover_new_adjudication_delta_manifests(
             )
     manifests = []
     revival_authorizations = set()
-    migration_bytes = None
     for change_id in sorted(new_paths):
         for payload_path in sorted(new_paths[change_id]):
             listing = _run_git(git_runner, repo_root, "ls-tree", "HEAD", "--", payload_path)
@@ -1773,9 +1732,7 @@ def discover_new_adjudication_delta_manifests(
                     f"new adjudication bundle payload is not a regular HEAD blob: {payload_path}"
                 )
             payload = _run_git_bytes(git_runner, repo_root, "show", f"HEAD:{payload_path}")
-            if payload_path == _MIGRATION_CERTIFICATE_PATH:
-                migration_bytes = payload
-            elif payload_path.endswith("/adjudication-delta.tsv"):
+            if payload_path.endswith("/adjudication-delta.tsv"):
                 manifests.append(
                     parse_adjudication_delta_manifest(
                         _decode_utf8(payload, f"adjudication bundle payload {payload_path}")
@@ -1792,10 +1749,6 @@ def discover_new_adjudication_delta_manifests(
                         f"{sorted(duplicates)[0]}"
                     )
                 revival_authorizations.update(parsed)
-    if include_migration and include_revivals:
-        return manifests, migration_bytes, frozenset(revival_authorizations)
-    if include_migration:
-        return manifests, migration_bytes
     if include_revivals:
         return manifests, frozenset(revival_authorizations)
     return manifests
@@ -3857,42 +3810,12 @@ def analyze_adjudication_changes(
         "show",
         f"{merge_base}:{_ADJUDICATION_TABLE_PATH}",
     )
-    (
-        manifests,
-        migration_bytes,
-        revival_authorizations,
-    ) = discover_new_adjudication_delta_manifests(
+    manifests, revival_authorizations = discover_new_adjudication_delta_manifests(
         repo_root,
         merge_base,
-        include_migration=True,
         include_revivals=True,
         git_runner=git_runner,
     )
-    base_digest = hashlib.sha256(base_bytes).hexdigest()
-    current_digest = hashlib.sha256(current_bytes).hexdigest()
-    if base_digest == _LEGACY_ADJUDICATION_SHA256:
-        require_current_adjudication_base(
-            repo_root,
-            base_ref,
-            merge_base=merge_base,
-            git_runner=git_runner,
-        )
-        if (
-            current_digest != _RESOLVED_ADJUDICATION_SHA256
-            or migration_bytes != _MIGRATION_CERTIFICATE_BYTES
-            or manifests
-            or hash_adjudication_semantic_map(current)
-            != _RESOLVED_ADJUDICATION_SEMANTIC_SHA256
-        ):
-            raise InfrastructureError(
-                "adjudication migration does not match the exact bootstrap certificate"
-            )
-        return AdjudicationAnalysis([], current, current, {}, frozenset())
-
-    if migration_bytes is not None:
-        raise InfrastructureError(
-            "adjudication migration certificate is invalid for a strict base table"
-        )
     base = parse_current_adjudications(
         _decode_utf8(base_bytes, "base adjudication table")
     )

--- a/lib/test/test_pin_corpus_lint.py
+++ b/lib/test/test_pin_corpus_lint.py
@@ -1976,16 +1976,9 @@ class AdjudicationStateTests(unittest.TestCase):
 
 
 class AdjudicationChangeScanTests(unittest.TestCase):
-    LEGACY_SHA256 = "db13cb2caa85b95c3bcdca6488f87c1b79428de5d4055e2faaf3b9636bc985cd"
-    RESOLVED_SHA256 = "bc955639aee8f6fa37a8a41cf42202e175254bff95cfb13e5a347bbe527a2aa9"
-    SEMANTIC_SHA256 = "63eae0fc7617e23a4ab3ec71e36cac0e81f246515759bbb381557f007707c0c5"
     MIGRATION_PATH = (
         ".devflow/logs/pin-corpus-adjudication-changes/"
         "2026-07-26-pr-849/migration.tsv"
-    )
-    MIGRATION_TEXT = (
-        "legacy_sha256\tresolved_sha256\tsemantic_map_sha256\n"
-        f"{LEGACY_SHA256}\t{RESOLVED_SHA256}\t{SEMANTIC_SHA256}\n"
     )
 
     @classmethod
@@ -2006,6 +1999,9 @@ class AdjudicationChangeScanTests(unittest.TestCase):
             capture_output=True,
             text=True,
         ).stdout
+        cls.migration_certificate = (
+            REPO_ROOT / cls.MIGRATION_PATH
+        ).read_text(encoding="utf-8")
 
     def _commit(self, root, message):
         subprocess.run(["git", "add", "."], cwd=root, check=True)
@@ -2052,87 +2048,62 @@ class AdjudicationChangeScanTests(unittest.TestCase):
             root, merge_base, "origin/main"
         )
 
-    def test_exact_legacy_to_resolved_bootstrap_is_the_only_accepted_migration(self):
-        self.assertEqual(
-            self.LEGACY_SHA256,
-            hashlib.sha256(self.legacy_table.encode("utf-8")).hexdigest(),
-        )
-        self.assertEqual(
-            self.RESOLVED_SHA256,
-            hashlib.sha256(self.live_table.encode("utf-8")).hexdigest(),
-        )
+    def test_former_legacy_base_is_rejected_by_strict_current_state_parser(self):
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
             base, table = self._repo(root, self.legacy_table)
             table.write_text(self.live_table, encoding="utf-8")
-            self._write_bundle(root, self.MIGRATION_PATH, self.MIGRATION_TEXT)
-            self._commit(root, "exact migration")
-            self.assertEqual([], self._scan(root, base))
+            self._commit(root, "replace legacy event table")
+            with self.assertRaisesRegex(
+                self.mod.InfrastructureError, "invalid adjudication key"
+            ):
+                self._scan(root, base)
 
-        variants = {
-            "legacy bytes": (
-                self.legacy_table.replace("boundary", "generated", 1),
-                self.live_table,
-                self.MIGRATION_TEXT,
-            ),
-            "resolved bytes": (
-                self.legacy_table,
-                self.live_table.replace("boundary", "generated", 1),
-                self.MIGRATION_TEXT,
-            ),
-            "certificate bytes": (
-                self.legacy_table,
-                self.live_table,
-                self.MIGRATION_TEXT.replace(self.SEMANTIC_SHA256, "0" * 64),
-            ),
-        }
-        for label, (base_text, current_text, certificate) in variants.items():
-            with self.subTest(variant=label), tempfile.TemporaryDirectory() as td:
+    def test_new_migration_certificate_is_not_a_supported_bundle_payload(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            base, _table = self._repo(root, self.live_table)
+            self._write_bundle(
+                root, self.MIGRATION_PATH, self.migration_certificate
+            )
+            self._commit(root, "attempt a second migration")
+            with self.assertRaisesRegex(
+                self.mod.InfrastructureError, "unexpected bundle path"
+            ):
+                self._scan(root, base)
+
+    def test_historical_migration_certificate_is_inert_but_immutable(self):
+        for mutation in ("edit", "delete", "type"):
+            with self.subTest(mutation=mutation), tempfile.TemporaryDirectory() as td:
                 root = Path(td)
-                base, table = self._repo(root, base_text)
-                table.write_text(current_text, encoding="utf-8")
-                self._write_bundle(root, self.MIGRATION_PATH, certificate)
-                self._commit(root, "nearby migration")
+                _base, _table = self._repo(root, self.live_table)
+                certificate = self._write_bundle(
+                    root, self.MIGRATION_PATH, self.migration_certificate
+                )
+                base = self._commit(root, "record historical migration")
+                subprocess.run(
+                    ["git", "update-ref", "refs/remotes/origin/main", base],
+                    cwd=root,
+                    check=True,
+                )
+                self.assertEqual([], self._scan(root, base))
+
+                if mutation == "edit":
+                    certificate.write_text(
+                        self.migration_certificate + "changed\n",
+                        encoding="utf-8",
+                    )
+                else:
+                    certificate.unlink()
+                    if mutation == "type":
+                        target = root / "historical-certificate.tsv"
+                        target.write_text(
+                            self.migration_certificate, encoding="utf-8"
+                        )
+                        certificate.symlink_to(target)
+                self._commit(root, f"{mutation} historical migration")
                 with self.assertRaises(self.mod.InfrastructureError):
                     self._scan(root, base)
-
-    def test_migration_bundle_accepts_only_the_exact_regular_certificate(self):
-        for label, extra_path in (
-            (
-                "delta sibling",
-                ".devflow/logs/pin-corpus-adjudication-changes/"
-                "2026-07-26-pr-849/adjudication-delta.tsv",
-            ),
-            (
-                "nested payload",
-                ".devflow/logs/pin-corpus-adjudication-changes/"
-                "2026-07-26-pr-849/nested/payload.tsv",
-            ),
-        ):
-            with self.subTest(case=label), tempfile.TemporaryDirectory() as td:
-                root = Path(td)
-                base, table = self._repo(root, self.legacy_table)
-                table.write_text(self.live_table, encoding="utf-8")
-                self._write_bundle(root, self.MIGRATION_PATH, self.MIGRATION_TEXT)
-                self._write_bundle(root, extra_path, "unexpected\n")
-                self._commit(root, "migration with extra payload")
-                with self.assertRaisesRegex(
-                    self.mod.InfrastructureError, "unexpected bundle path"
-                ):
-                    self._scan(root, base)
-
-        with tempfile.TemporaryDirectory() as td:
-            root = Path(td)
-            base, table = self._repo(root, self.legacy_table)
-            table.write_text(self.live_table, encoding="utf-8")
-            certificate = root / self.MIGRATION_PATH
-            certificate.parent.mkdir(parents=True)
-            target = root / "outside.tsv"
-            target.write_text(self.MIGRATION_TEXT, encoding="utf-8")
-            certificate.symlink_to(target)
-            self._commit(root, "symlink certificate")
-            with self.assertRaisesRegex(self.mod.InfrastructureError, "regular HEAD blob"):
-                self._scan(root, base)
 
     def test_strict_table_delta_requires_exact_authorization(self):
         key = "literal:" + "a" * 64
@@ -2247,16 +2218,15 @@ class AdjudicationChangeScanTests(unittest.TestCase):
             ):
                 self._scan(root, base)
 
-    def test_migration_rejects_a_committed_table_symlink(self):
+    def test_adjudication_change_rejects_a_committed_table_symlink(self):
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
-            base, table = self._repo(root, self.legacy_table)
+            base, table = self._repo(root, self.live_table)
             resolved = root / "resolved.tsv"
             resolved.write_text(self.live_table, encoding="utf-8")
             table.unlink()
             table.symlink_to("../../resolved.tsv")
-            self._write_bundle(root, self.MIGRATION_PATH, self.MIGRATION_TEXT)
-            self._commit(root, "symlinked migration table")
+            self._commit(root, "symlinked adjudication table")
             with self.assertRaisesRegex(
                 self.mod.InfrastructureError,
                 "adjudication table is not a regular HEAD blob",


### PR DESCRIPTION
## Summary

- remove the completed one-time PR #849 legacy adjudication bootstrap from the live pin-corpus gate
- strict-parse every merge-base adjudication table as current state and reject newly added `migration.tsv` payloads
- retain and protect the historical migration certificate while removing the corresponding contributor-policy exception

## Scope

This is the narrow closeout promised by PR #849. Historical migration evidence, frozen inventories, retirement manifests, and the active adjudication table remain unchanged.

## Verification

- `python3 lib/test/test_pin_corpus_lint.py`
- `DEVFLOW_POOL_WIDTH=1 lib/test/run-module.sh harness-python-guards`
- `DEVFLOW_POOL_WIDTH=1 lib/test/run.sh` — 12,211 passed, 0 failed
- `ruff check lib/test/pin-corpus-lint.py lib/test/test_pin_corpus_lint.py`
- `git diff --check`
- independent whole-branch review: clean, no Critical or Important findings
