### PR TITLE
Remove the duplicated `test_pin_corpus_lint.py` invocation from `lib/test/run.sh`

### DIFF
--- a/lib/test/modules/harness-python-guards.sh
+++ b/lib/test/modules/harness-python-guards.sh
@@ -311,7 +311,9 @@ echo "#810 pin-corpus wording-only authoring gate"
 # ────────────────────────────────────────────────────────────────────────────
 # These focused tests drive the same path-aware parser, registry-closed source
 # population, classification-preserving move logic, and fail-closed worktree setup
-# that the production pin-corpus-lint.py whole-tree scan in run.sh consumes.
+# that run.sh's blocking `pin-corpus-lint.py mutation-routing-worktree` gate
+# consumes. run.sh carries several production pin-corpus-lint.py subcommands, so
+# the gate is named by subcommand rather than by position or by breadth.
 _HPG_PIN_LINT_OUT="$(mktemp "$_hpg_tmp_root/pin-lint-unit.XXXXXX")" || {
   printf 'could not allocate the #810 pin-lint unit-test capture\n' >&2
   return 1
@@ -321,9 +323,17 @@ devflow_run_focused_python_test \
   "$LIB/test/test_pin_corpus_lint.py" \
   "$_HPG_PIN_LINT_OUT"
 # The focused unit suite is module-driven only: a direct run.sh invocation of it
-# would re-add a second serial execution of an identical population (issue #865).
-# The basename is the match literal because the removed invocation spelled its
-# argument through $LIB, which a fully-literal path would not have caught.
+# would re-execute an identical population serially, on top of the module-driven
+# run above (issue #865). The basename is the match literal because the removed
+# invocation spelled its argument through $LIB, which a fully-literal path would
+# not have caught; the price is that this trips on ANY mention of the basename in
+# run.sh, a bare comment reference included, not only on an invocation. `grep`
+# writes its diagnostics to stderr and nothing to stdout, so an absent or
+# unreadable run.sh yields an EMPTY comparand that fails this assertion — do not
+# add -s, a second file operand, or a glob, each of which breaks that fail-closed
+# path. Search domain is run.sh alone: a reintroduced invocation in another
+# lib/test/modules/*.sh, or in lib/test/module-harness.sh, is an accepted residual
+# this assertion does not detect.
 assert_eq "#810 pin-corpus lint tests remain module-driven (no run.sh invocation)" \
   "0" "$(grep -cF 'test_pin_corpus_lint.py' "$LIB/test/run.sh" || true)"
 rm -f "$_HPG_PIN_LINT_OUT"

--- a/lib/test/modules/harness-python-guards.sh
+++ b/lib/test/modules/harness-python-guards.sh
@@ -311,7 +311,7 @@ echo "#810 pin-corpus wording-only authoring gate"
 # ────────────────────────────────────────────────────────────────────────────
 # These focused tests drive the same path-aware parser, registry-closed source
 # population, classification-preserving move logic, and fail-closed worktree setup
-# that the blocking run.sh invocation above consumes.
+# that the production pin-corpus-lint.py whole-tree scan in run.sh consumes.
 _HPG_PIN_LINT_OUT="$(mktemp "$_hpg_tmp_root/pin-lint-unit.XXXXXX")" || {
   printf 'could not allocate the #810 pin-lint unit-test capture\n' >&2
   return 1
@@ -320,6 +320,12 @@ devflow_run_focused_python_test \
   "#810 pin-corpus authoring gate: focused Python tests pass" \
   "$LIB/test/test_pin_corpus_lint.py" \
   "$_HPG_PIN_LINT_OUT"
+# The focused unit suite is module-driven only: a direct run.sh invocation of it
+# would re-add a second serial execution of an identical population (issue #865).
+# The basename is the match literal because the removed invocation spelled its
+# argument through $LIB, which a fully-literal path would not have caught.
+assert_eq "#810 pin-corpus lint tests remain module-driven (no run.sh invocation)" \
+  "0" "$(grep -cF 'test_pin_corpus_lint.py' "$LIB/test/run.sh" || true)"
 rm -f "$_HPG_PIN_LINT_OUT"
 
 # ────────────────────────────────────────────────────────────────────────────

--- a/lib/test/modules/harness-python-guards.sh
+++ b/lib/test/modules/harness-python-guards.sh
@@ -324,16 +324,16 @@ devflow_run_focused_python_test \
   "$_HPG_PIN_LINT_OUT"
 # The focused unit suite is module-driven only: a direct run.sh invocation of it
 # would re-execute an identical population serially, on top of the module-driven
-# run above (issue #865). The basename is the match literal because the removed
-# invocation spelled its argument through $LIB, which a fully-literal path would
-# not have caught; the price is that this trips on ANY mention of the basename in
-# run.sh, a bare comment reference included, not only on an invocation. `grep`
-# writes its diagnostics to stderr and nothing to stdout, so an absent or
-# unreadable run.sh yields an EMPTY comparand that fails this assertion — do not
-# add -s, a second file operand, or a glob, each of which breaks that fail-closed
-# path. Search domain is run.sh alone: a reintroduced invocation in another
-# lib/test/modules/*.sh, or in lib/test/module-harness.sh, is an accepted residual
-# this assertion does not detect.
+# run above (issue #865). Match on the basename: an invocation may spell its path
+# through $LIB, which a repo-relative literal would miss. The price is that this
+# trips on ANY mention of the basename in run.sh, a bare comment reference
+# included, not only on an invocation. `grep` writes its diagnostics to stderr and
+# nothing to stdout, so an absent or unreadable run.sh yields an EMPTY comparand
+# that fails this assertion; keep the single file operand, because two or more (a
+# second path, or a glob expanding past one file) switch `grep -c` to prefixed
+# `file:count` output that never equals "0". Search domain is run.sh alone: a
+# reintroduced invocation in another lib/test/modules/*.sh, or in
+# lib/test/module-harness.sh, is an accepted residual this assertion misses.
 assert_eq "#810 pin-corpus lint tests remain module-driven (no run.sh invocation)" \
   "0" "$(grep -cF 'test_pin_corpus_lint.py' "$LIB/test/run.sh" || true)"
 rm -f "$_HPG_PIN_LINT_OUT"

--- a/lib/test/run.sh
+++ b/lib/test/run.sh
@@ -41655,9 +41655,9 @@ devflow_pool_open \
   "test_module_runner.py" "$LIB/test/test_module_runner.py" single-verdict \
   "test_python_scripts.py" "$LIB/test/test_python_scripts.py" self-tally
 
-# The zero-population mutation census and the ban on new mutation-pin helpers are
-# executable CI contracts. Run their focused unittest suites serially and feed each
-# verdict into the same RESULTS_FILE tally as the rest of the full suite.
+# The zero-population mutation census is an executable CI contract. Run its focused
+# unittest suite serially and feed the verdict into the same RESULTS_FILE tally as
+# the rest of the full suite.
 MUTATION_CENSUS_TEST_OUT="$(python3 "$LIB/test/test_mutation_pin_census.py" 2>&1)"
 MUTATION_CENSUS_TEST_RC=$?
 assert_eq "mutation-pin census focused tests pass" "0" "$MUTATION_CENSUS_TEST_RC"
@@ -41665,14 +41665,6 @@ assert_eq "mutation-pin census focused tests pass" "0" "$MUTATION_CENSUS_TEST_RC
   while IFS= read -r _mpc_line || [ -n "$_mpc_line" ]; do
     printf '    %s\n' "$_mpc_line"
   done <<< "$MUTATION_CENSUS_TEST_OUT"
-
-PIN_CORPUS_LINT_TEST_OUT="$(python3 "$LIB/test/test_pin_corpus_lint.py" 2>&1)"
-PIN_CORPUS_LINT_TEST_RC=$?
-assert_eq "pin-corpus lint focused tests pass" "0" "$PIN_CORPUS_LINT_TEST_RC"
-[ "$PIN_CORPUS_LINT_TEST_RC" -eq 0 ] || \
-  while IFS= read -r _pcl_line || [ -n "$_pcl_line" ]; do
-    printf '    %s\n' "$_pcl_line"
-  done <<< "$PIN_CORPUS_LINT_TEST_OUT"
 
 # test_module_harness.py runs SERIALLY on the main shell, OUTSIDE the pool — both its
 # full-suite invocation and its --signal-matrix-capability probe. The supervisor forks
@@ -41708,7 +41700,7 @@ assert_eq "issue #767: create-issue context eval focused tests pass" "0" "$CICE_
 # module). The registry and this full-suite call share the same lower-bound contract;
 # test_module_runner.py parses this operand and rejects any coupling drift.
 if ! devflow_run_full_suite_module "$LIB/test/modules/harness-python-guards.sh" \
-  "harness-python-guards" 38; then
+  "harness-python-guards" 39; then
   printf 'ERROR: harness-python-guards boundary could not record its result\n'
   exit 1
 fi

--- a/scripts/workflow-flight-recorder-registry.json
+++ b/scripts/workflow-flight-recorder-registry.json
@@ -38,7 +38,7 @@
     },
     "harness-python-guards": {
       "path": "lib/test/modules/harness-python-guards.sh",
-      "minimum_assertions": 38,
+      "minimum_assertions": 39,
       "description": "Focused monolith-only Python guard drivers whose subject is a single code unit and whose verification is self-contained: the #600 render-audit-prompt renderer, the #527 verification-launch baseline analyzer, the #528 single-flight verification ledger, the #668 reception-identity producer, the #798 pin-corpus classifier unit tests, the #810 pin-corpus authoring-gate unit tests plus the red-on-removal and residual-prose retirement censuses/current-corpus closure, and the #591 coverage-map ratchet guard (live-tree invocation, unit test, and a planted coverage-map drift as the coverage-map guard's positive control)"
     },
     "prompt-extension-reader": {


### PR DESCRIPTION
## Summary

`lib/test/run.sh` drove `lib/test/test_pin_corpus_lint.py` from a **second serial call site**, alongside the one the `harness-python-guards` module already owns. Both ran the same argument-less command over an identical test population — the file's `__main__` is a bare `unittest.main()` with no self-skip — so the second could not produce a verdict the first would not. This removes it.

The change does **not** claim a specific reduction in total job time: a third execution runs concurrently inside the Python pool, and the main shell's slack over that pool is unestablished. What is certain is that the redundant serial work, the redundant CPU, and a duplicated maintenance surface that had already drifted once all go away.

Resolves #865

## What changed

- **`lib/test/run.sh`** — deleted the seven-line `PIN_CORPUS_LINT_TEST_OUT` block in full (the `$OUT`/`$RC` capture, the `pin-corpus lint focused tests pass` assertion, and the `_pcl_line` echo loop). The immediately preceding `MUTATION_CENSUS_TEST_OUT` block is retained untouched; its shared introductory comment is narrowed to the zero-population mutation census alone, since the ban on new mutation-pin helpers is asserted by `RetiredMutationHelperBanTests` in `test_pin_corpus_lint.py` — which now runs only through the module.
- **`lib/test/modules/harness-python-guards.sh`** — added one regression assertion to the `#810` section, mirroring the shape of the `#798` sibling a few lines above; re-pointed the section's explanatory comment at the gate that actually consumes the machinery it describes.
- **`scripts/workflow-flight-recorder-registry.json`** + the `devflow_run_full_suite_module` call site — the coupled assertion-count triple moves 38 → 39 in the same change. `test_module_runner.py` parses the call-site operand and asserts the module's rendered summary line against the registry value by list membership, so a one-sided edit would have shipped RED.

## Why the guard matches a basename

The removed invocation spelled its argument through `$LIB` (`python3 "$LIB/test/test_pin_corpus_lint.py"`), so a guard written against a fully-literal repo-relative path would have passed on the very tree that motivated it. The assertion matches the basename instead. The price, disclosed beside it: it trips on **any** mention of the basename in `run.sh`, a bare comment reference included — not only on an invocation.

## Verification

**Mutation evidence (test-first RED, then GREEN).** The assertion was added **before** the deletion and run against the still-duplicated tree:

```
FAIL  #810 pin-corpus lint tests remain module-driven (no run.sh invocation)
       expected: 0
       actual:   1
Module harness-python-guards: 38 passed, 1 failed
```

That RED reproduces the exact defect PR #830 shipped, not an absent feature. After deleting the block and reconciling the triple, the same command is GREEN:

```
Module harness-python-guards: 39 passed, 0 failed
```

**Fail-closed trace.** `grep` is not preflight-guaranteed, so the comparand's degradation direction was traced rather than assumed. `grep` writes its diagnostics to stderr and nothing to stdout, so an absent or unreadable `run.sh`, an unset `$LIB`, or a missing `grep` all yield an **empty** comparand, which `assert_eq` compares unequal to `"0"` and fails **closed**. Measured on this host: `grep -cF pat /nonexistent` and `grep -s -cF pat /nonexistent` both print nothing — so `-s` is fail-closed-neutral. What does matter is the operand count: two or more operands switch `grep -c` to prefixed `file:count` output (measured: `lib/test/module-harness.sh:0 lib/test/run.sh:48`), which never equals `"0"`. The comment beside the assertion records exactly that.

**Other checks.** `python3 lib/test/test_module_runner.py` → `Ran 80 tests, OK` (covers the coupling parse and the issue-#720 classification cross-check). `shellcheck --severity=warning -e SC1091` clean on both changed shell files. `python3 lib/test/pin-corpus-lint.py mutation-routing-worktree .` exits 0 — the new count-based guard draws no declaration obligation, since the `#810` extractor builds a guard site only for a raw `grep` carrying both `-F` and `-q`, and count-based guards are additionally exempt by helper.

## Scope

The regression assertion's search domain is `lib/test/run.sh` alone. A reintroduced direct invocation inside another `lib/test/modules/*.sh` file, or inside `lib/test/module-harness.sh`, satisfies this assertion and is **not** detected by it — an accepted residual recorded in issue #865 and restated beside the assertion. Closing it generically, across all eleven `MODULE_DRIVEN_SUITES` members, is tracked in **#867**.

No changeset: `.github/actions/vendor-plugin/vendor-slice.sh` copies `lib` and `scripts` into the staged tree and then `rm -rf`s `lib/test` from it, so both edited shell surfaces never reach a consumer repository, and the registry's `minimum_assertions` value is read only by `lib/test/**`. This is internal test infrastructure, which the repo's versioning policy scopes out of the changeset requirement.

## Review

Two fix-loop iterations plus a blinded shadow pass (early `engine_self_modifying` trigger, full five-agent roster). The shadow earned its keep: it caught a `documented_falsehood` that **iteration 1's own fix** had introduced — a comment asserting that adding `-s` breaks the guard's fail-closed path. Two of the five reviewers filed it independently, both having run `grep` rather than read the sentence. Fixed in iteration 2.

Findings deferred to #867 rather than fixed here: generalizing the routing invariant over all eleven module-driven suites, and adding the inverse assertion that a serially-invoked suite stays invoked. Both are out of scope against acceptance criteria that prescribe this guard's exact shape and location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
