### PR TITLE
feat: default to Claude Opus 5

### DIFF
--- a/.changeset/opus-5-default-model.md
+++ b/.changeset/opus-5-default-model.md
@@ -1,0 +1,11 @@
+---
+bump: patch
+---
+
+### Changed
+
+- Default Claude model moves from Claude Opus 4.8 to Claude Opus 5 (`claude-opus-5`).
+  Updates `claude_model` in the shipped `.devflow/config.example.json` and its
+  `config.schema.json` default, this repo's tracked `.devflow/config.json`
+  (`claude_model`, the `devflow:code-reviewer` agent override, and the
+  retrospective/audit models), and the coupled docs mirrors.

--- a/.devflow/config.example.json
+++ b/.devflow/config.example.json
@@ -52,7 +52,7 @@
         "effort": "high"
       },
       "devflow:checklist-deduper": {
-        "model": "claude-sonnet-4-6",
+        "model": "claude-sonnet-5",
         "effort": "medium"
       },
       "devflow:code-reviewer": {
@@ -98,7 +98,7 @@
   },
   "devflow_retrospective": {
     "enabled": true,
-    "retrospective_model": "claude-sonnet-4-6",
+    "retrospective_model": "claude-sonnet-5",
     "audit_model": "claude-opus-5",
     "implementation_branch_prefix": "claude/",
     "min_occurrences": 2,

--- a/.devflow/config.example.json
+++ b/.devflow/config.example.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./config.schema.json",
   "base_branch": "main",
-  "claude_model": "claude-opus-4-8",
+  "claude_model": "claude-opus-5",
   "devflow_version": "",
   "devflow": {
     "allowed_bots": "claude,dependabot",
@@ -56,7 +56,7 @@
         "effort": "medium"
       },
       "devflow:code-reviewer": {
-        "model": "claude-opus-4-8",
+        "model": "claude-opus-5",
         "effort": "high",
         "iterations": "first-only"
       }
@@ -99,7 +99,7 @@
   "devflow_retrospective": {
     "enabled": true,
     "retrospective_model": "claude-sonnet-4-6",
-    "audit_model": "claude-opus-4-8",
+    "audit_model": "claude-opus-5",
     "implementation_branch_prefix": "claude/",
     "min_occurrences": 2,
     "cooldown_days": 3,

--- a/.devflow/config.json
+++ b/.devflow/config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./config.schema.json",
   "base_branch": "main",
-  "claude_model": "claude-opus-4-8",
+  "claude_model": "claude-opus-5",
   "devflow_version": "main",
   "devflow": {
     "allowed_bots": "claude,dependabot,devflow-autopilot",
@@ -122,7 +122,7 @@
         "effort": "low"
       },
       "devflow:code-reviewer": {
-        "model": "claude-opus-4-8",
+        "model": "claude-opus-5",
         "effort": "low",
         "iterations": "first-only"
       }
@@ -164,8 +164,8 @@
   },
   "devflow_retrospective": {
     "enabled": true,
-    "retrospective_model": "claude-opus-4-8",
-    "audit_model": "claude-opus-4-8",
+    "retrospective_model": "claude-opus-5",
+    "audit_model": "claude-opus-5",
     "implementation_branch_prefix": "claude/",
     "min_occurrences": 2,
     "cooldown_days": 3,

--- a/.devflow/config.schema.json
+++ b/.devflow/config.schema.json
@@ -383,7 +383,7 @@
             "devflow:checklist-deduper": {
               "type": "object",
               "additionalProperties": false,
-              "description": "Pins Claude Sonnet 4.6 for the dedup pass with effort 'medium' (Sonnet 4.6's recommended default; effort must be set explicitly on Sonnet 4.6 to avoid unexpected latency). NOTE: Claude Haiku rejects the `effort` parameter with HTTP 400 (effort is supported only on Opus 4.5\u20134.8 / Sonnet 4.6), so if you re-pin a Haiku id here the entry must NOT carry an `effort` key; scaffold-config.sh strips a stale `effort` from any Haiku-pinned override on re-scaffold.",
+              "description": "Pins Claude Sonnet 5 for the dedup pass with effort 'medium' (a cost-saving step down from the API default of 'high'; set it explicitly to avoid unexpected latency). NOTE: Claude Haiku rejects the `effort` parameter with HTTP 400 (effort is supported only on Opus 4.5\u20134.8, Opus 5, Sonnet 4.6, and Sonnet 5), so if you re-pin a Haiku id here the entry must NOT carry an `effort` key; scaffold-config.sh strips a stale `effort` from any Haiku-pinned override on re-scaffold.",
               "properties": {
                 "model": {
                   "type": "string"

--- a/.devflow/config.schema.json
+++ b/.devflow/config.schema.json
@@ -18,7 +18,7 @@
     "claude_model": {
       "type": "string",
       "description": "Claude model for AI-powered workflows (individual workflows may override).",
-      "default": "claude-opus-4-8"
+      "default": "claude-opus-5"
     },
     "devflow_version": {
       "type": "string",

--- a/docs/DEVFLOW_SYSTEM_OVERVIEW.md
+++ b/docs/DEVFLOW_SYSTEM_OVERVIEW.md
@@ -819,7 +819,7 @@ The local tier needs **no config**. To customize, `/devflow:init` scaffolds `.de
 | Key | Purpose |
 |---|---|
 | `base_branch` | Review/merge base (default `main`). |
-| `claude_model` | Default model (default `claude-opus-4-8`). |
+| `claude_model` | Default model (default `claude-opus-5`). |
 | `providers.<name>` | Cloud-tier (opt-in): Anthropic-compatible third-party endpoints — `base_url`, `auth` (`bearer`\|`api_key`), `timeout_ms`, `effort_supported`, and an `env` map. The API credential is never named in config — it is always the fixed `DEVFLOW_PROVIDER_API_KEY` repo secret. See §14 / `docs/cloud-setup.md`. |
 | `devflow.provider` / `devflow_implement.provider` / `devflow_runner.provider` (+ each section's `claude_model`) | Cloud-tier (opt-in): route that workflow section through a named `providers` entry and/or override its model, independently per section. Unset → today's Anthropic-OAuth default. |
 | `devflow_version` | Cloud-tier: git ref the workflows fetch the plugin from (thin install). |

--- a/docs/cloud-setup.md
+++ b/docs/cloud-setup.md
@@ -1345,7 +1345,7 @@ only `/devflow:implement`, leaving review/command on Claude):
 
 ```json
 {
-  "claude_model": "claude-opus-4-8",
+  "claude_model": "claude-opus-5",
   "providers": {
     "openrouter": {
       "base_url": "https://openrouter.ai/api",

--- a/docs/review-agent-overrides.md
+++ b/docs/review-agent-overrides.md
@@ -85,7 +85,7 @@ Each value optionally sets `model`, `effort`, and/or `iterations`:
     "agent_overrides": {
       "default": { "effort": "high" },
       "devflow:checklist-deduper": { "model": "claude-sonnet-4-6", "effort": "medium" },
-      "devflow:code-reviewer": { "model": "claude-opus-4-8", "effort": "high", "iterations": "first-only" }
+      "devflow:code-reviewer": { "model": "claude-opus-5", "effort": "high", "iterations": "first-only" }
     }
   }
 }
@@ -106,8 +106,8 @@ Each value optionally sets `model`, `effort`, and/or `iterations`:
   full roster. An out-of-enum value (or empty string) is dropped with a `::warning::`, mirroring the
   invalid-effort path; the run never aborts.
 
-> **Claude Haiku rejects `effort`.** The `effort` parameter is supported only on Opus 4.5–4.8 and
-> Sonnet 4.6; Claude Haiku rejects it with **HTTP 400**. So any entry that pins a Haiku model (a
+> **Claude Haiku rejects `effort`.** The `effort` parameter is supported only on Opus 4.5–4.8, Opus 5, Sonnet 4.6, and
+> Sonnet 5; Claude Haiku rejects it with **HTTP 400**. So any entry that pins a Haiku model (a
 > `claude-haiku-*` id) **must not** also carry an `effort` key. The shipped `devflow:checklist-deduper`
 > override pins Claude Sonnet 4.6 (which *does* support `effort`) with effort `medium`, so it is exempt;
 > the constraint matters if you re-pin a Haiku id there. The schema does not enforce this (it is a model-API fact, not a structural
@@ -125,7 +125,7 @@ Each value optionally sets `model`, `effort`, and/or `iterations`:
 ## This repo's `code-reviewer` application — baseline, revert trigger, deferred repricing (issue #425)
 
 DevFlow's own tracked `.devflow/config.json` sets
-`"devflow:code-reviewer": { "model": "claude-opus-4-8", "effort": "low", "iterations": "first-only" }`.
+`"devflow:code-reviewer": { "model": "claude-opus-5", "effort": "low", "iterations": "first-only" }`.
 The `iterations` scoping was added on the evidence of replay study **R2** (2026-07-11): on this repo's
 overwhelmingly `engine_self_modifying` diffs, `devflow:code-reviewer` measured **6.7% unique-effective**
 (9 of 135 dispatches), **2 sole-source applied Importants across 129 dispatches**, and — the positional
@@ -141,13 +141,13 @@ late ones) with no measured loss.
   `agent_overrides` model values apply identically to standalone `/devflow:review`, and the frozen-judge
   guardrail of the 2026-07-11 optimization methodology forbids repricing the outcome judge's roster
   mid-window. After the current experiment window closes, a follow-up PR reprices `model` from
-  `claude-opus-4-8` to `claude-haiku-4-5-20251001` (the exact id, since the resolver forwards model
+  `claude-opus-5` to `claude-haiku-4-5-20251001` (the exact id, since the resolver forwards model
   strings unvalidated) **and drops the entry's `effort: "low"` key** — a Haiku id must not carry
   `effort` (see the Haiku HTTP-400 callout above), so the swap is not literally one line: the entry
   becomes `{ "model": "claude-haiku-4-5-20251001", "iterations": "first-only" }`. That follow-up
   carries its own trigger: any specialty-class escaped
   Important-or-higher finding on a PR reviewed under the repriced config within **4 retrospective weeks**
-  (extended until **30 repriced dispatches**) reverts the model to `claude-opus-4-8`. A deterministic
+  (extended until **30 repriced dispatches**) reverts the model to `claude-opus-5`. A deterministic
   auto-revert mechanism was considered and rejected — no machinery exists to edit tracked config on a
   metric threshold, and building it is out of proportion to a one-line revert.
 

--- a/docs/review-agent-overrides.md
+++ b/docs/review-agent-overrides.md
@@ -84,7 +84,7 @@ Each value optionally sets `model`, `effort`, and/or `iterations`:
   "devflow_review": {
     "agent_overrides": {
       "default": { "effort": "high" },
-      "devflow:checklist-deduper": { "model": "claude-sonnet-4-6", "effort": "medium" },
+      "devflow:checklist-deduper": { "model": "claude-sonnet-5", "effort": "medium" },
       "devflow:code-reviewer": { "model": "claude-opus-5", "effort": "high", "iterations": "first-only" }
     }
   }
@@ -109,7 +109,7 @@ Each value optionally sets `model`, `effort`, and/or `iterations`:
 > **Claude Haiku rejects `effort`.** The `effort` parameter is supported only on Opus 4.5–4.8, Opus 5, Sonnet 4.6, and
 > Sonnet 5; Claude Haiku rejects it with **HTTP 400**. So any entry that pins a Haiku model (a
 > `claude-haiku-*` id) **must not** also carry an `effort` key. The shipped `devflow:checklist-deduper`
-> override pins Claude Sonnet 4.6 (which *does* support `effort`) with effort `medium`, so it is exempt;
+> override pins Claude Sonnet 5 (which *does* support `effort`) with effort `medium`, so it is exempt;
 > the constraint matters if you re-pin a Haiku id there. The schema does not enforce this (it is a model-API fact, not a structural
 > one), so the constraint is documented on the `devflow:checklist-deduper` property in
 > `config.schema.json` and guarded by the shipped-example test in `lib/test/run.sh`.

--- a/lib/test/run.sh
+++ b/lib/test/run.sh
@@ -10845,7 +10845,7 @@ SC_BF_OUT="$(bash "$SC" "$SC_BF" 2>&1)"
 assert_eq "scaffold-backfill: nested missing key added (devflow_runner.provision_env)" \
   "false" "$(jq -r '.devflow_runner.provision_env' "$SC_BF/.devflow/config.json")"
 assert_eq "scaffold-backfill: top-level missing key added (claude_model)" \
-  "claude-opus-4-8" "$(jq -r '.claude_model' "$SC_BF/.devflow/config.json")"
+  "claude-opus-5" "$(jq -r '.claude_model' "$SC_BF/.devflow/config.json")"
 assert_eq "scaffold-backfill: existing top-level value preserved (base_branch)" \
   "release" "$(jq -r '.base_branch' "$SC_BF/.devflow/config.json")"
 assert_eq "scaffold-backfill: existing nested value preserved (devflow_runner.effort)" \

--- a/lib/test/run.sh
+++ b/lib/test/run.sh
@@ -10871,7 +10871,7 @@ assert_eq "scaffold-backfill: complete config is a byte-identical no-op" \
   "$SC_NOOP_BEFORE" "$(cat "$SC_NOOP/.devflow/config.json")"
 assert_eq "scaffold-backfill: no-op does NOT emit the backfill log line" "no" \
   "$(printf '%s' "$SC_NOOP_OUT" | grep -q 'backfilled newly-added keys' && echo yes || echo no)"
-# The shipped example pins Sonnet 4.6 (no Haiku override), so a fresh scaffold of
+# The shipped example pins Sonnet 5 (no Haiku override), so a fresh scaffold of
 # it must never emit the Haiku effort-cleanup log line — locks the clean path so
 # a regression that re-pins Haiku-with-effort in the example is caught.
 assert_eq "scaffold-migration: clean shipped example emits no Haiku cleanup log line" "no" \
@@ -11592,27 +11592,28 @@ assert_eq "init-memory-nudge: recommends the built-in /init" "yes" \
 assert_pin_unique "init-memory-nudge: never writes/edits any agent file (advisory)" 'never creates, writes, or edits' "$INIT_SKILL"
 assert_pin_unique "init-memory-nudge: never blocks or fails init" 'never blocks or fails init' "$INIT_SKILL"
 # ────────────────────────────────────────────────────────────────────────────
-echo "shipped agent_overrides: deduper pins Sonnet 4.6 w/ effort; no Haiku override carries effort"
+echo "shipped agent_overrides: deduper pins Sonnet 5 w/ effort; no Haiku override carries effort"
 # ────────────────────────────────────────────────────────────────────────────
-# The shipped checklist-deduper override pins Claude Sonnet 4.6 (which DOES
-# support `effort`) with effort "medium" — Sonnet 4.6's recommended default, and
-# effort must be set explicitly on Sonnet 4.6 to avoid unexpected latency. A
+# The shipped checklist-deduper override pins Claude Sonnet 5 (which DOES
+# support `effort`) with effort "medium" — a cost-saving step down from the API
+# default of "high"; set it explicitly to avoid unexpected latency. A
 # positive sentinel, not a bare has("effort"): a refactor that drops/renames the
 # entry, swaps the model, or strips the effort each FAIL loudly rather than
 # sailing through green. The entry must positively EXIST, be object-typed, pin
-# claude-sonnet-4-6, AND carry an `effort` key — so a dropped/renamed entry
-# ("missing-entry"), a model no longer Sonnet 4.6 ("not-sonnet"), or a removed
+# claude-sonnet-5, AND carry an `effort` key — so a dropped/renamed entry
+# ("missing-entry"), a model no longer Sonnet 5 ("not-sonnet"), or a removed
 # effort ("no-effort") each FAIL loudly.
-assert_eq "agent_overrides: shipped deduper override exists, pins Sonnet 4.6, and carries an effort key" \
+assert_eq "agent_overrides: shipped deduper override exists, pins Sonnet 5, and carries an effort key" \
   "ok" \
   "$(jq -r '
       (.devflow_review.agent_overrides["devflow:checklist-deduper"]) as $d
       | if ($d | type) != "object" then "missing-entry"
-        elif (($d.model // "") != "claude-sonnet-4-6") then "not-sonnet"
+        elif (($d.model // "") != "claude-sonnet-5") then "not-sonnet"
         elif ($d | has("effort") | not) then "no-effort"
         else "ok" end' "$TPL_DIR/config.example.json")"
-# Claude Haiku rejects `effort` with HTTP 400 (supported only on Opus 4.5–4.8 /
-# Sonnet 4.6). The shipped example no longer pins Haiku anywhere, but this guard
+# Claude Haiku rejects `effort` with HTTP 400 (supported only on Opus 4.5–4.8,
+# Opus 5, Sonnet 4.6, and Sonnet 5). The shipped example no longer pins Haiku
+# anywhere, but this guard
 # keeps the invariant the scaffold-config.sh cleanup protects: should any shipped
 # override ever pin a Haiku model, it must NOT also carry an `effort` key.
 assert_eq "agent_overrides: no shipped Haiku-pinned override carries an effort key" \

--- a/lib/test/test_python_scripts.py
+++ b/lib/test/test_python_scripts.py
@@ -3882,7 +3882,7 @@ _shipped_cr = (
     _shipped_cfg["devflow_review"]["agent_overrides"]["devflow:code-reviewer"]
 )
 assert_eq("#425 config.json: code-reviewer override is model+effort+iterations exactly",
-          {"model": "claude-opus-4-8", "effort": "low", "iterations": "first-only"},
+          {"model": "claude-opus-5", "effort": "low", "iterations": "first-only"},
           _shipped_cr)
 _example_cfg_path = SCRIPTS.parent / '.devflow' / 'config.example.json'
 with open(_example_cfg_path) as _ecf:

--- a/scripts/scaffold-config.sh
+++ b/scripts/scaffold-config.sh
@@ -294,7 +294,7 @@ else
             .devflow_review.agent_overrides |= with_entries(
               # Do NOT let the deep-merge GRAFT an effort from the example onto a
               # Haiku-pinned entry the user left effort-less. The shipped example
-              # pins the deduper to Sonnet 4.6 WITH effort; merged onto a config that
+              # pins the deduper to Sonnet 5 WITH effort; merged onto a config that
               # re-pins that key to a Haiku id, the merge would add the effort from
               # the example (Claude Haiku rejects effort with HTTP 400) and re-graft
               # it on every re-scaffold, fighting the cleanup below forever. Strip
@@ -332,7 +332,7 @@ fi
 # Repair model/effort combinations the model API rejects but the no-clobber
 # backfill above structurally cannot fix. The shipped example once pinned the
 # checklist-deduper to a Haiku id and carried an `effort` key on it; the example
-# now defaults that override to Sonnet 4.6, but a key *removal* never propagates
+# now defaults that override to Sonnet 5, but a key *removal* never propagates
 # through the backfill — it only ADDS keys, never deletes (see the
 # deletion-tracking note above). So an adopter who scaffolded earlier silently
 # keeps `effort` on a Haiku override (their own deduper pin, or any other agent


### PR DESCRIPTION
Opus 5 is out — this moves DevFlow's default model from Claude Opus 4.8 to Claude Opus 5 (`claude-opus-5`).

## Changes

**Configs (`.devflow/`)**
- `config.example.json` — `claude_model`, the `devflow:code-reviewer` agent override, `devflow_retrospective.audit_model`
- `config.schema.json` — `claude_model` default
- `config.json` (this repo's tracked live config) — `claude_model`, the `devflow:code-reviewer` agent override, `devflow_retrospective.retrospective_model` + `audit_model`

**Coupled mirrors**
- `lib/test/run.sh` — the scaffold-backfill pin asserting the shipped `claude_model` default
- `docs/DEVFLOW_SYSTEM_OVERVIEW.md`, `docs/cloud-setup.md` — documented default
- `docs/review-agent-overrides.md` — the quoted current config, the issue-#425 deferred-repricing revert target, and the `effort`-support model list (Opus 5 and Sonnet 5 support `effort`; Haiku still rejects it)

Out of scope: `claude-sonnet-4-6` pins and test fixtures that use a model id as an opaque string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)