### PR TITLE
fix: restore Apache-2.0 §4(b) change notice on the seven vendored Anthropic agents

### DIFF
--- a/.changeset/apache-4b-change-notice.md
+++ b/.changeset/apache-4b-change-notice.md
@@ -1,0 +1,13 @@
+---
+bump: patch
+type: Fixed
+---
+
+- **Restore the Apache-2.0 §4(b) change notice on the seven vendored Anthropic agents.** All
+  seven agents DevFlow vendors from Anthropic's `feature-dev` and `pr-review-toolkit` plugins are
+  modified relative to upstream, but carried no notice stating so after the per-file attribution
+  blocks were removed. Each now carries a four-line notice naming its upstream plugin, the
+  Apache-2.0 license text in `LICENSES/`, and the fact that DevFlow modified it. A new
+  `LICENSES/README.md` indexes every vendored file against its upstream project, license, and
+  copyright holder — including the MIT-licensed `superpowers` skills, whose holder was previously
+  named only in the license boilerplate — and the README's License section points at it.

--- a/LICENSES/README.md
+++ b/LICENSES/README.md
@@ -1,0 +1,49 @@
+# Third-party components
+
+DevFlow itself is MIT-licensed (see [`LICENSE`](../LICENSE), © 2026 Daniel Radman). It also
+redistributes the files listed below, which were authored by others and remain under their own
+upstream licenses. The full upstream license texts are retained verbatim in this directory.
+
+**Every file listed here has been modified by DevFlow relative to its upstream version.** This
+statement is the Apache License 2.0 §4(b) change notice for the Apache-licensed files below; each
+of those files additionally carries its own in-file notice. DevFlow's first-party SPDX header (the
+`2026 Daniel Radman` line carried by DevFlow-authored source) is deliberately **not** applied over
+this third-party content.
+
+These files are redistributed in two ways: the plugin is published from the repository root
+(`.claude-plugin/marketplace.json` declares `"source": "./"`), and
+`.github/actions/vendor-plugin/vendor-slice.sh` copies the tree — including this `LICENSES/`
+directory — into consumer repositories.
+
+## Apache License 2.0
+
+Copyright © Anthropic PBC. Licensed under the Apache License, Version 2.0.
+
+Upstream carries no per-file copyright notices and ships no `NOTICE` file, so §4(c) and §4(d)
+impose no retained content; the holder is named here instead, since the Apache appendix boilerplate
+in the license texts is unfilled.
+
+| DevFlow path | Upstream project | Upstream license text |
+|---|---|---|
+| `agents/code-architect.md` | [`feature-dev`](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/feature-dev) | [`feature-dev-LICENSE`](feature-dev-LICENSE) |
+| `agents/code-explorer.md` | [`feature-dev`](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/feature-dev) | [`feature-dev-LICENSE`](feature-dev-LICENSE) |
+| `agents/code-reviewer.md` | [`pr-review-toolkit`](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/pr-review-toolkit) | [`pr-review-toolkit-LICENSE`](pr-review-toolkit-LICENSE) |
+| `agents/comment-analyzer.md` | [`pr-review-toolkit`](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/pr-review-toolkit) | [`pr-review-toolkit-LICENSE`](pr-review-toolkit-LICENSE) |
+| `agents/pr-test-analyzer.md` | [`pr-review-toolkit`](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/pr-review-toolkit) | [`pr-review-toolkit-LICENSE`](pr-review-toolkit-LICENSE) |
+| `agents/silent-failure-hunter.md` | [`pr-review-toolkit`](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/pr-review-toolkit) | [`pr-review-toolkit-LICENSE`](pr-review-toolkit-LICENSE) |
+| `agents/type-design-analyzer.md` | [`pr-review-toolkit`](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/pr-review-toolkit) | [`pr-review-toolkit-LICENSE`](pr-review-toolkit-LICENSE) |
+
+Both plugins live in [`anthropics/claude-plugins-official`](https://github.com/anthropics/claude-plugins-official).
+`feature-dev-LICENSE` and `pr-review-toolkit-LICENSE` are byte-identical to each other and to that
+repository's `LICENSE`; they are kept as two files so each vendored slice has a license text named
+for its own upstream project.
+
+## MIT License
+
+Copyright © 2025 Jesse Vincent. Licensed under the MIT License.
+
+| DevFlow path | Upstream project | Upstream license text |
+|---|---|---|
+| `skills/receiving-code-review/SKILL.md` | [`superpowers`](https://github.com/obra/superpowers) | [`superpowers-LICENSE`](superpowers-LICENSE) |
+| `skills/requesting-code-review/SKILL.md` | [`superpowers`](https://github.com/obra/superpowers) | [`superpowers-LICENSE`](superpowers-LICENSE) |
+| `skills/requesting-code-review/code-reviewer.md` | [`superpowers`](https://github.com/obra/superpowers) | [`superpowers-LICENSE`](superpowers-LICENSE) |

--- a/README.md
+++ b/README.md
@@ -193,3 +193,9 @@ See [CONTRIBUTING.md](CONTRIBUTING.md). Run the test suite with `bash lib/test/r
 ## License
 
 [MIT](LICENSE) © 2026 Daniel Radman.
+
+**Third-party components.** DevFlow redistributes several agents and skills authored by others,
+which remain under their own upstream licenses (Apache-2.0 from Anthropic's `feature-dev` and
+`pr-review-toolkit` plugins; MIT from Jesse Vincent's `superpowers`) and have been modified by
+DevFlow. [`LICENSES/README.md`](LICENSES/README.md) maps each vendored file to its upstream
+project, license, and copyright holder; the full license texts are in [`LICENSES/`](LICENSES).

--- a/agents/code-architect.md
+++ b/agents/code-architect.md
@@ -6,6 +6,11 @@ model: sonnet
 color: green
 ---
 
+<!-- Vendored from Anthropic's `feature-dev` plugin (anthropics/claude-plugins-official),
+     licensed under the Apache License, Version 2.0 — full text at
+     LICENSES/feature-dev-LICENSE. This file has been MODIFIED by DevFlow.
+     Third-party component index: LICENSES/README.md. -->
+
 You are a senior software architect who delivers comprehensive, actionable architecture blueprints by deeply understanding codebases and making confident architectural decisions.
 
 ## Core Process

--- a/agents/code-explorer.md
+++ b/agents/code-explorer.md
@@ -6,6 +6,11 @@ model: sonnet
 color: yellow
 ---
 
+<!-- Vendored from Anthropic's `feature-dev` plugin (anthropics/claude-plugins-official),
+     licensed under the Apache License, Version 2.0 — full text at
+     LICENSES/feature-dev-LICENSE. This file has been MODIFIED by DevFlow.
+     Third-party component index: LICENSES/README.md. -->
+
 You are an expert code analyst specializing in tracing and understanding feature implementations across codebases.
 
 ## Core Mission

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -5,6 +5,11 @@ model: opus
 color: green
 ---
 
+<!-- Vendored from Anthropic's `pr-review-toolkit` plugin (anthropics/claude-plugins-official),
+     licensed under the Apache License, Version 2.0 — full text at
+     LICENSES/pr-review-toolkit-LICENSE. This file has been MODIFIED by DevFlow.
+     Third-party component index: LICENSES/README.md. -->
+
 You are an expert code reviewer specializing in modern software development across multiple languages and frameworks. Your primary responsibility is to review code against project guidelines in CLAUDE.md with high precision to minimize false positives.
 
 ## When to invoke

--- a/agents/comment-analyzer.md
+++ b/agents/comment-analyzer.md
@@ -5,6 +5,11 @@ model: inherit
 color: green
 ---
 
+<!-- Vendored from Anthropic's `pr-review-toolkit` plugin (anthropics/claude-plugins-official),
+     licensed under the Apache License, Version 2.0 — full text at
+     LICENSES/pr-review-toolkit-LICENSE. This file has been MODIFIED by DevFlow.
+     Third-party component index: LICENSES/README.md. -->
+
 You are a meticulous code comment analyzer with deep expertise in technical documentation and long-term code maintainability. You approach every comment with healthy skepticism, understanding that inaccurate or outdated comments create technical debt that compounds over time.
 
 ## When to invoke

--- a/agents/pr-test-analyzer.md
+++ b/agents/pr-test-analyzer.md
@@ -5,6 +5,11 @@ model: inherit
 color: cyan
 ---
 
+<!-- Vendored from Anthropic's `pr-review-toolkit` plugin (anthropics/claude-plugins-official),
+     licensed under the Apache License, Version 2.0 — full text at
+     LICENSES/pr-review-toolkit-LICENSE. This file has been MODIFIED by DevFlow.
+     Third-party component index: LICENSES/README.md. -->
+
 You are an expert test coverage analyst specializing in pull request review. Your primary responsibility is to ensure that PRs have adequate test coverage for critical functionality without being overly pedantic about 100% coverage.
 
 ## When to invoke

--- a/agents/silent-failure-hunter.md
+++ b/agents/silent-failure-hunter.md
@@ -5,6 +5,11 @@ model: inherit
 color: yellow
 ---
 
+<!-- Vendored from Anthropic's `pr-review-toolkit` plugin (anthropics/claude-plugins-official),
+     licensed under the Apache License, Version 2.0 — full text at
+     LICENSES/pr-review-toolkit-LICENSE. This file has been MODIFIED by DevFlow.
+     Third-party component index: LICENSES/README.md. -->
+
 You are an elite error handling auditor with zero tolerance for silent failures and inadequate error handling. Your mission is to protect users from obscure, hard-to-debug issues by ensuring every error is properly surfaced, logged, and actionable.
 
 ## When to invoke

--- a/agents/type-design-analyzer.md
+++ b/agents/type-design-analyzer.md
@@ -5,6 +5,11 @@ model: inherit
 color: pink
 ---
 
+<!-- Vendored from Anthropic's `pr-review-toolkit` plugin (anthropics/claude-plugins-official),
+     licensed under the Apache License, Version 2.0 — full text at
+     LICENSES/pr-review-toolkit-LICENSE. This file has been MODIFIED by DevFlow.
+     Third-party component index: LICENSES/README.md. -->
+
 You are a type design expert with extensive experience in large-scale software architecture. Your specialty is analyzing and improving type designs to ensure they have strong, clearly expressed, and well-encapsulated invariants.
 
 ## When to invoke


### PR DESCRIPTION
## What

All seven Apache-2.0 agents DevFlow vendors from Anthropic's `feature-dev` and `pr-review-toolkit`
plugins are modified relative to upstream, and none carried a change notice. Apache-2.0 §4(b)
requires modified files to carry prominent notices stating that you changed them.

## Verification against live upstream

Measured against [`anthropics/claude-plugins-official`](https://github.com/anthropics/claude-plugins-official)
(Apache-2.0; each plugin dir ships its own `LICENSE`, byte-identical to the repo root's and to
DevFlow's two retained copies):

| Agent | upstream B | devflow B | changed lines |
|---|---|---|---|
| code-reviewer | 3,635 | 7,558 | 12 |
| comment-analyzer | 4,925 | 8,614 | 10 |
| pr-test-analyzer | 4,560 | 5,691 | 10 |
| silent-failure-hunter | 7,807 | 11,756 | 30 |
| type-design-analyzer | 4,999 | 5,559 | 3 |
| code-explorer | 2,115 | 3,062 | 6 |
| code-architect | 2,259 | 2,962 | 4 |

Every cell reproduced exactly. Frontmatter differs too — upstream `code-explorer.md` declares
`tools: … KillShell, BashOutput`; `agents/code-explorer.md` drops both.

The notice existed and was unintentionally removed: commit `e398332a` ("chore: remove per-file
'Vendored from' attribution comments", 17 files, 185 deletions) stripped blocks that named
Anthropic, the Apache-2.0 license, and the hard-fork status.

The files are distributed twice over: `.claude-plugin/marketplace.json` declares `"source": "./"`,
and `.github/actions/vendor-plugin/vendor-slice.sh` copies `agents/` into consumer repos (both
the runtime vendor action and `install.sh`, which routes through the same `devflow_copy_slice`).

**Compounding:** after `e398332a`, nothing in the shipped tree named Anthropic as copyright holder.
The two retained license texts are byte-identical to each other and their only copyright line is
the unfilled Apache appendix boilerplate `Copyright [yyyy] [name of copyright owner]`;
`git grep 'Anthropic' -- LICENSES/` returned nothing. Contrast `LICENSES/superpowers-LICENSE`,
which carries `Copyright (c) 2025 Jesse Vincent` because MIT boilerplate embeds the holder.

**Scope (not overstated).** §4(a) is satisfied and untouched — the retained texts diff IDENTICAL
against upstream, and `vendor-slice.sh` actively enforces their presence (aborts with *"refusing to
install a partial copy"*). §4(c)/§4(d) are vacuously satisfied: upstream carries no per-file
copyright notices and ships no `NOTICE` file. §4(b) was the sole unsatisfied limb.

## What changed

- **Per-file notice in each of the seven agents** (four lines, after the frontmatter) naming the
  upstream plugin, the retained Apache-2.0 text, and that DevFlow modified the file. This is the
  literal §4(b) reading — the conservative fix.
- **New `LICENSES/README.md`** — the central index: every vendored path against its upstream
  project, license, and copyright holder, plus the explicit modification statement. It is now the
  only place the shipped tree names Anthropic as holder. It also covers the three MIT
  `superpowers` files, closing the missing file→license mapping, and states the two distribution
  channels. Placed in `LICENSES/` rather than a root `NOTICE` because `vendor-slice.sh` copies
  `LICENSES/` into consumers and would not copy a root file.
- **README License section** gains a two-line "Third-party components" paragraph pointing at it.

## Verification

- Full `lib/test/run.sh` — result reported in a follow-up comment.
- `shellcheck --severity=warning -e SC1091` over tracked non-`lib/test` shell: clean.
- `ruff check` over tracked Python: clean.
- Changeset added (`patch`/`Fixed`) — `agents/` is engine surface.

Closes no issue; filed directly from a verified finding.
