### PR TITLE
fix(workflows): correct devflow.yml comments describing the withheld auto-review tier

### DIFF
--- a/.changeset/stale-devflow-yml-synchronize-comments.md
+++ b/.changeset/stale-devflow-yml-synchronize-comments.md
@@ -1,0 +1,12 @@
+---
+bump: patch
+---
+
+### Fixed
+
+- Corrected stale comments in `.github/workflows/devflow.yml` that still described the
+  automatic pull-request-triggered review tier — withheld by issue #936, with
+  `devflow-review.yml` removed from the tree — as a live `synchronize`-driven mechanism.
+  The file header, the `review_dedupe` policy block, and the Signal 2 comment now state
+  that the tier is withheld here and that the dedupe gate is retained for consumers whose
+  installed copy predates the withholding. Comment-only: no executable line changed.

--- a/.github/workflows/devflow.yml
+++ b/.github/workflows/devflow.yml
@@ -6,12 +6,18 @@ name: DevFlow
 # `review_dedupe` / `gate` / `command`). This is the body that used to live in
 # the standalone claude.yml.
 #
-# The reusable runner that devflow-review.yml calls lives in its OWN file,
-# devflow-runner.yml — NOT here. It was split out because a called reusable
+# The reusable review runner lives in its OWN file, devflow-runner.yml — NOT
+# here. Its caller was devflow-review.yml, the automatic pull-request-triggered
+# review tier, which issue #936 WITHHELD from this release: that file is no
+# longer in the tree, install.sh ships none of the tier's files, and
+# devflow-runner.yml is retained without a caller. The supported review path is
+# therefore a collaborator commenting `/devflow:review` — this file's `command`
+# job. The runner was split out in the first place because a called reusable
 # workflow's permission ceiling is validated against the caller's grant across
 # the whole graph: co-locating the high-privilege `command` job (contents:write
-# to push, issues:write to react) with the low-privilege runner made a read-only
-# caller like devflow-review.yml fail with `startup_failure`. This file therefore
+# to push, issues:write to react) with the low-privilege runner made that
+# caller — a workflow holding read permissions alone — fail with
+# `startup_failure`. This file therefore
 # has NO `workflow_call` trigger — it is purely event-driven.
 #
 # Why bare commands (no `@claude`): Anthropic's Claude GitHub App owns the
@@ -134,24 +140,28 @@ jobs:
           fi
           echo "claude_code_executable=$CLAUDE_CODE_EXECUTABLE" >> "$GITHUB_OUTPUT"
 
-  # Dedupe a MANUAL bare `/devflow:review` comment against the AUTOMATED
-  # devflow-review path. Both are independent triggers: a commit
-  # push fires devflow-review's `synchronize` re-review, and the
-  # human who pushed it typically also comments `/devflow:review`
-  # within a second or two. Without this gate BOTH run a full (billable) LLM
-  # review of the same HEAD and post their own status comment — the observed
-  # "two comments" bug (PR #113, 15:06:55 synchronize + 15:06:56 comment).
+  # Dedupe a MANUAL bare `/devflow:review` comment against an AUTOMATED
+  # pull-request-triggered review. Issue #936 WITHHELD that automatic tier from
+  # this release, so nothing in this tree fires one and both signals below
+  # resolve to zero (fail-open — the manual review proceeds). The gate is
+  # retained because a consumer that installed the tier before it was withheld
+  # keeps its own copy, and there the two triggers stay independent: a commit
+  # push fires that copy's re-review, and the human who pushed it typically also
+  # comments `/devflow:review` within a second or two. Without this gate BOTH
+  # run a full (billable) LLM review of the same HEAD and post their own status
+  # comment — the observed "two comments" bug (PR #113, 15:06:55 synchronize +
+  # 15:06:56 comment).
   #
-  # Policy ("auto suppresses manual"): if devflow-review is already
+  # Policy ("auto suppresses manual"): if such an automated review is already
   # in-flight for this PR's CURRENT head — either an in_progress `Devflow
   # Review` check on that exact SHA, or a queued/in_progress
-  # devflow-review run on the PR's branch (covers the sub-second
-  # race before create_check POSTs the check) — skip the manual review and
-  # leave a one-line pointer instead. Deliberately fail-OPEN (default
-  # suppress=false): a missed suppression just reproduces today's recoverable
+  # auto-review workflow run on the PR's branch (covers the sub-second
+  # race before that tier's create_check POSTs the check) — skip the manual
+  # review and leave a one-line pointer instead. Deliberately fail-OPEN (default
+  # suppress=false): a missed suppression just reproduces the recoverable
   # double-comment, whereas a wrong suppression would silently swallow a
   # review the user explicitly asked for. This is the opposite failure
-  # direction from devflow-review's fail-closed gates, by design.
+  # direction from that tier's fail-closed gates, by design.
   #
   # Only `/devflow:review` is deduped — NOT `/devflow:review-and-fix` (that
   # auto-applies fixes and has no automated equivalent), and not the
@@ -273,11 +283,15 @@ jobs:
           fi
           [[ "$IC" =~ ^[0-9]+$ ]] || IC=0
 
-          # Signal 2: a queued/in_progress devflow-review run on the
-          # PR's branch. Covers the <1s synchronize-vs-comment race where the
-          # auto run has started but create_check has not POSTed the check yet
-          # (an in-flight auto run on the same branch is, by that workflow's
-          # own first-ready/synchronize design, reviewing the latest HEAD).
+          # Signal 2: a queued/in_progress devflow-review.yml run on the
+          # PR's branch. Issue #936 withheld that workflow, so in this tree the
+          # query resolves nothing and Signal 2 never suppresses (an
+          # unresolvable query takes the fail-open arm below). It still fires for
+          # a consumer whose installed copy predates the withholding, where it
+          # covers the sub-second auto-vs-comment race in which the auto run has
+          # started but create_check has not POSTed the check yet (an in-flight
+          # auto run on the same branch is, by that tier's own
+          # first-ready/re-review design, reviewing the latest HEAD).
           IR=0
           if [ -n "$BRANCH" ] && [ "$BRANCH" != "null" ]; then
             if ! IR=$(gh run list --repo "$REPO" \


### PR DESCRIPTION
## What was stale, and why

PR #937 (issue #936) **withheld the automatic pull-request-triggered review tier**:
`.github/workflows/devflow-review.yml` is gone from the tree, `devflow-runner.yml` is
retained but has no caller, and `install.sh` ships none of the three tier files. The
supported review path is now a collaborator commenting `/devflow:review` or
`/devflow:review-and-fix`, handled by `devflow.yml`'s `command` job (actor-gated by
`scripts/authorize-actor.sh` in the `gate` job).

`devflow.yml` was not touched by #937 and still described that tier's `synchronize`-driven
auto-review as a **live mechanism**. This PR corrects those comments. Comment-only.

## Sites changed (3 comment blocks)

`git grep -n synchronize -- .github/workflows/devflow.yml` returned **4** hits on
`origin/main`. Three were stale; one is an accurate past-time record and is deliberately
untouched.

| # | Site (origin/main line) | Was | Now |
|---|---|---|---|
| 1 | File header, ~L9–15 (no `synchronize` token — the stale claim spans lines that do not contain the word) | "The reusable runner that `devflow-review.yml` **calls**…" — present tense, asserting the caller exists | States the caller *was* `devflow-review.yml`, that #936 withheld it from this release, that `install.sh` ships none of the tier's files, that `devflow-runner.yml` is retained without a caller, and that the supported path is the `/devflow:review` comment. The `startup_failure` split rationale is kept, reworded to past tense. |
| 2 | `review_dedupe` header, L137–158 (`synchronize` at L139) | "Dedupe … against the AUTOMATED devflow-review path. Both are independent triggers: a commit push **fires** devflow-review's `synchronize` re-review" | States the tier is withheld here so both signals resolve to zero (fail-open), and that the gate is **retained** because a consumer that installed the tier before it was withheld keeps its own copy — where the two triggers do stay independent. Policy paragraph re-pointed from "devflow-review" to "that tier". |
| 3 | Signal 2 comment inside the `guard` step's `run:` script, L276–280 (`synchronize` at L277 and L280) | "Covers the <1s **synchronize-vs-comment** race … by that workflow's own first-ready/`synchronize` design" | States that #936 withheld the workflow so in this tree Signal 2 never suppresses (an unresolvable query takes the fail-open arm below), and that it still fires for a consumer whose installed copy predates the withholding. |

### Deliberately left alone

- **The 4th `synchronize` hit** — `(PR #113, 15:06:55 synchronize + 15:06:56 comment)` — is a
  correct past-time record of an observed event (the "two comments" bug), not a
  live-mechanism claim. It survives verbatim; it is the only remaining `synchronize` token in
  the file.
- **`devflow-runner.yml` references** (the `allowed_bots` guard mirror, the token-downscope
  contracts, the `Compose review prompt` parallel, the `DEVFLOW_TELEMETRY_PUSH` contrast).
  That file is retained in the tree with those contents intact, so the statements are true.
- **`devflow-review.yml`'s `finalize_check`** cited as a design sibling in the dead-run
  review-progress flip (~L1292) and the no-verdict auto-resume backstop (~L1330). These are
  design-lineage parallels rather than claims that an auto-review will happen here, #937
  deliberately left them, and correcting them would be a judgement call rather than a
  fact fix — **reported as ambiguous rather than guessed at**.
- The executable `gh run list --workflow devflow-review.yml` query itself, which is still
  correct for a consumer retaining the tier.

## No executable line changed

```
git diff origin/main...HEAD -- .github/workflows/devflow.yml \
  | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' | grep -vE '^[+-][[:space:]]*#'
```
→ **no output**: every added and removed line is a comment line.

Independently, parsing both revisions with PyYAML and walking the trees shows exactly one
differing value — `/jobs/review_dedupe/steps[2]/run`, because site 3 is a *shell* comment
inside a `run: |` block scalar — and that value is identical once whole-line shell comments
are stripped. All other job/step/permission/`if:`/`TOOLS` values are byte-identical.

## Verification observed

- `lib/test/run.sh` (full suite, direct leading token, foreground session with default
  signal disposition): **`14033 passed, 0 failed`** — the summary carries no skip tally, and the log holds
  **zero `NOTE ` emits** (the suite's only sanctioned self-skip channel), zero `FAIL` lines
  and no `Failure recap`. So: 14033 passed / 0 failed / **0 skipped** — a clean pass under the
  issue-#456 accounting, not a `0 failed` with a laundered skip population.
- `git ls-files '*.sh' | grep -v '^lib/test/' | xargs -r shellcheck --severity=warning -e SC1091`
  → clean, rc 0.
- `git diff origin/main...HEAD | scripts/stale-prose-lint.py --rev HEAD` → **no findings**,
  rc 0. (An earlier draft of site 1 tripped the issue-#818 coverage-universal tier: the
  phrase `read-only caller` matches the `only` + `caller` shape. Reworded to "a workflow
  holding read permissions alone" rather than opted out.)
- No `lib/test/` pin was touched. The `#936` surviving-reference allowlist in
  `lib/test/run.sh` already lists `.github/workflows/devflow.yml` and asserts a *path set*,
  not comment wording; the file still mentions `devflow-review.yml`, so that inventory is
  unchanged.

## Changeset

`.changeset/stale-devflow-yml-synchronize-comments.md`, `bump: patch` (`.github/workflows/`
is engine surface). `plugin.json` and `CHANGELOG.md` untouched, per the changeset policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
