### PR TITLE
fix(agents): declare explicit tools: allowlists on the eight inheriting subagents

### DIFF
--- a/.changeset/subagent-tool-allowlists.md
+++ b/.changeset/subagent-tool-allowlists.md
@@ -1,0 +1,34 @@
+---
+bump: patch
+---
+
+### Changed
+
+- **Every DevFlow-authored subagent now declares an explicit `tools:` allowlist.** The three
+  `checklist-*` agents and the five vendored `pr-review-toolkit` review agents
+  (`code-reviewer`, `comment-analyzer`, `pr-test-analyzer`, `silent-failure-hunter`,
+  `type-design-analyzer`) previously carried no `tools:` key, so each inherited the full
+  subagent toolset — including `Edit`, `Write`, `MultiEdit`, `NotebookEdit` and `Task` —
+  while five of them state a read-only advisory working-tree policy in their own bodies
+  ("never modify working-tree source files, the index, HEAD, or branch state"). That policy
+  was requested in prose and unenforced by the harness. Each agent now names only what its
+  body and its dispatch prompt actually use: `Read, Grep, Glob` for `checklist-generator`,
+  `Read` for `checklist-deduper` (a pure JSON-to-JSON merge), and `Read, Grep, Glob, Bash`
+  for the five review agents, whose `git diff` / `git show` scope reads and `mktemp`
+  mutation-checks need Bash. `checklist-verifier` additionally keeps `Write`, because the
+  Phase 2.1b dispatch prompt instructs it to write its verdict JSON to `{VERDICT_FILE}`.
+  `Task` is dropped everywhere: none of the eight dispatches a subagent.
+
+  **This is a name-level boundary, not read-only enforcement.** The six agents that hold
+  `Bash` can still reach the working tree through it (`sed -i`, `git checkout --`, `git
+  reset`). What the change closes is the tool-shaped path — an agent reaching for `Edit`
+  or `Write` on a file it was told only to report on. The Phase-3 dirty-tree snapshot guard
+  remains the behavioral backstop, and per-tool argument scoping (`Bash(git show:*)`) is a
+  possible follow-up: such entries parse and round-trip, but whether they are *enforced* as
+  scoping is not yet measured.
+
+  Restricting an agent has one non-obvious failure mode, measured on Claude Code 2.1.220 and
+  now guarded: a `tools:` key whose value is **empty** — bare, `[]`, or `""` — parses
+  identically to omitting the key, so the agent inherits every tool. An emptied value is a
+  silent fail-open of this boundary rather than the tightest possible restriction, which is
+  why the new suite rows prove each value is non-empty before testing what it omits.

--- a/agents/checklist-deduper.md
+++ b/agents/checklist-deduper.md
@@ -1,6 +1,7 @@
 ---
 name: checklist-deduper
 description: Merges multiple batches of checklist items from checklist-generator into a single deduped checklist. Preserves traceability by recording which original IDs were merged. Does NOT judge correctness or re-tag items.
+tools: Read
 model: sonnet
 color: violet
 ---

--- a/agents/checklist-generator.md
+++ b/agents/checklist-generator.md
@@ -1,6 +1,7 @@
 ---
 name: checklist-generator
 description: Use when an orchestrator needs to enumerate every verifiable claim in a code diff (dependency interactions, test-mock alignment, data format assumptions, API contracts) and return a JSON checklist for independent verification. Does NOT judge correctness.
+tools: Read, Grep, Glob
 model: opus
 color: blue
 ---

--- a/agents/checklist-verifier.md
+++ b/agents/checklist-verifier.md
@@ -1,6 +1,7 @@
 ---
 name: checklist-verifier
 description: 'Verifies a single claim from the verification checklist against the actual source code. Reports PASS, FAIL, or INCONCLUSIVE with file:line evidence. Used for `verification_mode: "agent"` items; lite-mode items are resolved by the orchestrator directly via grep.'
+tools: Read, Grep, Glob, Bash, Write
 model: sonnet
 color: cyan
 ---

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -1,6 +1,7 @@
 ---
 name: code-reviewer
 description: DevFlow's project-guidelines reviewer, dispatched by the review engine and available directly. Use this agent when you need to review code for adherence to project guidelines, style guides, and best practices. This agent should be used proactively after writing or modifying code, especially before committing changes or creating pull requests. It will check for style violations, potential issues, and ensure code follows the established patterns in CLAUDE.md. Also the agent needs to know which files to focus on for the review. In most cases this will be recently completed work which is unstaged in git (can be retrieved by running git diff). However there can be cases where this is different, make sure to specify this as the agent input when calling the agent. Typical triggers include the user asking for a review of a feature they just implemented, the assistant proactively reviewing its own newly-written code before declaring a task done, and a final pre-PR check before opening a pull request. See "When to invoke" in the agent body for worked scenarios.
+tools: Read, Grep, Glob, Bash
 model: opus
 color: green
 ---

--- a/agents/comment-analyzer.md
+++ b/agents/comment-analyzer.md
@@ -1,6 +1,7 @@
 ---
 name: comment-analyzer
 description: DevFlow's comment-quality reviewer, dispatched by the review engine and available directly. Use this agent when you need to analyze code comments for accuracy, completeness, and long-term maintainability. This includes (1) after generating large documentation comments or docstrings, (2) before finalizing a pull request that adds or modifies comments, (3) when reviewing existing comments for potential technical debt or comment rot, and (4) when you need to verify that comments accurately reflect the code they describe. See "When to invoke" in the agent body for worked scenarios.
+tools: Read, Grep, Glob, Bash
 model: inherit
 color: green
 ---

--- a/agents/pr-test-analyzer.md
+++ b/agents/pr-test-analyzer.md
@@ -1,6 +1,7 @@
 ---
 name: pr-test-analyzer
 description: DevFlow's test-coverage reviewer, dispatched by the review engine and available directly. Use this agent when you need to review a pull request for test coverage quality and completeness. This agent should be invoked after a PR is created or updated to ensure tests adequately cover new functionality and edge cases. Typical triggers include the user asking whether tests on a freshly-created PR are thorough, an updated PR adding new logic that needs coverage analysis, and a final pre-merge double-check before marking a PR ready. See "When to invoke" in the agent body for worked scenarios.
+tools: Read, Grep, Glob, Bash
 model: inherit
 color: cyan
 ---

--- a/agents/silent-failure-hunter.md
+++ b/agents/silent-failure-hunter.md
@@ -1,6 +1,7 @@
 ---
 name: silent-failure-hunter
 description: 'DevFlow''s silent-failure reviewer, dispatched by the review engine and available directly. Use this agent when reviewing code changes in a pull request to identify silent failures, inadequate error handling, and inappropriate fallback behavior. This agent should be invoked proactively after completing a logical chunk of work that involves error handling, catch blocks, fallback logic, or any code that could potentially suppress errors. See "When to invoke" in the agent body for worked scenarios.'
+tools: Read, Grep, Glob, Bash
 model: inherit
 color: yellow
 ---

--- a/agents/type-design-analyzer.md
+++ b/agents/type-design-analyzer.md
@@ -1,6 +1,7 @@
 ---
 name: type-design-analyzer
 description: DevFlow's type-design reviewer, dispatched by the review engine and available directly. Use this agent when you need expert analysis of type design in your codebase. Specifically use it (1) when introducing a new type to ensure it follows best practices for encapsulation and invariant expression, (2) during pull request creation to review all types being added, and (3) when refactoring existing types to improve their design quality. The agent will provide both qualitative feedback and quantitative ratings on encapsulation, invariant expression, usefulness, and enforcement. See "When to invoke" in the agent body for worked scenarios.
+tools: Read, Grep, Glob, Bash
 model: inherit
 color: pink
 ---

--- a/lib/test/run.sh
+++ b/lib/test/run.sh
@@ -28160,9 +28160,9 @@ assert_eq "#141 no operative surface references the namespaced pr-review-toolkit
 # five review agents: the file exists first-party under agents/; the shared review engine
 # (skills/review/SKILL.md) dispatches the devflow: id AND a first-party agent of that exact
 # `name:` exists to resolve it (closing the #62/#98 dead-end-dispatch gap); the resolver
-# allowlists the devflow: id; and the frontmatter is well-formed. NOTE: unlike the #139
-# feature-dev agents, these carry NO `tools:` key (they inherit all tools), so 2c asserts
-# model: but NOT tools:.
+# allowlists the devflow: id; and the frontmatter is well-formed. Like the #139 feature-dev
+# agents, these now carry an explicit `tools:` allowlist (they no longer inherit every tool);
+# 2c asserts model:, and the tool-boundary block below owns the `tools:` contract.
 for a in $PRT_AGENTS; do
   assert_eq "#141 agents/$a.md exists (vendored first-party)" \
     "yes" "$([ -f "$FDROOT/agents/$a.md" ] && echo yes || echo no)"
@@ -28189,7 +28189,8 @@ for a in $PRT_AGENTS; do
     "yes" "$(grep -qF "\"devflow:$a\"" "$FDROOT/scripts/resolve-review-overrides.py" && echo yes || echo no)"
   # Structural markers (open + close ---, model:) within the head window — bounded to
   # head -30 so a body horizontal-rule cannot inflate the closing-fence count and mask a
-  # dropped closer. tools: is intentionally NOT required (these agents inherit all tools).
+  # dropped closer. The `tools:` key is asserted by the tool-boundary block below, which owns
+  # that contract for all eight explicitly-allowlisted agents (not just these five).
   assert_eq "#141 agents/$a.md has well-formed frontmatter (open+close ---, model:)" \
     "yes" "$(head -1 "$FDROOT/agents/$a.md" | grep -qx -- '---' \
             && [ "$(head -30 "$FDROOT/agents/$a.md" | grep -c '^---$')" -ge 2 ] \
@@ -28209,6 +28210,58 @@ assert_eq "#141 LICENSES/pr-review-toolkit-LICENSE retains the upstream Apache-2
 # scoped-removal guard above.
 assert_eq "#141 plugin.json dependencies no longer lists pr-review-toolkit" \
   "0" "$(jq '[.dependencies[]? | select(.name == "pr-review-toolkit")] | length' "$FDROOT/.claude-plugin/plugin.json")"
+
+# ────────────────────────────────────────────────────────────────────────────
+echo "subagent tool-boundary allowlists (agents/*.md)"
+# ────────────────────────────────────────────────────────────────────────────
+# Every DevFlow-authored subagent declares an explicit `tools:` allowlist, so the read-only
+# advisory policy each one states in its own body is enforced by the harness rather than only
+# requested in prose. Two measured facts drive the shape of these rows:
+#   - An empty `tools:` value (bare key, `[]`, or `""`) parses IDENTICALLY to omitting the key
+#     — the agent inherits EVERY tool (measured on Claude Code 2.1.220 by probing all four
+#     forms against a control). So an emptied value is a silent fail-OPEN of this boundary,
+#     never a tightening: each row proves the value is non-empty BEFORE testing what it omits,
+#     exactly the "guard whose comparand can be absent fails open" class in CLAUDE.md.
+#   - Agent frontmatter has no deny/disallow key, so the allowlist is the only lever.
+# Write is granted to exactly ONE agent — checklist-verifier — because its Phase 2.1b dispatch
+# prompt (skills/review/phases/phase-2-verification.md) instructs it to Write its verdict JSON
+# to {VERDICT_FILE}. Granting Write to any other agent here contradicts that agent's own
+# stated working-tree policy, which is why the expectation is per-agent, not global.
+# NOTE: this boundary is name-level, not a claim of read-only-ness — the six agents that hold
+# Bash can still reach the tree through it (`sed -i`, `git checkout --`). It closes the
+# tool-shaped path; the Phase-3 dirty-tree snapshot guard remains the behavioral backstop.
+AGENT_TOOL_ROSTER="checklist-deduper checklist-generator checklist-verifier code-reviewer"
+AGENT_TOOL_ROSTER="$AGENT_TOOL_ROSTER comment-analyzer pr-test-analyzer silent-failure-hunter"
+AGENT_TOOL_ROSTER="$AGENT_TOOL_ROSTER type-design-analyzer"
+for a in $AGENT_TOOL_ROSTER; do
+  # structural-pin-ok: security-credential-boundary -- the `tools:` line IS the runtime tool
+  # boundary the harness parses for a dispatched subagent; no other surface constrains what a
+  # dispatched review agent may do to the working tree.
+  atools="$(grep -E '^tools:[[:space:]]' "$FDROOT/agents/$a.md" | head -1)"
+  atools_value="${atools#tools:}"
+  case "$atools_value" in
+    *[![:space:]]*) atools_nonempty=yes ;;
+    *) atools_nonempty=no ;;
+  esac
+  # Fail CLOSED on an absent/emptied/reformatted value: an empty capture would make every
+  # omission row below pass VACUOUSLY (printf '' | grep -qw -> "no") while the agent had in
+  # fact reverted to inheriting all tools — the precise fail-open this block exists to catch.
+  assert_eq "#agent-tools agents/$a.md declares a NON-EMPTY tools: value (empty == inherits all tools)" \
+    "yes" "$atools_nonempty"
+  for denied in Edit MultiEdit NotebookEdit Task; do
+    assert_eq "#agent-tools agents/$a.md tools: omits $denied" \
+      "no" "$(printf '%s' "$atools_value" | grep -qw "$denied" && echo yes || echo no)"  # raw-guard-ok: loop body: the pattern is the $denied loop variable, not a static pin
+  done
+  # Write: expected on checklist-verifier (its dispatch prompt mandates the verdict-file
+  # write), asserted ABSENT on every other agent — asserted both ways so neither a dropped
+  # grant that would break Phase 2 nor a spread grant that would breach the policy is silent.
+  case "$a" in
+    checklist-verifier) atools_write_expected=yes ;;
+    *) atools_write_expected=no ;;
+  esac
+  assert_eq "#agent-tools agents/$a.md tools: Write grant matches its dispatch contract" \
+    "$atools_write_expected" "$(printf '%s' "$atools_value" | grep -qw 'Write' && echo yes || echo no)"
+done
 
 # --- #191: retain the review agents' complete-location-set deliverable boundary. ---
 assert_pin_unique "#191 code-reviewer includes the complete location set in the finding body before submitting" \


### PR DESCRIPTION
## What

The three `checklist-*` agents and the five vendored `pr-review-toolkit` review agents carried **no `tools:` key**, so each inherited the full subagent toolset — `Edit`, `Write`, `MultiEdit`, `NotebookEdit`, `Task` included. Five of them state a read-only advisory working-tree policy *in their own bodies* ("never modify working-tree source files, the index, HEAD, or branch state"). That policy was requested in prose and unenforced by the harness.

Each agent now declares only what its body and its dispatch prompt actually use:

| Agent | `tools:` | Why |
|---|---|---|
| `checklist-deduper` | `Read` | Pure JSON→JSON merge; touches no file |
| `checklist-generator` | `Read, Grep, Glob` | Reads the cached diff by path, greps to ground claims |
| `checklist-verifier` | `Read, Grep, Glob, Bash, Write` | Steps 2–3 name Read/Grep/Glob; `git show`/`git cat-file` for #504 routing; **Write** for the verdict file |
| `code-reviewer` | `Read, Grep, Glob, Bash` | `git diff` scope, `git show` for #504, `mktemp` mutation-checks |
| `comment-analyzer` | `Read, Grep, Glob, Bash` | same |
| `pr-test-analyzer` | `Read, Grep, Glob, Bash` | same |
| `silent-failure-hunter` | `Read, Grep, Glob, Bash` | same |
| `type-design-analyzer` | `Read, Grep, Glob, Bash` | same |

`Task` is dropped everywhere — none of the eight dispatches a subagent (the "task" hits in `code-reviewer`/`comment-analyzer` are the English word).

## Two findings that shaped this

**`checklist-verifier` genuinely needs `Write`.** Its own body never mentions writing, but `skills/review/phases/phase-2-verification.md` instructs the dispatched agent: *"Write your verdict JSON to the file path {VERDICT_FILE} using the Write tool."* The grant is derived from the dispatch prompt, not from the agent body — checking only the body would have broken Phase 2.

**An empty `tools:` value is a silent fail-open, not the tightest restriction.** Measured on Claude Code 2.1.220 by probing all four forms against a control (`tools: Read`):

| Frontmatter form | Parsed as |
|---|---|
| `tools:` (bare/null) | `All tools` |
| `tools: []` | `All tools` |
| `tools: ""` | `All tools` |
| key omitted | `All tools` |
| `tools: Read` (control) | `Read` |

So there is no zero-tool agent, and an emptied value reverts to inheriting everything. The new suite rows therefore prove each value is **non-empty before** testing what it omits — otherwise every omission row would pass vacuously on exactly the regression they exist to catch. Agent frontmatter also has no deny/disallow key, so an allowlist is the only lever.

## What this does *not* claim

This is a **name-level** boundary, not read-only enforcement. The six agents holding `Bash` can still reach the working tree through it (`sed -i`, `git checkout --`, `git reset`). What it closes is the tool-shaped path — an agent reaching for `Edit`/`Write` on a file it was told only to report on. The Phase-3 dirty-tree snapshot guard in `phase-3-agents.md` remains the behavioral backstop.

Per-tool argument scoping (`Bash(git show:*)`, `Write(.devflow/tmp/**)`) is a possible follow-up: such entries parse and round-trip intact, but whether they are **enforced** as scoping — rather than read as a tool name that matches nothing — is not measured, and getting it wrong would silently strip Bash from a reviewer. Left out deliberately.

## Upstream provenance (checked against the sources)

Fetched verbatim via `gh api .../contents/...` (not a summarizer), so these are the upstream bytes:

- **The five `pr-review-toolkit` agents declare no `tools:` key upstream either.** `anthropics/claude-plugins-official@main`'s `plugins/pr-review-toolkit/agents/*.md` carry only `name`, `description`, `model`, `color`. So the inherit-everything state was **inherited verbatim from Anthropic**, not introduced when DevFlow vendored them — and this PR is a deliberate DevFlow divergence from upstream, on files already marked "MODIFIED by DevFlow".
- **The two `feature-dev` agents DO declare one upstream**, and it is the read-only idiom: `Glob, Grep, LS, Read, NotebookRead, WebFetch, TodoWrite, WebSearch, KillShell, BashOutput` — identical for both, and DevFlow's copies are that list minus `KillShell, BashOutput` (dropped as inert in #628). Note what it omits: **no `Bash`, no `Edit`/`Write`**. That is the shape Anthropic gives an analysis-only agent.
- **The three `checklist-*` agents are first-party DevFlow** — no upstream to compare.
- **Nothing to compare on the superpowers side.** `skills/requesting-code-review/code-reviewer.md` has no frontmatter upstream or locally (it is a prompt template dispatched as `general-purpose`, not an agent definition), and neither vendored skill declares `allowed-tools`.

The one place this cuts against the PR: upstream's read-only agents get **no `Bash` at all**, whereas five agents here keep it. That is not copyable — DevFlow's reviewers need `git diff`/`git show` for scope and #504 displaced-path routing, and the `mktemp` mutation-check the bodies mandate. It does sharpen where the remaining exposure is, and it is the same gap the "not read-only" caveat above names: `Bash`, not the four tree-mutation tools, is what still reaches the tree.

## Coupled sites

- Two `#141` comments in `lib/test/run.sh` recorded the old state ("these carry NO `tools:` key (they inherit all tools)") — corrected in the same change.
- New `#agent-tools` block in `lib/test/run.sh` asserts, per agent: a non-empty `tools:` value; `Edit`/`MultiEdit`/`NotebookEdit`/`Task` absent; and `Write` present **iff** the agent is `checklist-verifier` (asserted both ways, so neither a dropped grant that breaks Phase 2 nor a spread grant that breaches the policy is silent).
- `.changeset/subagent-tool-allowlists.md`, `bump: patch` (engine surface).

## Verification

- `shellcheck --severity=warning -e SC1091 --extended-analysis=false lib/test/run.sh` — clean (ShellCheck 0.11.0).
- `python3 lib/test/validate-frontmatter.py .` — `OK 28 frontmatter files parsed`.
- Full `lib/test/run.sh` running locally; result reported in a follow-up comment. No focused module covers `run.sh` main-shell assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
