### PR TITLE
fix(lint): make the structural-pin-ok hatch usable via a three-step routing ladder (#948)

### DIFF
--- a/.changeset/issue-948-pin-gate-routing-ladder.md
+++ b/.changeset/issue-948-pin-gate-routing-ladder.md
@@ -1,0 +1,22 @@
+---
+bump: patch
+---
+
+### Changed
+
+- The pin-corpus authoring gate now **routes** a changed pin site through an ordered
+  three-step ladder instead of returning on a single prose test (issue #948): (1) a
+  program in `scripts/**`, `lib/**` outside `lib/test/`, or `.github/**` demonstrably
+  reads the literal or a machine-identifier-shaped token it names — pass; (2) otherwise
+  the delta-gated ledger `lib/test/pin-corpus-adjudications.tsv` already records the
+  literal as `boundary` **and** the site carries a valid `# structural-pin-ok:`
+  declaration — pass, the marker acting as a pointer to that authorized decision; (3)
+  neither — the finding stands, naming which half was missing. Step 1 can only ever
+  route a site down to step 2, and step 2 fails closed: a tag with no ledger row, a
+  ledger row with no tag, a row in any other bucket, and an unestablished ledger are all
+  findings. The `# structural-pin-ok:` escape hatch, previously unreachable for any
+  literal the lint classified as prose, is usable again — so a retained pin with a
+  recorded boundary decision can carry its reason at the site and be edited normally.
+  A declaration whose grammar is invalid is still decided *before* the ladder, a retired
+  wording literal's revival keeps its stronger pre-existing contract, and an
+  unresolvable declaration target is still unfixable.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,21 +170,45 @@ an executable structural boundary and must carry
 
 **The marker is a declaration required of a NEW or CHANGED pin — it is not a retention
 badge you can retrofit onto the standing population (issue #885).** The gate scopes the
-requirement to a site whose every physical line is in the diff's added set, and it runs
-the prose-resolution check *before* the declaration check: a pin whose literal resolves
-into visible Markdown prose draws
-`literal resolves into prose at <target>:<line>` **regardless of any declaration**.
-A large majority of the retained pins resolve that way (a past-time snapshot, not a
-live figure: 229 of them measured on the post-sweep population at the #885 sweep
-commit, kept as provenance for the probe below and deliberately not re-rendered) — they
-are retained because a tool or consumer reads the *thing the literal names* (a marker, a
-grant-matched invocation shape, a schema field set), a distinction the lint's
-prose boundary cannot see. So adding a marker to one of those turns the required gate
-RED and its only gate-satisfying disposition would be deletion, which the recorded
-adjudication contradicts. The per-pin retention record therefore lives where it is
-delta-gated and auditable — `lib/test/pin-corpus-adjudications.tsv`, surfaced per row in
-the census — and not as several hundred uncoupled copies in source comments. Touch a
-retained pin's lines only when you are prepared to answer the gate for it.
+requirement to a site whose every physical line is in the diff's added set. For such a
+site — once its declaration *grammar* has been checked, which happens first and which no
+later arm routes around — the gate **routes** through an ordered three-step ladder
+(issue #948), and the routing is deliberately not a judgement:
+
+1. **A program demonstrably reads it.** The literal, or a machine-identifier-shaped
+   token it names, occurs in the operative (comment-stripped) text of a tracked
+   `scripts/**`, `lib/**`-outside-`lib/test/` or `.github/**` file. Pass; no
+   declaration and no ledger row needed. A grep-shaped search misses a *generic*
+   consumer by construction — a helper that walks a routing table row by row names no
+   individual row — so "found none" routes to step 2 and never to a finding.
+2. **The ledger already recorded the decision.** `lib/test/pin-corpus-adjudications.tsv`
+   carries this literal as `boundary` **and** the site carries a valid
+   `# structural-pin-ok:` declaration. The marker is a *pointer to an authorized
+   decision*, never a self-granted permission: a tag with no ledger row is a finding,
+   and so is a ledger row with no tag. Step 2 fails closed — an absent, unestablished
+   or non-`boundary` row never satisfies it, and a ledger the gate cannot read is an
+   infrastructure failure before the ladder runs at all.
+3. **Neither.** The finding stands: `literal resolves into prose at <target>:<line>`,
+   naming which half of step 2 was missing. This is the pin the policy exists to remove.
+
+Be honest about where the control sits: after step 2 the gate is only routing, and the
+real safeguard is the **review of ledger changes**, which is separately delta-gated and
+needs an exact branch change manifest. A large majority of the retained pins resolve
+into prose (a past-time snapshot, not a live figure: 229 of them measured on the
+post-sweep population at the #885 sweep commit, kept as provenance for the probe below
+and deliberately not re-rendered) — they are retained because a tool or consumer reads
+the *thing the literal names* (a marker, a grant-matched invocation shape, a schema
+field set), a distinction the lint's prose boundary cannot see; step 2 exists so that
+such a pin can carry its reason at the site *and* be edited normally, which before #948
+it could not. The per-pin retention record still lives where it is delta-gated and
+auditable — `lib/test/pin-corpus-adjudications.tsv`, surfaced per row in the census —
+and not as several hundred uncoupled copies in source comments, so retrofitting a marker
+onto the standing population is still not the ask. Two cases the ladder does **not**
+reach: a pin whose declared target the lint cannot resolve at all
+(`typed structural declaration target cannot be inspected` — e.g. a concatenated
+in-module bundle) is still unfixable, and a *retired* wording literal's revival keeps its
+own stronger contract below. Touch a retained pin's lines only when you are prepared to
+answer the gate for it.
 
 `lib/test/pin-corpus-adjudications.tsv` contains only the current active adjudication
 state. Every addition, removal, or change to that table must be authorized by an exact

--- a/lib/test/pin-corpus-lint.py
+++ b/lib/test/pin-corpus-lint.py
@@ -63,6 +63,27 @@ authoring time:
   scan exits 0. The lower-level ``mutation-routing`` synthetic-fixture command
   remains for legacy self-tests.
 
+  **The static classifier ROUTES; it does not judge (issue #948).** For a changed
+  site whose declaration grammar is valid, it walks an ordered three-step ladder:
+  (1) a program in ``scripts/**``, ``lib/**`` (non-test) or ``.github/**``
+  demonstrably reads the literal or a distinctive token it names — pass, no human
+  needed; (2) otherwise, the delta-gated ledger
+  ``lib/test/pin-corpus-adjudications.tsv`` already records this literal as
+  ``boundary`` **and** the site carries a valid ``# structural-pin-ok:``
+  declaration — pass, honouring the tag as a *pointer to an authorized decision*;
+  (3) neither — report the finding. Step 1 can only ever route a site to step 2
+  (a grep-shaped consumer search misses a generic consumer by construction, so
+  "found none" means "ask the ledger", never "reject"), and step 2 fails closed:
+  an absent, unestablished or non-``boundary`` ledger row never satisfies it, and
+  an unreadable ledger is an infrastructure failure long before this ladder runs.
+  The real control over step 2 is therefore not this classifier but the review of
+  ledger changes, which is separately delta-gated and needs an exact branch
+  manifest — do not read the ladder as the gate getting smarter. The ladder is
+  scoped to the RETAINED population: a *retired* wording literal's revival keeps
+  its pre-#948 contract (deliberate authorization plus a genuinely machine-shaped
+  target), since both ladder steps rest on the very boundary row that contract
+  says cannot on its own make a revival valid.
+
 **Fail-closed:** a call site the scanner cannot resolve statically (the literal
 interpolates a variable it cannot resolve, or the target file is a variable with
 no ``--var`` binding and no ``$LIB``-relative assignment) is COUNTED and reported
@@ -1110,6 +1131,147 @@ STRUCTURAL_PIN_CATEGORIES = frozenset(
         "cross-file-phase-contract",
     }
 )
+
+# ── Step 1 of the issue-948 routing ladder: does a program demonstrably read it? ──
+#
+# The corpus is the tracked machine-consumer surface: `scripts/**`, `lib/**`
+# excluding the suite's own `lib/test/**`, and `.github/**`. `docs/**`, `skills/**`
+# and the repository's markdown are deliberately NOT consumers — a sentence
+# reappearing in prose is the very thing the policy retired.
+MACHINE_CONSUMER_PATH_PREFIXES = ("scripts/", "lib/", ".github/")
+MACHINE_CONSUMER_EXCLUDED_PREFIXES = ("lib/test/",)
+
+# A "distinctive token" is a machine-identifier-shaped word: >= 8 characters,
+# >= 3 letters, and at least one of these shapes. The shape requirement is the
+# whole point of the rule — a common English word (however long) is NOT
+# distinctive, so an unrelated file mentioning "configuration" or "verdict" can
+# never satisfy step 1. Two-segment kebab words that read as ordinary English
+# ("fail-closed", "best-effort") are excluded on purpose: a kebab token qualifies
+# only with a digit or a third segment.
+_DISTINCTIVE_TOKEN_TRIM = "\"'`(),;:.*!?[]{}<>|&"
+_DOTTED_TOKEN_RE = re.compile(r"[A-Za-z0-9][.][A-Za-z0-9]")
+# The accepted shapes, each paired with the name it is known by in the docs. One
+# hit qualifies the token; which shape matched is not part of the answer (the
+# evidence string names the matched TOKEN, which is what makes a step-1 pass
+# attributable), so the names are documentation of a closed set, not routing.
+_DISTINCTIVE_TOKEN_SHAPES = (
+    ("snake", lambda token: "_" in token),
+    ("path", lambda token: "/" in token),
+    ("marker", lambda token: ":" in token),
+    ("flag", lambda token: token.startswith("--")),
+    ("dotted", lambda token: _DOTTED_TOKEN_RE.search(token) is not None),
+    (
+        "numbered",
+        lambda token: "-" in token and any(ch.isdigit() for ch in token),
+    ),
+    (
+        "kebab",
+        lambda token: len([part for part in token.split("-") if len(part) >= 2]) >= 3,
+    ),
+)
+
+
+def is_machine_consumer_path(path):
+    """True for a repo-relative path in the step-1 machine-consumer corpus."""
+    if path.startswith(MACHINE_CONSUMER_EXCLUDED_PREFIXES):
+        return False
+    return path.startswith(MACHINE_CONSUMER_PATH_PREFIXES)
+
+
+def distinctive_consumer_tokens(literal):
+    """Return the machine-identifier-shaped tokens of ``literal``, in order.
+
+    Whitespace-split, then trimmed of surrounding quoting/sentence punctuation
+    (an interior ``:``/``.``/``-`` is part of the token and is never trimmed).
+    A literal with no such token yields ``()`` — which routes its pin to step 2
+    rather than rejecting it.
+    """
+    if not literal:
+        return ()
+    tokens = []
+    for raw in literal.split():
+        token = raw.strip(_DISTINCTIVE_TOKEN_TRIM)
+        if len(token) < 8 or token in tokens:
+            continue
+        if sum(1 for ch in token if ch.isalpha()) < 3:
+            continue
+        if any(matches(token) for _, matches in _DISTINCTIVE_TOKEN_SHAPES):
+            tokens.append(token)
+    return tuple(tokens)
+
+
+def _consumer_token_pattern(tokens):
+    """One boundary-anchored alternation over ``tokens`` (single-pass search)."""
+    if not tokens:
+        return None
+    return re.compile(
+        r"(?<![\w-])(?:"
+        + "|".join(re.escape(token) for token in tokens)
+        + r")(?![\w-])"
+    )
+
+
+def build_machine_consumer_corpus(consumer_sources):
+    """Return the ordered ``(path, operative_text)`` step-1 corpus.
+
+    ``consumer_sources`` maps repo-relative path to raw file text. Only
+    consumer-surface paths are kept, and for ``#``-comment languages the comment
+    regions are SUBTRACTED: a literal quoted in a ``lib/*.sh`` comment is not a
+    program reading it. That subtraction can only move a site from step 1 to
+    step 2, which is the safe direction.
+    """
+    corpus = []
+    for path in sorted(consumer_sources or ()):
+        if not is_machine_consumer_path(path):
+            continue
+        text = consumer_sources[path]
+        if os.path.splitext(path)[1].lower() in COMMENT_HASH_EXTS:
+            lines = text.split("\n")
+            spans = {lineno: comment for lineno, comment in hash_comment_regions(lines)}
+            text = _strip_line_spans(lines, spans)
+        corpus.append((path, text))
+    return tuple(corpus)
+
+
+def machine_consumer_evidence(literal, corpus):
+    """Return step-1 evidence that a program reads ``literal``, else ``None``.
+
+    Evidence is either the whole literal occurring in a consumer file's operative
+    text, or one of its distinctive tokens occurring there as a whole token. A
+    ``None`` return means only "no consumer was FOUND" — a generic consumer (a
+    helper that walks a routing table row by row, a renderer driven by a manifest)
+    names no individual literal, so this search misses it by construction and its
+    answer routes to step 2 instead of rejecting the pin.
+    """
+    if not literal or not corpus:
+        return None
+    tokens = distinctive_consumer_tokens(literal)
+    pattern = _consumer_token_pattern(tokens)
+    for path, text in corpus:
+        if literal in text:
+            return f"{path} contains the pinned literal"
+        if pattern is None:
+            continue
+        match = pattern.search(text)
+        if match is not None:
+            return f"{path} contains the distinctive token {match.group(0)!r}"
+    return None
+
+
+def ledger_records_boundary(literal_key, current_adjudications):
+    """Step 2: True only when the ledger's current state reads ``boundary``.
+
+    Fails closed by construction: an unestablished ledger (``None``), an empty
+    one, an absent row, and a row in any other bucket all return False. The
+    production caller never reaches here with an unreadable ledger at all —
+    ``analyze_adjudication_changes`` raises ``InfrastructureError`` first — so
+    there is no path on which unreadability becomes a pass.
+    """
+    if literal_key is None or not current_adjudications:
+        return False
+    state = current_adjudications.get(literal_key)
+    return state is not None and state[0] == "boundary"
+
 
 # This population is intentionally committed and independent of the registry. The
 # production gate compares the two sets exactly, so registering a new focused module
@@ -3180,10 +3342,17 @@ def scan_changed_sources(
     adjudication_delta=None,
     current_adjudications=None,
     target_loader=None,
+    consumer_sources=None,
 ):
-    """Classify changed complete sites and return blocking finding strings."""
+    """Classify changed complete sites and return blocking finding strings.
+
+    ``consumer_sources`` is the step-1 machine-consumer corpus (repo-relative
+    path -> raw text). Omitting it leaves step 1 finding nothing, which routes
+    every site to step 2 — the fail-toward-step-2 direction the ladder requires.
+    """
     adjudication_delta = adjudication_delta or {}
     current_adjudications = current_adjudications or {}
+    consumer_corpus = build_machine_consumer_corpus(consumer_sources)
     revival_authorizations = frozenset(revival_authorizations)
     patches = parse_unified_diff(difftext)
     new_candidates = []
@@ -3335,28 +3504,84 @@ def scan_changed_sources(
                 f"{inspection_error}"
             )
             continue
+        # A declaration that is PRESENT but ungrammatical is a declaration error,
+        # decided ahead of the routing ladder and never routed around: an unknown
+        # category, an empty rationale or a duplicated marker is reported whatever
+        # the ladder would have answered (issue #948 keeps this arm exactly as it
+        # was — the ~35 standing pins on a pre-vocabulary free-text category stay
+        # findings until someone edits the category into a legal one).
+        if (
+            site.declaration_error is not None
+            and site.declaration_error != "missing structural declaration"
+        ):
+            findings.append(
+                f"MUTATION-ROUTING\t{site.source_path}:{site.line_start}\t"
+                f"{site.helper or site.family}\t"
+                f"{site.literal or '<unresolved-literal>'}\t{site.declaration_error}"
+            )
+            continue
+        # ── The issue-948 three-step routing ladder, in order ──────────────────
+        # This is ROUTING, not judging. Step 1 asks a mechanical question and can
+        # only ever route DOWN to step 2; step 2 defers to an authorization that
+        # was granted elsewhere (the delta-gated ledger, whose review is the real
+        # control); step 3 is the residue the policy exists to remove. Reordering
+        # these three arms silently changes verdicts, which is why every arm and
+        # the order itself is driven from lib/test/test_pin_corpus_lint.py.
+        #
+        # SCOPE. The ladder governs the RETAINED population #948 is about. A
+        # RETIRED wording literal reaching this point has already cleared the
+        # revival block above, and its documented contract (CONTRIBUTING.md: a
+        # revival needs deliberate authorization AND a *genuine* declared
+        # structural boundary) is exactly the pre-#948 prose test — a boundary
+        # row alone must not make a revival valid, and both ladder steps rest on
+        # such a row. So a retired literal keeps the pre-#948 behavior verbatim.
+        ladder_applies = literal_key not in retired_literal_keys
+        # Step 1: a program demonstrably reads the literal. No human needed.
+        if (
+            ladder_applies
+            and machine_consumer_evidence(site.literal, consumer_corpus) is not None
+        ):
+            continue
+        declared = site.declaration is not None and site.declaration_error is None
+        # Step 2: the ledger already records this literal as a boundary, and the
+        # site's own `# structural-pin-ok:` tag POINTS AT that decision. Both
+        # halves are required — a tag alone cannot self-grant legitimacy, and a
+        # ledger row alone leaves the reader of the pin no reason at the site.
         prose_resolution = _literal_prose_resolution(
             site, repo_root, target_loader
         )
         if prose_resolution is not None:
+            ledger_boundary = ledger_records_boundary(
+                literal_key, current_adjudications
+            )
+            if ladder_applies and declared and ledger_boundary:
+                continue
             prose_target, prose_line = prose_resolution
-            findings.append(
-                f"MUTATION-ROUTING\t{site.source_path}:{site.line_start}\t"
-                f"{site.helper or site.family}\t{site.literal}\t"
+            detail = (
                 f"literal resolves into prose at {prose_target}:{prose_line}; "
                 f"the {site.helper or site.family} helper does not change the "
                 "verdict"
             )
-            continue
-        if site.declaration is not None and site.declaration_error is None:
-            continue
-        if site.declaration_error != "missing structural declaration":
-            detail = site.declaration_error
+            if ladder_applies:
+                missing = []
+                if not declared:
+                    missing.append(
+                        "the site carries no valid '# structural-pin-ok:' declaration"
+                    )
+                if not ledger_boundary:
+                    missing.append(
+                        "the adjudication ledger records no boundary decision for "
+                        "this literal"
+                    )
+                detail += "; no program consumer reads it and " + " and ".join(missing)
             findings.append(
                 f"MUTATION-ROUTING\t{site.source_path}:{site.line_start}\t"
-                f"{site.helper or site.family}\t{site.literal or '<unresolved-literal>'}\t{detail}"
+                f"{site.helper or site.family}\t{site.literal}\t{detail}"
             )
             continue
+        if declared:
+            continue
+        # Step 3: no consumer, no authorized decision to point at.
         detail = site.declaration_error or "wording-only presence pin"
         findings.append(
             f"MUTATION-ROUTING\t{site.source_path}:{site.line_start}\t"
@@ -3741,6 +3966,45 @@ def _read_source_blob(repo_root, revision, path, git_runner):
         _run_git_bytes(git_runner, repo_root, "show", f"{revision}:{path}"),
         f"scanned source {revision}:{path}",
     )
+
+
+def load_machine_consumer_sources(repo_root, git_runner=subprocess.run):
+    """Read the tracked step-1 machine-consumer corpus from the worktree.
+
+    The population comes from an index-reading ``git ls-files`` with no
+    ``--others`` (the issue-#711 rule: a repository-root-anchored recursive walk
+    would descend into sibling worktrees under ``.claude/worktrees/``). Contents
+    come from the WORKTREE, and the same corpus serves both the committed-HEAD
+    and worktree passes: a consumer added in the same uncommitted change as its
+    pin is a normal in-progress state, and since the worktree pass shares the
+    corpus anyway, splitting it per revision would change no reachable verdict
+    except to red-flag that state. An untracked consumer file is NOT in the
+    corpus, and an unreadable or non-UTF-8 one is skipped with a stderr
+    breadcrumb — both route their pins to step 2, never to a pass.
+    """
+    listing = _run_git(
+        git_runner,
+        repo_root,
+        "ls-files",
+        "--",
+        *MACHINE_CONSUMER_PATH_PREFIXES,
+    )
+    sources = {}
+    skipped = []
+    for path in filter(None, listing.splitlines()):
+        if not is_machine_consumer_path(path):
+            continue
+        try:
+            sources[path] = (Path(repo_root) / path).read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            skipped.append(f"{path}: {type(exc).__name__}")
+    if skipped:
+        sys.stderr.write(
+            "MUTATION-ROUTING-CONSUMER-CORPUS-SKIPPED\t"
+            + ", ".join(sorted(skipped))
+            + "\n"
+        )
+    return sources
 
 
 def _read_worktree_source(repo_root, path, expected_mode=None):
@@ -4257,6 +4521,7 @@ def scan_static_pin_changes(
     worktree_target_loader, verify_worktree_targets = _worktree_target_loader(
         repo_root
     )
+    consumer_sources = load_machine_consumer_sources(repo_root, git_runner)
     source_findings = scan_changed_sources(
         head_sources,
         base_sources,
@@ -4267,6 +4532,7 @@ def scan_static_pin_changes(
         adjudication_delta=adjudication_analysis.delta,
         current_adjudications=adjudication_analysis.current,
         target_loader=head_target_loader,
+        consumer_sources=consumer_sources,
     )
     source_findings.extend(
         scan_changed_sources(
@@ -4279,6 +4545,7 @@ def scan_static_pin_changes(
             adjudication_delta=adjudication_analysis.delta,
             current_adjudications=adjudication_analysis.current,
             target_loader=worktree_target_loader,
+            consumer_sources=consumer_sources,
         )
     )
     verify_worktree_targets()

--- a/lib/test/run.sh
+++ b/lib/test/run.sh
@@ -1561,8 +1561,10 @@ assert_eq "#857 the SKILL.md seed fence passes PR_NUMBER, MARKER, BODY_FILE in t
 # `create` statements live in a prose paragraph as inline backticked code rather than in a
 # fenced block, which is why each is authored as a pin_count call from the outset: a raw
 # presence assertion over prose resolves inside prose and hits pin-corpus-lint's
-# prose-resolution arm ("literal resolves into prose at <file>:<line>"), which no
-# `# structural-pin-ok:` declaration rescues — and, since #925 removed the count-helper
+# prose-resolution arm ("literal resolves into prose at <file>:<line>"), which a
+# `# structural-pin-ok:` declaration rescues only in company with a `boundary` row in the
+# delta-gated adjudication ledger (the issue-#948 step-2 pointer contract — a declaration
+# on its own never did and still cannot) — and, since #925 removed the count-helper
 # short-circuit, which a pin_count spelling no longer skips either.
 assert_eq "#871 the SKILL.md fallback arm's id call passes the PR number positionally and the marker behind --marker" "1" \
   "$(pin_count 'workpad.py id "$PR_NUMBER" --marker "$MARKER" 2>.devflow/tmp/review/<slug>/<run-id>/rv-id.err' "$ST_REV")"

--- a/lib/test/test_pin_corpus_lint.py
+++ b/lib/test/test_pin_corpus_lint.py
@@ -3284,6 +3284,75 @@ class StaticPinWorktreeCompositionTests(unittest.TestCase):
             )
             self.assertEqual((0, "", ""), self._public_rc(root))
 
+    def test_step_one_consumer_passes_the_public_worktree_ladder(self):
+        # End-to-end proof of the issue-948 step-1 WIRING: the corpus population
+        # is an index-reading `git ls-files` over scripts/, lib/ (non-test) and
+        # .github/, and its contents come from the worktree. An UNDECLARED pin
+        # over a literal a tracked scripts/ program reads is clean; the identical
+        # pin is RED when that program's only mention is a comment. Note the pin's
+        # own target (lib/test/static-pin-fixture.sh) also carries the literal and
+        # cannot satisfy step 1 — the suite is excluded from the corpus.
+        for body, expected_rc in (
+            ('grep -qF "STATIC_PIN_FIXTURE=1" "$1"\n', 0),
+            ("# only a comment mentions STATIC_PIN_FIXTURE=1\n", 3),
+        ):
+            with self.subTest(rc=expected_rc), tempfile.TemporaryDirectory() as td:
+                root = Path(td)
+                self._repo(root)
+                subprocess.run(
+                    ["git", "switch", "-qc", "topic"], cwd=root, check=True
+                )
+                consumer = root / "scripts/read-fixture-token.sh"
+                consumer.write_text("#!/usr/bin/env bash\n" + body, encoding="utf-8")
+                subprocess.run(
+                    ["git", "add", "scripts/read-fixture-token.sh"],
+                    cwd=root,
+                    check=True,
+                )
+                subprocess.run(
+                    ["git", "commit", "-qm", "add consumer"], cwd=root, check=True
+                )
+                source = root / "lib/test/run.sh"
+                source.write_text(
+                    source.read_text(encoding="utf-8")
+                    + "\nassert_pin_unique 'consumed pin' 'STATIC_PIN_FIXTURE=1' "
+                    + "\"$LIB/test/static-pin-fixture.sh\"\n",
+                    encoding="utf-8",
+                )
+                rc, stdout, stderr = self._public_rc(root)
+                self.assertEqual(expected_rc, rc, stdout + stderr)
+
+    def test_unreadable_ledger_is_infrastructure_not_a_step_two_pass(self):
+        # The fail-closed control for step 2 at the production boundary: a ledger
+        # the gate cannot read is an infrastructure failure (rc 2), never an
+        # empty-but-fine ledger and never a pass. The appended pin is one that
+        # exits 0 on a readable ledger, so rc 2 here is attributable.
+        marker = (
+            "# structural-pin-ok: machine-sentinel-provenance -- "
+            "the fixture token is consumed as an executable sentinel"
+        )
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            self._repo(root)
+            subprocess.run(["git", "switch", "-qc", "topic"], cwd=root, check=True)
+            table = root / "lib/test/pin-corpus-adjudications.tsv"
+            table.write_bytes(
+                b"adjudication_key\tbucket_final\trationale\n\xff\xfe not utf-8\n"
+            )
+            subprocess.run(["git", "add", "-A"], cwd=root, check=True)
+            subprocess.run(
+                ["git", "commit", "-qm", "unreadable ledger"], cwd=root, check=True
+            )
+            source = root / "lib/test/run.sh"
+            source.write_text(
+                source.read_text(encoding="utf-8")
+                + "\nassert_pin_unique 'typed static pin' 'STATIC_PIN_FIXTURE=1' "
+                + f"\"$LIB/test/static-pin-fixture.sh\"  {marker}\n",
+                encoding="utf-8",
+            )
+            rc, stdout, stderr = self._public_rc(root)
+            self.assertEqual(2, rc, stdout + stderr)
+
     # ── cross-repository memo-leak probes ──────────────────────────────────
     #
     # The linter and census memos live for the process, and _public_rc runs
@@ -4184,6 +4253,353 @@ class RetiredMutationHelperBanTests(unittest.TestCase):
                     [],
                     self.mod.scan_retired_mutation_population(root),
                 )
+
+
+class PinRoutingLadder948Tests(unittest.TestCase):
+    """The issue-948 three-step routing ladder: every arm, and the arm ORDER.
+
+    A reordered ladder changes verdicts silently, so each test names the arm it
+    exercises and asserts the DECIDING message rather than only the count. The
+    fixture literal is a whitespace-bearing visible Markdown sentence, i.e. one
+    the lint classifies as prose — before #948 that classification ran first and
+    returned unconditionally, so no declaration and no ledger row could be
+    reached for it. Every step-2 test below is therefore a case that could not
+    pass at all before this change.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mod = load_linter()
+
+    MARKER = (
+        "# structural-pin-ok: cross-file-phase-contract -- "
+        "the sentence spells the command shape a cloud grant must match"
+    )
+    INVALID_MARKER = "# structural-pin-ok: contract-presence over skill prose -- why"
+    LITERAL = "re-opens the diff at every --verdict-threshold value"
+    TARGET = "skills/review/SKILL.md"
+    RATIONALE = "maintainer adjudication: declared security or interface boundary"
+
+    def _fixture(self, td, *, marker="", literal=None, target_text=None):
+        """Write the prose target and return (repo_root, pin source text)."""
+        literal = literal or self.LITERAL
+        root = Path(td)
+        target = root / self.TARGET
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(
+            target_text
+            or f"# Review\n\nThe fix loop {literal} so the pass is observable.\n",
+            encoding="utf-8",
+        )
+        source = (
+            f'F="$LIB/../{self.TARGET}"\n'
+            f"assert_pin_unique \"threshold\" '{literal}' \"$F\""
+            + (f"  {marker}" if marker else "")
+        )
+        return root, source
+
+    def _scan(self, root, source, **kwargs):
+        return self.mod.scan_changed_sources(
+            {"lib/test/a.sh": source},
+            {"lib/test/a.sh": ""},
+            one_file_diff("lib/test/a.sh", "", source),
+            repo_root=root,
+            **kwargs,
+        )
+
+    def _key(self, literal=None):
+        return self.mod._literal_adjudication_key(literal or self.LITERAL)
+
+    def _ledger(self, bucket="boundary", literal=None):
+        return {self._key(literal): (bucket, self.RATIONALE)}
+
+    # ── Step 1: a program demonstrably reads it ────────────────────────────
+    def test_step_one_passes_with_no_tag_and_no_ledger_row(self):
+        with tempfile.TemporaryDirectory() as td:
+            root, source = self._fixture(td)
+            consumer = {
+                "scripts/derive-verdict.sh": (
+                    "#!/usr/bin/env bash\n"
+                    f"grep -qF '{self.LITERAL}' \"$1\" || exit 1\n"
+                )
+            }
+            self.assertEqual([], self._scan(root, source, consumer_sources=consumer))
+            # RED-first control: the identical site with no consumer corpus is a
+            # finding, so the pass above is attributable to step 1 alone.
+            unrouted = self._scan(root, source)
+            self.assertEqual(1, len(unrouted))
+            self.assertIn("resolves into prose", unrouted[0])
+
+    def test_step_one_accepts_a_distinctive_token_not_only_the_whole_literal(self):
+        with tempfile.TemporaryDirectory() as td:
+            root, source = self._fixture(td)
+            consumer = {
+                "scripts/derive-verdict.sh": 'THRESHOLD_FLAG="--verdict-threshold"\n'
+            }
+            self.assertEqual([], self._scan(root, source, consumer_sources=consumer))
+
+    def test_step_one_ignores_a_common_word_in_an_unrelated_file(self):
+        # The negative control for the token rule. This literal carries no
+        # machine-identifier-shaped token: "configuration" and "documentation"
+        # are long, but a plain English word is never distinctive, and
+        # "fail-closed" is a two-segment kebab word the rule excludes on purpose.
+        literal = "the configuration documentation stays fail-closed"
+        with tempfile.TemporaryDirectory() as td:
+            root, source = self._fixture(td, literal=literal)
+            consumer = {
+                "scripts/unrelated.sh": (
+                    "printf 'configuration documentation fail-closed verdict\\n'\n"
+                )
+            }
+            findings = self._scan(root, source, consumer_sources=consumer)
+            self.assertEqual(1, len(findings))
+            self.assertIn("no program consumer reads it", findings[0])
+
+    def test_step_one_ignores_a_mention_that_is_only_a_comment(self):
+        with tempfile.TemporaryDirectory() as td:
+            root, source = self._fixture(td)
+            consumer = {"scripts/derive-verdict.sh": f"# quotes {self.LITERAL}\n"}
+            findings = self._scan(root, source, consumer_sources=consumer)
+            self.assertEqual(1, len(findings))
+            self.assertIn("no program consumer reads it", findings[0])
+
+    def test_step_one_corpus_excludes_the_suite_and_prose_surfaces(self):
+        for path in (
+            "lib/test/other-module.sh",
+            "docs/cloud-allowlist.md",
+            "skills/review/phases/phase-4-verdict.md",
+            "CONTRIBUTING.md",
+        ):
+            with self.subTest(path=path), tempfile.TemporaryDirectory() as td:
+                root, source = self._fixture(td)
+                findings = self._scan(
+                    root, source, consumer_sources={path: f"x {self.LITERAL} y\n"}
+                )
+                self.assertEqual(1, len(findings))
+
+    def test_distinctive_token_shapes_are_machine_identifiers(self):
+        qualifying = (
+            "DEVFLOW_BASH",
+            "scripts/workpad.py",
+            "devflow:workpad",
+            "--tick-progress",
+            "config-get.sh",
+            "phase-4-verdict",
+            "mutation-routing-worktree",
+        )
+        for token in qualifying:
+            with self.subTest(token=token):
+                self.assertEqual(
+                    (token,), self.mod.distinctive_consumer_tokens(f"see {token} here")
+                )
+        non_qualifying = (
+            "configuration",
+            "documentation",
+            "fail-closed",
+            "best-effort",
+            "INCONCLUSIVE",
+            "verdict",
+            "2026-07-29",
+        )
+        for token in non_qualifying:
+            with self.subTest(token=token):
+                self.assertEqual(
+                    (), self.mod.distinctive_consumer_tokens(f"see {token} here")
+                )
+
+    # ── Step 2: the ledger already recorded this literal as a boundary ──────
+    def test_step_two_passes_a_prose_pin_with_a_tag_and_a_boundary_row(self):
+        # The case that is impossible before #948: a prose-resolving literal
+        # whose retention was adjudicated, tagged at the site.
+        with tempfile.TemporaryDirectory() as td:
+            root, source = self._fixture(td, marker=self.MARKER)
+            self.assertEqual(
+                [],
+                self._scan(root, source, current_adjudications=self._ledger()),
+            )
+
+    def test_step_two_rejects_a_tag_with_no_ledger_row(self):
+        # The anti-self-grant control: a tag is a POINTER to an authorized
+        # decision, so tagging your own pin cannot make it legitimate.
+        with tempfile.TemporaryDirectory() as td:
+            root, source = self._fixture(td, marker=self.MARKER)
+            findings = self._scan(root, source, current_adjudications={})
+            self.assertEqual(1, len(findings))
+            self.assertIn("records no boundary decision", findings[0])
+            self.assertNotIn("no valid '# structural-pin-ok:'", findings[0])
+
+    def test_step_two_rejects_a_ledger_row_with_no_tag(self):
+        # DELIBERATE DECISION: the ledger row alone does NOT pass. Step 2 needs
+        # both halves. Retrofitting tags onto the standing retained population is
+        # out of scope precisely because the gate only asks when a site's own
+        # lines change — and when they do, the reader of that line is owed the
+        # reason at the site. This also keeps the change a pure loosening for
+        # TAGGED pins and never a loosening for untagged ones.
+        with tempfile.TemporaryDirectory() as td:
+            root, source = self._fixture(td)
+            findings = self._scan(root, source, current_adjudications=self._ledger())
+            self.assertEqual(1, len(findings))
+            self.assertIn("no valid '# structural-pin-ok:'", findings[0])
+            self.assertNotIn("records no boundary decision", findings[0])
+
+    def test_step_two_rejects_a_row_in_any_other_bucket(self):
+        for bucket in (
+            "prose-sole-copy",
+            "prose-multi-copy",
+            "required-copy",
+            "suite-internal",
+            "generated",
+            "config-key",
+        ):
+            with self.subTest(bucket=bucket), tempfile.TemporaryDirectory() as td:
+                root, source = self._fixture(td, marker=self.MARKER)
+                findings = self._scan(
+                    root, source, current_adjudications=self._ledger(bucket)
+                )
+                self.assertEqual(1, len(findings))
+                self.assertIn("records no boundary decision", findings[0])
+
+    def test_step_two_fails_closed_on_an_unestablished_ledger(self):
+        # An unreadable ledger must never silently satisfy step 2. In production
+        # it cannot even reach here (analyze_adjudication_changes raises first —
+        # see StaticPinWorktreeCompositionTests.test_unreadable_ledger_*), and at
+        # this boundary an unestablished or empty state is refused, not assumed.
+        for label, ledger in (("unestablished", None), ("empty", {})):
+            with self.subTest(ledger=label), tempfile.TemporaryDirectory() as td:
+                root, source = self._fixture(td, marker=self.MARKER)
+                findings = self._scan(root, source, current_adjudications=ledger)
+                self.assertEqual(1, len(findings))
+                self.assertIn("records no boundary decision", findings[0])
+
+    def test_a_different_literals_boundary_row_does_not_carry_over(self):
+        with tempfile.TemporaryDirectory() as td:
+            root, source = self._fixture(td, marker=self.MARKER)
+            findings = self._scan(
+                root,
+                source,
+                current_adjudications=self._ledger(literal="an unrelated sentence"),
+            )
+            self.assertEqual(1, len(findings))
+            self.assertIn("records no boundary decision", findings[0])
+
+    # ── Step 3, and the arms that precede the ladder ────────────────────────
+    def test_a_wording_only_pin_with_nothing_behind_it_is_still_a_finding(self):
+        # The positive control that the policy did not get weaker.
+        with tempfile.TemporaryDirectory() as td:
+            root, source = self._fixture(td)
+            findings = self._scan(root, source, consumer_sources={})
+            self.assertEqual(1, len(findings))
+            self.assertIn("resolves into prose", findings[0])
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            target = root / "docs/x.md"
+            target.parent.mkdir(parents=True)
+            target.write_text("```text\nMACHINE_SENTINEL\n```\n", encoding="utf-8")
+            source = (
+                'F="$LIB/../docs/x.md"\n'
+                "assert_pin_unique \"sentinel\" 'MACHINE_SENTINEL' \"$F\""
+            )
+            findings = self._scan(root, source, current_adjudications=self._ledger())
+            self.assertEqual(1, len(findings))
+            self.assertIn("missing structural declaration", findings[0])
+
+    def test_an_invalid_category_is_a_finding_ahead_of_the_whole_ladder(self):
+        # Arm ORDER: declaration grammar is decided BEFORE routing, so neither a
+        # program consumer nor a boundary row routes around a malformed tag. The
+        # ~35 standing pins on a pre-vocabulary category therefore stay findings
+        # (fixing them is issue-948-out-of-scope follow-up work).
+        for marker in (
+            self.INVALID_MARKER,
+            "# structural-pin-ok: helper-contract --   ",
+            "# structural-pin-ok: -- no category at all",
+        ):
+            with self.subTest(marker=marker), tempfile.TemporaryDirectory() as td:
+                root, source = self._fixture(td, marker=marker)
+                findings = self._scan(
+                    root,
+                    source,
+                    consumer_sources={
+                        "scripts/derive-verdict.sh": f"grep -qF '{self.LITERAL}' x\n"
+                    },
+                    current_adjudications=self._ledger(),
+                )
+                self.assertEqual(1, len(findings))
+                self.assertNotIn("resolves into prose", findings[0])
+
+    def test_each_configuration_selects_its_documented_arm(self):
+        """One site, every configuration, the deciding arm named in each verdict.
+
+        This is the arm-order driver: a reordered ladder moves at least one row.
+        """
+        consumer = {"scripts/derive-verdict.sh": f"grep -qF '{self.LITERAL}' x\n"}
+        cases = (
+            # (marker, consumer corpus, ledger, expected deciding fragment)
+            ("valid", True, "boundary", None),
+            ("valid", False, "boundary", None),
+            ("none", True, "boundary", None),
+            ("none", True, None, None),
+            ("valid", False, None, "records no boundary decision"),
+            ("none", False, "boundary", "no valid '# structural-pin-ok:'"),
+            ("none", False, None, "no program consumer reads it"),
+            ("invalid", True, "boundary", "unknown structural category"),
+        )
+        for marker, with_consumer, bucket, expected in cases:
+            label = f"marker={marker} consumer={with_consumer} ledger={bucket}"
+            with self.subTest(label), tempfile.TemporaryDirectory() as td:
+                root, source = self._fixture(
+                    td,
+                    marker={
+                        "valid": self.MARKER,
+                        "invalid": self.INVALID_MARKER,
+                        "none": "",
+                    }[marker],
+                )
+                findings = self._scan(
+                    root,
+                    source,
+                    consumer_sources=consumer if with_consumer else {},
+                    current_adjudications=self._ledger(bucket) if bucket else {},
+                )
+                if expected is None:
+                    self.assertEqual([], findings, label)
+                else:
+                    self.assertEqual(1, len(findings), label)
+                    self.assertIn(expected, findings[0], label)
+
+    def test_a_retired_literal_keeps_the_pre_948_revival_contract(self):
+        # SCOPE: the ladder governs the RETAINED population. An authorized
+        # revival of a RETIRED wording literal still requires a genuinely
+        # machine-shaped target, because both ladder steps rest on the same
+        # boundary row that contract says cannot alone authorize a revival. Here
+        # the site has everything the ladder would want — valid tag, boundary
+        # row, a program consumer — and is still reported, with no ladder clause.
+        with tempfile.TemporaryDirectory() as td:
+            root, source = self._fixture(td, marker=self.MARKER)
+            key = self._key()
+            state = ("boundary", self.RATIONALE)
+            authorization = self.mod.RevivalAuthorization(
+                "lib/test/a.sh",
+                "static-helper",
+                "assert_pin_unique",
+                key,
+                self.TARGET,
+                "cross-file-phase-contract",
+                self.MARKER.split(" -- ", 1)[1],
+            )
+            findings = self._scan(
+                root,
+                source,
+                retired_literal_keys=frozenset({key}),
+                revival_authorizations=frozenset({authorization}),
+                adjudication_delta={key: (None, state)},
+                current_adjudications={key: state},
+                consumer_sources={
+                    "scripts/derive-verdict.sh": f"grep -qF '{self.LITERAL}' x\n"
+                },
+            )
+            self.assertEqual(1, len(findings))
+            self.assertIn("resolves into prose", findings[0])
+            self.assertNotIn("no program consumer reads it", findings[0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #948.

## The ladder as implemented

`lib/test/pin-corpus-lint.py`'s `scan_changed_sources` no longer answers a changed pin
site with a single prose test. Per site, in this order:

**Before the ladder (unchanged arms).** The retired-wording-literal revival block, then
`_typed_pin_inspection_error`, then — the one arm I moved — a declaration that is
**present but ungrammatical** (unknown category, empty rationale, duplicate marker). That
grammar check now runs *ahead* of the routing ladder so neither a program consumer nor a
ledger row can route around a malformed tag. The ~35 standing pins on a pre-vocabulary
free-text category therefore stay findings, exactly as today.

1. **A program demonstrably reads it → pass, no human needed.** The literal, or a
   machine-identifier-shaped token it names, occurs in the *operative* text of a tracked
   `scripts/**`, `lib/**`-outside-`lib/test/`, or `.github/**` file. No tag and no ledger
   row are required for this arm.
2. **Otherwise, the ledger already recorded the decision → pass.**
   `lib/test/pin-corpus-adjudications.tsv` carries this literal as `boundary` **and** the
   site carries a valid `# structural-pin-ok:` declaration. The tag is a *pointer to an
   authorized decision*, never a self-granted permission.
3. **Neither → the finding stands**, and its text now names which half of step 2 was
   missing.

`load_machine_consumer_sources` builds the step-1 corpus once per gate run: population
from an index-reading `git ls-files -- scripts/ lib/ .github/` (no `--others`, no
root-anchored recursive walk — issue #711), contents from the worktree, `lib/test/**`
excluded. For `#`-comment languages the comment regions are **subtracted**: a literal
quoted in a `lib/*.sh` comment is not a program reading it.

### The token-matching rule I chose, and why

A "distinctive token" is a whitespace-split word, trimmed of surrounding quoting and
sentence punctuation, that is **≥ 8 characters, contains ≥ 3 letters, and has a
machine-identifier shape**: contains `_`, contains `/`, contains `:`, starts with `--`,
has an interior `alnum.alnum`, or is kebab-case with a digit or ≥ 3 segments. Matching is
whole-token (neither neighbour may be `[\w-]`).

The shape requirement is the whole rule: a common English word is never distinctive
however long it is, so `configuration`, `documentation`, `verdict` and `INCONCLUSIVE`
cannot satisfy step 1. Two-segment kebab words that read as ordinary English
(`fail-closed`, `best-effort`) are excluded on purpose — a kebab token qualifies only with
a digit or a third segment. `DEVFLOW_BASH`, `scripts/workpad.py`, `--tick-progress`,
`devflow:workpad`, `config-get.sh`, `phase-4-verdict` and `mutation-routing-worktree` all
qualify. A literal with no such token yields no tokens at all, which routes its pin to
step 2 — never to a finding.

## The three constraints

- **Step 1 fails toward step 2, never toward rejection.** "No consumer found" is only ever
  the absence of *found* evidence — a helper that walks a routing table row by row names
  no individual row — so it hands the site to step 2. Every way step 1 can come up short
  (no corpus supplied, an untracked consumer, an unreadable or non-UTF-8 file, a
  comment-only mention, a literal with no distinctive token) routes down, and the
  unreadable-file case emits a stderr breadcrumb rather than failing silently.
- **Step 2 fails closed.** An absent row, a row in any other bucket, an empty ledger and
  an unestablished ledger are all findings. An *unreadable* ledger never reaches the
  ladder at all: `analyze_adjudication_changes` raises `InfrastructureError` first, so the
  public command exits **2**, not 0 — driven end-to-end below.
- **The gate routes; it does not judge.** Step 1 asks a mechanical question. Step 2 defers
  to an authorization granted elsewhere. The real control over step 2 is the **review of
  ledger changes**, which is separately delta-gated and needs an exact branch change
  manifest against the current `origin/main` tip. This is not the gate getting smarter,
  and the code comment and `CONTRIBUTING.md` both say so in those words.

## The deliberate decision: ledger row present, tag absent → **finding**

Step 2 requires *both* halves. Rationale, recorded in the test's own comment:

- It keeps this change a pure **loosening for tagged pins** and never a loosening for
  untagged ones — a tagless pin is a finding today and stays one, so nothing red today
  silently goes green except via a tag or a demonstrable consumer.
- The gate only asks about a site whose own lines changed. When a maintainer edits that
  line, the next reader of it is owed the reason *at the site*; a ledger-only pass would
  leave the gate with no on-site signal at all.
- It does not conflict with "don't retrofit tags onto the 674" — retrofitting is still not
  the ask, because the question is never posed until the line is edited.

## Scope decision surfaced by a pre-existing test

`test_authorized_retired_revival_cannot_launder_committed_prose_target` went red on the
first draft, and correctly. A **retired** wording literal's revival has its own stronger
contract (deliberate revival authorization **plus** a genuinely declared structural
boundary — `CONTRIBUTING.md`: "a new boundary row alone does not make the revival valid"),
and both ladder steps rest on exactly that boundary row. So the ladder is scoped to the
**retained** population: a retired literal keeps its pre-#948 behaviour verbatim, message
text included. That test passes unchanged, and a new unit test drives the scope directly.

## Which arm is covered by which test

All in `lib/test/test_pin_corpus_lint.py`. The new `PinRoutingLadder948Tests` fixture pins
a whitespace-bearing visible Markdown sentence — a literal the lint classifies as prose,
i.e. one for which *no* declaration and *no* ledger row was reachable before this change.
Each test asserts the deciding message, not just the count, because a reordered ladder
would otherwise stay green.

| Arm | Test |
|---|---|
| Step 1 passes with no tag and no ledger row (+ RED-first control: same site, no corpus → finding) | `test_step_one_passes_with_no_tag_and_no_ledger_row` |
| Step 1 accepts a distinctive token, not only the whole literal | `test_step_one_accepts_a_distinctive_token_not_only_the_whole_literal` |
| **Negative control** — an unrelated file mentioning common words does not pass step 1 | `test_step_one_ignores_a_common_word_in_an_unrelated_file` |
| A consumer whose only mention is a `#` comment does not pass step 1 | `test_step_one_ignores_a_mention_that_is_only_a_comment` |
| The corpus excludes `lib/test/`, `docs/`, `skills/` and repo-root prose | `test_step_one_corpus_excludes_the_suite_and_prose_surfaces` |
| The token rule itself (7 qualifying, 7 non-qualifying shapes) | `test_distinctive_token_shapes_are_machine_identifiers` |
| **Step 2 passes a prose-resolving pin** — the case impossible today | `test_step_two_passes_a_prose_pin_with_a_tag_and_a_boundary_row` |
| **Anti-self-grant** — tag, no ledger row → finding | `test_step_two_rejects_a_tag_with_no_ledger_row` |
| **Deliberate decision** — ledger row, no tag → finding | `test_step_two_rejects_a_ledger_row_with_no_tag` |
| A row present but not `boundary` (6 buckets) → finding | `test_step_two_rejects_a_row_in_any_other_bucket` |
| **Fail-closed** — unestablished and empty ledger → finding | `test_step_two_fails_closed_on_an_unestablished_ledger` |
| A different literal's boundary row does not carry over | `test_a_different_literals_boundary_row_does_not_carry_over` |
| **Positive control** — wording-only pin with nothing behind it → still a finding (prose and non-prose targets) | `test_a_wording_only_pin_with_nothing_behind_it_is_still_a_finding` |
| Invalid/missing category → finding *even with* a consumer and a boundary row (arm order) | `test_an_invalid_category_is_a_finding_ahead_of_the_whole_ladder` |
| **Arm order** — one site, 8 configurations, each asserting the deciding arm's message | `test_each_configuration_selects_its_documented_arm` |
| Retired literal keeps the pre-#948 revival contract (scope) | `test_a_retired_literal_keeps_the_pre_948_revival_contract` |
| **End-to-end step-1 wiring** through `git ls-files` + worktree reads: undeclared pin over a literal a tracked `scripts/` program reads → rc 0; comment-only mention → rc 3 | `StaticPinWorktreeCompositionTests.test_step_one_consumer_passes_the_public_worktree_ladder` |
| **End-to-end fail-closed** — unreadable ledger → rc 2, on a pin that exits 0 with a readable one | `StaticPinWorktreeCompositionTests.test_unreadable_ledger_is_infrastructure_not_a_step_two_pass` |

**Arm I could not test:** an end-to-end step-2 pass through the public command. Reaching it
needs a `boundary` row for the fixture literal *plus* an authorized delta manifest, and
adding a row without one is itself a finding (`unauthorized pin adjudication delta`) — so
the fixture would end up testing the bundle machinery, which has its own tests. Step 2 is
driven at the `scan_changed_sources` boundary instead, with the production wiring
(`current_adjudications=adjudication_analysis.current`) unchanged.

## Explicitly not done

- The ~35 pins whose tag carries an invalid category are **not** fixed. They become
  fixable after this lands; touching them here would balloon the diff.
- The uninspectable-target case (`typed structural declaration target cannot be
  inspected`) is **not** fixed. Neither half of the proposal addresses it, and the frozen
  site in `lib/test/modules/create-issue-contract.sh` stays frozen.
- No tags retrofitted onto the retained population; no existing `boundary` adjudication
  re-litigated.

## Coupled prose updated in the same change

- `CONTRIBUTING.md` — the paragraph stating that the gate "runs the prose-resolution check
  *before* the declaration check … **regardless of any declaration**" is now false; it
  states the ladder, where the real control sits, and both out-of-scope cases.
- `lib/test/run.sh` — the `#871` comment asserting that the prose arm is one "no
  `# structural-pin-ok:` declaration rescues" now records the step-2 pointer contract.

## Verification

Run on this branch, rebased onto current `main` (`0de0fbc1`, after #947 merged), every
script invoked as a direct leading token:

- `python3 lib/test/test_pin_corpus_lint.py` → `Ran 155 tests … OK`
- `python3 lib/test/pin-corpus-lint.py mutation-routing-worktree <repo-root>` → rc 0
- `python3 lib/test/test_pin_corpus_classifier.py` → `Ran 15 tests … OK`
- `python3 lib/test/coverage_map_guard.py .` → rc 0
- `git ls-files '*.py' | xargs -r ruff check` → `All checks passed!`
- `shellcheck --severity=warning -e SC1091 --extended-analysis=false lib/test/run.sh` → rc 0
- the full `lib/test/run.sh` — result posted as a comment on this PR

Writing-skills evidence: not applicable — this change touches no `SKILL.md` and no prompt
surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
