### PR TITLE
fix(pins): make concatenated in-module bundle pin targets inspectable — unfreezes 12 declaration lines (#956)

### DIFF
--- a/.changeset/bundle-pin-target-inspection.md
+++ b/.changeset/bundle-pin-target-inspection.md
@@ -1,0 +1,23 @@
+---
+bump: patch
+type: Fixed
+---
+
+- **The `# structural-pin-ok:` declaration on a pin that targets a runtime-concatenated
+  bundle can be edited again.** `lib/test/pin-corpus-lint.py` now resolves a bundle
+  variable (`$CI_BUNDLE`, `$MAXI_BUNDLE`) back to the repository files its own builder
+  call concatenates, and inspects a typed declaration against that member set: every
+  member must be inside the repository and readable, and the literal must be present in
+  at least one of them. Before this, such a target resolved to a scratch path no static
+  resolution reached, so the gate reported `typed structural declaration target cannot be
+  inspected` for any declared pin on it — and because a site is classified whenever its
+  lines land in the diff's added set, the whole logical line, declaration text included,
+  was permanently uneditable. Eleven retained pins were frozen that way. Membership is
+  resolved only through a closed grammar (a builder call, an array built from literal
+  words and/or one for-loop over a path glob with an optional basename skip, and
+  whole-variable aliases of a resolved bundle); an unresolvable build, an ambiguous name,
+  an empty glob expansion and an unreadable member all keep the existing refusal, and a
+  literal present in no member is still reported absent. Prose resolution follows the same
+  member set, so the routing ladder still requires an authorized ledger row and a tag
+  cannot self-grant a bundle pin. Eleven declarations now carry a legal category authored
+  from the site's own recorded ledger rationale. (#956)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -205,10 +205,15 @@ auditable — `lib/test/pin-corpus-adjudications.tsv`, surfaced per row in the c
 and not as several hundred uncoupled copies in source comments, so retrofitting a marker
 onto the standing population is still not the ask. Two cases the ladder does **not**
 reach: a pin whose declared target the lint cannot resolve at all
-(`typed structural declaration target cannot be inspected` — e.g. a concatenated
-in-module bundle) is still unfixable, and a *retired* wording literal's revival keeps its
-own stronger contract below. Touch a retained pin's lines only when you are prepared to
-answer the gate for it.
+(`typed structural declaration target cannot be inspected`) is still unfixable, and a
+*retired* wording literal's revival keeps its own stronger contract below. A
+**concatenated in-module bundle** target is no longer one of those unresolvable cases
+(issue #956): the lint resolves the bundle variable to the member files its own builder
+call concatenates and inspects the declaration against that member set, so such a pin is
+editable like any other. What still cannot be resolved — an unmodeled build shape, an
+ambiguous bundle name, an empty glob expansion, an unreadable member — keeps the refusal,
+and a literal present in no member is still reported absent. Touch a retained pin's lines
+only when you are prepared to answer the gate for it.
 
 `lib/test/pin-corpus-adjudications.tsv` contains only the current active adjudication
 state. Every addition, removal, or change to that table must be authorized by an exact

--- a/lib/test/modules/create-issue-contract.sh
+++ b/lib/test/modules/create-issue-contract.sh
@@ -448,21 +448,21 @@ devflow_module_pin_unique "#600/#709: the auditor is told to invoke render-audit
 # breaks no behavioral guarantee the suite otherwise proves — it removes the skill-side
 # instruction that makes the gate reachable, which is a prose-presence property.
 devflow_module_pin_unique "#709: the dispatch prompt is a generated pointer, not freehand prose" \
-  'the Agent-tool prompt string is a **generated pointer**' "$CI_BUNDLE"  # structural-pin-ok: contract-presence over skill prose; the behavioral gate is proven by the #709 state-owner rows
+  'the Agent-tool prompt string is a **generated pointer**' "$CI_BUNDLE"  # structural-pin-ok: generated-artifact-identity -- the ledger records this dispatch prompt as generator output rather than freehand text
 devflow_module_pin_unique "#709: the skill invokes the dispatch-instructions generator" \
-  'render-audit-prompt.py dispatch-instructions --slug' "$CI_BUNDLE"  # structural-pin-ok: contract-presence over skill prose; the behavioral gate is proven by the #709 state-owner rows
+  'render-audit-prompt.py dispatch-instructions --slug' "$CI_BUNDLE"  # structural-pin-ok: routing-dispatch-contract -- the ledger names the generator invocation the skill must reach at dispatch
 devflow_module_pin_unique "#709: the closed regeneration inputs are forwarded at dispatch" \
-  '--instructions-file "<instructions path>" --instructions-draft-path' "$CI_BUNDLE"  # structural-pin-ok: contract-presence over skill prose; the behavioral gate is proven by the #709 state-owner rows
+  '--instructions-file "<instructions path>" --instructions-draft-path' "$CI_BUNDLE"  # structural-pin-ok: routing-dispatch-contract -- the ledger names the closed regeneration-input set forwarded at dispatch
 devflow_module_pin_unique "#709: withhold-then-disclose never blocks filing" \
-  '**Filing is never blocked on any arm.**' "$CI_BUNDLE"  # structural-pin-ok: contract-presence over skill prose; the behavioral gate is proven by the #709 state-owner rows
+  '**Filing is never blocked on any arm.**' "$CI_BUNDLE"  # structural-pin-ok: lifecycle-state-transition -- the ledger keeps this integrity boundary: no lifecycle arm may gate creation
 # The out-of-bounds declaration is PRESERVED by the cutover, not superseded by it — the narrow
 # scope is the whole point, so pin that it survived rather than trusting the diff review to have
 # noticed its absence. (#885 retired the companion information-diet pin: that rule is prose no
 # tool reads, so its preservation now rests on the review pass rather than on a pin.)
 devflow_module_pin_unique "#709: the cutover preserved the out-of-bounds declaration" \
-  'reasoning artifacts out of bounds' "$CI_BUNDLE"  # structural-pin-ok: preservation pin over prose the #709 cutover must not remove
+  'reasoning artifacts out of bounds' "$CI_BUNDLE"  # structural-pin-ok: cross-file-phase-contract -- the ledger keeps the audit artifact boundary the cutover had to preserve across the split surfaces
 devflow_module_pin_unique "#709: Step 4 renders the steering marker on the audit-summary line" \
-  'audit independence unestablished' "$CI_ROOT/skills/create-issue/references/step-4-present-create.md"  # structural-pin-ok: contract-presence over skill prose; the behavioral gate is proven by the #709 state-owner rows
+  'audit independence unestablished' "$CI_ROOT/skills/create-issue/references/step-4-present-create.md"  # structural-pin-ok: machine-sentinel-provenance -- the ledger keeps the exact steering marker Step 4 renders on the summary line
 
 # ── issue #803: the create-issue final-byte prose ↔ issue-audit-state.py registry ─
 # Per-contract determination for issue #792's six agent-executed prose contracts
@@ -541,11 +541,11 @@ assert_eq "#803 negative control: the exit-2 rejection came from the argparse di
 # behavioral guarantee the suite otherwise proves — it removes the skill-side instruction
 # that makes the cheap path conforming, a prose-presence property.
 devflow_module_pin_unique "#768: the instruction write uses a shell redirect in the bash fence" \
-  'to the instruction path with a shell redirect in the bash fence itself' "$CI_BUNDLE"  # structural-pin-ok: contract-presence over skill prose; the transport is proven by ias_instructions()
+  'to the instruction path with a shell redirect in the bash fence itself' "$CI_BUNDLE"  # structural-pin-ok: helper-contract -- the ledger names the writer interface between the fence and the generator
 devflow_module_pin_unique "#768: the redirect truncates the target before the generator runs" \
-  'The redirect truncates the target before the generator runs' "$CI_BUNDLE"  # structural-pin-ok: contract-presence over skill prose; the transport is proven by ias_instructions()
+  'The redirect truncates the target before the generator runs' "$CI_BUNDLE"  # structural-pin-ok: helper-contract -- the ledger names the truncation half of that same writer interface
 devflow_module_pin_unique "#768: the landed check is exit-zero plus a non-empty file" \
-  'The write has landed when the generator exits zero and the file at the instruction path is non-empty' "$CI_BUNDLE"  # structural-pin-ok: contract-presence over skill prose; the transport is proven by ias_instructions()
+  'The write has landed when the generator exits zero and the file at the instruction path is non-empty' "$CI_BUNDLE"  # structural-pin-ok: helper-contract -- the ledger names the delivery test that closes that writer interface
 # issue #795: the two #768 pins that stood over the standalone read-back extraction are
 # DELETED, not re-worded. That extraction is gone — the generator now emits the
 # `dispatch-pointer:` line on its own stderr — so their literals describe a fence the skill
@@ -560,7 +560,7 @@ devflow_module_pin_unique "#768: the landed check is exit-zero plus a non-empty 
 # stdout is byte-unchanged, and an earlier draft of this comment claimed it did — the
 # load-bearing half of a pin-deletion justification must describe assertions that exist.)
 devflow_module_pin_unique "#768: record-dispatch output names dispatch_regeneration" \
-  'dispatch_regeneration=<verified|diverged|unverified>' "$CI_BUNDLE"  # structural-pin-ok: contract-presence over skill prose; the field is printed by issue-audit-state.py
+  'dispatch_regeneration=<verified|diverged|unverified>' "$CI_BUNDLE"  # structural-pin-ok: helper-contract -- the ledger names this field of the state owner's record-dispatch output
 
 devflow_module_pin_unique "#600: SKILL states the positional two-marker delivery check" \
   'first line begins `render-status:`' "$CI_BUNDLE"
@@ -1369,17 +1369,16 @@ unset -f ci749_field
 # module — so a revert to the hardcoded internal-docs location, or one
 # dropping the Steps-1-and-2 read, is caught by the review pass over the SKILL prose, not here.
 #
-# READ THIS BEFORE TOUCHING THE CALL BELOW. Its trailing declaration still says "the behavioral
-# read is pinned by the two rows below"; that is stale (#885 retired those rows) and it is
-# deliberately left stale, because the declaration CANNOT be corrected. The #810 gate classifies
-# a site whose physical lines are in the diff's added set, so any edit to those two lines pulls
-# this site into scope — and it then fails on `typed structural declaration target cannot be
-# inspected` ($CI_DV is a concatenated in-module bundle the lint cannot resolve) as well as on
-# the category, which predates #885 and is not one of the eight legal ones. Editing the marker
-# text therefore turns the required gate RED with no valid form available. This paragraph is the
-# correction; the marker is frozen until the target becomes inspectable.
+# The declaration below was the site #948 recorded as permanently frozen: its category predated
+# the eight-name vocabulary, and its stale trailing text ("the behavioral read is pinned by the
+# two rows below" — #885 retired those rows) could not be corrected, because the #810 gate
+# classifies a site whose physical lines land in the diff's added set and this one then failed on
+# `typed structural declaration target cannot be inspected` as well as on the category, leaving no
+# valid form to edit into. Issue #956 resolved the target — $CI_DV is a single skill surface
+# reached through the module's `${…:-${LIB%/lib}}` root — so the declaration now states the
+# boundary its own ledger row records and the line is maintainable like any other.
 devflow_module_pin_unique "#749/AC26: docs-verify's argument grammar carries the search-space operand" \
-  'Grammar: `[--report-only] [--search-space <pathspec>] <topic…>`.' "$CI_DV"  # structural-pin-ok: grammar-declaration presence; the behavioral read is pinned by the two rows below
+  'Grammar: `[--report-only] [--search-space <pathspec>] <topic…>`.' "$CI_DV"  # structural-pin-ok: helper-contract -- the ledger records this argument grammar as the caller/parser interface the dispatcher composes calls against
 # The declaration above is prose; the locate-documentation step's own read is the behavior a
 # revert to the hardcoded internal-docs location would destroy while leaving that prose intact.
 # An unrecognized `--`-prefixed token must be refused, not stripped as a bare flag: stripping it

--- a/lib/test/modules/harness-python-guards.sh
+++ b/lib/test/modules/harness-python-guards.sh
@@ -325,8 +325,10 @@ echo "#810 pin-corpus wording-only authoring gate"
 # tests drive do hold process-global memos, which that docstring covers in the same
 # place, and it takes two limbs rather than one. The per-source parse memos are keyed
 # on the presented bytes — the census memos additionally on the source's name, the
-# linter memos on the text alone — and on no repo_root or filesystem state, so a hit
-# answers for exactly the source the caller presented. _load_mutation_census_module is
+# linter memos on the text alone (issue #956's two bundle-membership parses additionally
+# on the caller's lib path) — and on no repo_root or filesystem state, so a hit
+# answers for exactly what the caller presented; the bundle resolver's glob expansion
+# stays OUTSIDE its memo to keep that true. _load_mutation_census_module is
 # the second limb: it takes no arguments at all, so its safety rests not on its key but
 # on the module it returns mutating nothing after import beyond those same key-pure
 # memos — its other module-level objects, the compiled-regex dicts among them, are

--- a/lib/test/pin-corpus-lint.py
+++ b/lib/test/pin-corpus-lint.py
@@ -153,7 +153,9 @@ import ast
 import bisect
 import csv
 import difflib
+import fnmatch
 import functools
+import glob
 import hashlib
 import importlib.util
 import io
@@ -1332,6 +1334,9 @@ class GuardSite(NamedTuple):
     target_path: str | None
     declaration: StructuralDeclaration | None
     declaration_error: str | None
+    # The resolved member files of a concatenated bundle target, set only when
+    # ``target_path`` is None because the target is a runtime bundle (issue #956).
+    target_members: tuple | None = None
 
 
 class FilePatch(NamedTuple):
@@ -2750,6 +2755,394 @@ def _resolve_guard_target(args, spec, literal_vars, path_vars, lib):
     return None
 
 
+def _guard_target_variable(args, spec):
+    """The bare variable NAME a guard's target argument reads, or None.
+
+    Recovering the name is what lets an UNRESOLVED target still be identified: a
+    bundle variable holds a runtime scratch path, so ``_resolve_guard_target``
+    returns None for it and only the name it was written as remains (issue #956).
+    """
+    _, file_index, default_file = spec
+    if file_index < len(args):
+        return _bundle_variable_name(_token_value(args[file_index]).rstrip(";"))
+    return default_file
+
+
+# ── issue #956: concatenated in-module bundle targets ───────────────────────
+# A content-survival pin may target a bundle its test source CONCATENATES at
+# runtime from several repository files (``$CI_BUNDLE``, ``$MAXI_BUNDLE``): the
+# contract sentence must survive somewhere in a split skill, and which member
+# holds it is an implementation detail the pin deliberately does not fix. That
+# target is a scratch path no static resolution reaches, so every typed
+# declaration on such a pin was refused as uninspectable — and because the gate
+# classifies any site whose lines land in the diff, the whole logical line
+# (declaration text included) became permanently uneditable.
+#
+# Resolving the bundle variable back to the member files its own builder call
+# names gives those pins the SAME inspection the single-file case gets: the
+# declaration is inspected against the member set, and the literal must be
+# present in one of the members. This weakens nothing. Membership is resolved
+# only through the closed grammar below (a builder call, an array built from
+# literal words and/or one for-loop over a path glob with an optional basename
+# skip, and whole-variable aliases of a resolved bundle); anything outside it
+# leaves the bundle unresolved and the pre-existing refusal stands, an empty
+# member set is never treated as inspected, and a literal present in no member
+# is still reported.
+BUNDLE_BUILDERS = frozenset({"_build_skill_bundle", "devflow_module_build_bundle"})
+_BUNDLE_ARRAY_ASSIGN_RE = re.compile(
+    r"^\s*(?:local\s+)?([A-Za-z_]\w*)(\+?)=\(\s*(.*?)\s*\)\s*(?:#.*)?$"
+)
+_BUNDLE_ARRAY_EXPANSION_RE = re.compile(r"^\$\{(\w+)\[@\]\}$")
+_BUNDLE_FOR_RE = re.compile(r"^\s*for\s+([A-Za-z_]\w*)\s+in\s+(.*?)\s*;\s*do\b(.*)$")
+# ``case "${ref##*/}" in a.md|b.md) continue ;; esac`` — the one member filter the
+# grammar models, so a bundle that skips named basenames resolves EXACTLY rather
+# than to a superset of its real membership.
+_BUNDLE_CASE_SKIP_RE = re.compile(
+    r"^case\s+\"?\$\{(\w+)##\*/\}\"?\s+in\s+([^)]+)\)\s*continue\s*;;\s*esac$"
+)
+_BUNDLE_DEFAULT_EXPANSION_RE = re.compile(r"^\$\{(\w+):[-=](.*)\}$")
+_BUNDLE_SUFFIX_EXPANSION_RE = re.compile(r"^\$\{(\w+)%%?([^{}]*)\}$")
+_BUNDLE_GLOB_CHARS = "*?["
+
+
+class BundleMemberSpec(NamedTuple):
+    """One member word of a bundle build: a path, possibly a glob, plus the
+    basename patterns an enclosing loop filter skips."""
+
+    pattern: str
+    exclusions: tuple
+
+
+def _bundle_variable_name(token_value):
+    """The variable name a whole-token reference names (``"$CI_BUNDLE"``), else None."""
+    value = token_value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        value = value[1:-1]
+    match = _VARREF.match(value)
+    return match.group(1) if match else None
+
+
+def _bundle_expansion_path(rhs, lib, path_vars):
+    """Resolve a bundle root variable's right-hand side to a path, or None.
+
+    ``_resolve_path_rhs`` models plain and var-prefixed paths; a bundle's root is
+    additionally written with a default (``${VAR:-fallback}``) or a suffix strip
+    (``${LIB%/lib}``), so those two forms are resolved here. The extension is
+    deliberately LOCAL to bundle resolution rather than added to the shared
+    resolver: widening the shared one would change which targets the whole corpus
+    resolves, a far larger behavior change than issue #956 authorizes.
+    """
+    value = rhs.strip()
+    if len(value) >= 2 and value[0] == '"' and value.endswith('"'):
+        value = value[1:-1]
+    default = _BUNDLE_DEFAULT_EXPANSION_RE.match(value)
+    if default is not None:
+        if default.group(1) in path_vars:
+            return path_vars[default.group(1)]
+        return _bundle_expansion_path(default.group(2), lib, path_vars)
+    suffix = _BUNDLE_SUFFIX_EXPANSION_RE.match(value)
+    if suffix is not None:
+        base = path_vars.get(suffix.group(1))
+        if base is None:
+            return None
+        pattern = suffix.group(2)
+        if any(char in pattern for char in _BUNDLE_GLOB_CHARS):
+            return None  # a pattern suffix is not modeled; fail closed
+        if pattern and base.endswith(pattern):
+            return base[: -len(pattern)]
+        return base
+    return _resolve_path_rhs(value, lib, path_vars)
+
+
+def _extended_path_vars(text, lib):
+    """Sequential path-variable map extended with the two parameter expansions a
+    module's ROOT variable uses, for bundle membership and for the guard-target
+    fallback in ``extract_guard_sites``.
+
+    ``LIB`` is seeded (and protected) because a module reaches its repository root
+    through it (``${LIB%/lib}``) — the same special case the shared inline
+    ``$LIB/rel`` resolution already makes.
+
+    It is a whole-source final-state map, not the per-line view: a name it adds is
+    one the shared per-line resolver could not resolve at ANY line, so the two
+    cannot disagree about a name that resolves on both. A name reassigned between
+    two extended-only values would be read as its last value; no bundle source
+    does that today, and the callers use this map only as a fallback after the
+    per-line view has already failed.
+
+    Memoized on ``(text, lib)`` like the other whole-source parses; a fresh dict is
+    handed out so a caller cannot write through the cached object.
+    """
+    return dict(_extended_path_vars_cached(text, lib))
+
+
+@functools.lru_cache(maxsize=_IMAGE_PARSE_CACHE_SIZE)
+def _extended_path_vars_cached(text, lib):
+    path_vars = {}
+    if lib:
+        path_vars["LIB"] = lib
+    literal_vars = {}
+    for _, line in join_logical_lines(text):
+        if _BUNDLE_ARRAY_ASSIGN_RE.match(line) is not None:
+            continue  # array assignments are resolved by _bundle_arrays
+        match = _ASSIGNMENT_RE.match(line)
+        if match is None:
+            continue
+        name, rhs = match.group(1), match.group(2).strip()
+        _apply_assignment(
+            name, rhs, path_vars, literal_vars, lib, protected=("LIB",)
+        )
+        if name not in path_vars and name != "LIB":
+            value = _bundle_expansion_path(rhs, lib, path_vars)
+            if value is not None:
+                path_vars[name] = value
+    return path_vars
+
+
+def _bundle_word_specs(words, lib, path_vars):
+    """Resolve a whitespace-separated member word list, or None if any word is
+    unresolvable (fail closed: a partially resolved bundle is not a bundle)."""
+    specs = []
+    for token in tokenize(words.strip()):
+        resolved = resolve_arg(token, {}, path_vars, want_path=True, lib=lib)
+        if resolved is None:
+            return None
+        specs.append(BundleMemberSpec(resolved, ()))
+    return tuple(specs) or None
+
+
+def _bundle_loop_member_specs(loop_var, words, body, lib, path_vars):
+    """Resolve one ``for`` loop's contribution as (appended array names, specs).
+
+    ``specs`` is None when the loop body carries any statement the grammar does
+    not model, so every array it appends to is poisoned rather than silently
+    under-resolved. That direction is load-bearing: run.sh also builds bundles by
+    looping over a STEM list and appending an interpolated path
+    (``_members+=("$LIB/../skills/implement/phases/${_s}.md")``), a shape this
+    grammar does not model — reporting the appended-to array as merely "the words
+    resolved so far" would resolve those bundles to a strict SUBSET of their real
+    membership and let inspection call a literal absent that is really present.
+    """
+    exclusions = []
+    appended = []
+    unmodeled_arrays = []
+    modeled = True
+    for statement in body:
+        if not statement or statement.startswith("#"):
+            continue
+        skip = _BUNDLE_CASE_SKIP_RE.match(statement)
+        if skip is not None and skip.group(1) == loop_var:
+            exclusions.extend(
+                pattern.strip().strip("\"'") for pattern in skip.group(2).split("|")
+            )
+            continue
+        append = _BUNDLE_ARRAY_ASSIGN_RE.match(statement)
+        if append is not None and append.group(2) == "+":
+            if _bundle_variable_name(append.group(3)) == loop_var:
+                appended.append(append.group(1))
+            else:
+                unmodeled_arrays.append(append.group(1))
+            continue
+        modeled = False
+    if not appended and not unmodeled_arrays:
+        return (), None
+    if unmodeled_arrays or not modeled:
+        return tuple(appended) + tuple(unmodeled_arrays), None
+    specs = _bundle_word_specs(words, lib, path_vars)
+    if specs is None:
+        return tuple(appended), None
+    return tuple(appended), tuple(
+        spec._replace(exclusions=tuple(exclusions)) for spec in specs
+    )
+
+
+def _bundle_arrays(text, lib, path_vars):
+    """Return {array name: member specs}, mapping an unmodeled array to None."""
+    lines = list(join_logical_lines(text))
+    arrays = {}
+    index = 0
+    while index < len(lines):
+        line = lines[index][1]
+        loop = _BUNDLE_FOR_RE.match(line)
+        if loop is not None:
+            inline = loop.group(3).strip()
+            if inline:
+                body = [
+                    part.strip()
+                    for part in inline.split(";")
+                    if part.strip() and part.strip() != "done"
+                ]
+                index += 1
+            else:
+                body = []
+                index += 1
+                while index < len(lines) and lines[index][1].strip() != "done":
+                    body.append(lines[index][1].strip())
+                    index += 1
+                index += 1  # consume the `done`
+            names, specs = _bundle_loop_member_specs(
+                loop.group(1), loop.group(2), body, lib, path_vars
+            )
+            if line[:1] in {" ", "\t"}:
+                specs = None  # a nested loop's reachability is not modeled
+            for name in names:
+                if specs is None or arrays.get(name, ()) is None:
+                    arrays[name] = None
+                else:
+                    arrays[name] = arrays.get(name, ()) + specs
+            continue
+        assign = _BUNDLE_ARRAY_ASSIGN_RE.match(line)
+        if assign is not None:
+            name, append, words = assign.group(1), assign.group(2), assign.group(3)
+            # An INDENTED assignment outside a modeled loop sits inside some other
+            # compound (a function, an `if`, a `while read` loop) whose reachability
+            # this grammar does not model, so it is treated as unresolvable rather
+            # than as an unconditional member (fail closed).
+            specs = (
+                _bundle_word_specs(words, lib, path_vars)
+                if line[:1] not in {" ", "\t"}
+                else None
+            )
+            if append != "+" or name not in arrays:
+                arrays[name] = specs
+            elif arrays[name] is None or specs is None:
+                arrays[name] = None
+            else:
+                arrays[name] = arrays[name] + specs
+        index += 1
+    return arrays
+
+
+def _expand_bundle_specs(specs):
+    """Expand member specs to member file paths, or None when a glob member matched
+    nothing (an empty or partial member set must never read as inspected)."""
+    members = []
+    for spec in specs:
+        if not any(char in spec.pattern for char in _BUNDLE_GLOB_CHARS):
+            members.append(spec.pattern)
+            continue
+        # The pattern is a closed non-recursive single-directory one taken verbatim
+        # from the bundle's own builder call — no recursion and no `**`. It mirrors
+        # the shell glob the bundle is really assembled from, which is why the
+        # worktree, not the index, is the right population here.
+        candidates = glob.glob(spec.pattern)  # tree-walk-ok: closed non-recursive builder-call pattern, mirroring the shell glob that assembles the bundle
+        matched = sorted(path for path in candidates if os.path.isfile(path))
+        if spec.exclusions:
+            matched = [
+                path
+                for path in matched
+                if not any(
+                    fnmatch.fnmatch(os.path.basename(path), pattern)
+                    for pattern in spec.exclusions
+                )
+            ]
+        if not matched:
+            return None
+        members.extend(matched)
+    resolved = []
+    for member in members:
+        absolute = os.path.abspath(member)
+        if absolute not in resolved:
+            resolved.append(absolute)
+    return tuple(resolved) or None
+
+
+def _bundle_call_members(args, arrays, lib, path_vars):
+    """Resolve a builder call's member arguments to member specs, or None."""
+    specs = []
+    for token in args:
+        raw = _token_value(token)
+        expansion = _BUNDLE_ARRAY_EXPANSION_RE.match(raw.strip().strip("\"'"))
+        if expansion is not None:
+            array = arrays.get(expansion.group(1))
+            if array is None:
+                return None
+            specs.extend(array)
+            continue
+        resolved = _bundle_word_specs(raw, lib, path_vars)
+        if resolved is None:
+            return None
+        specs.extend(resolved)
+    return tuple(specs) or None
+
+
+def resolve_bundle_targets(text, lib):
+    """Map each bundle variable in ``text`` to the repository files its build
+    concatenates (issue #956).
+
+    The PARSE is memoized on the presented bytes; the glob EXPANSION deliberately
+    is not, so no memo in this module captures filesystem state — the property
+    ``lib/test/test_pin_corpus_lint.py``'s sharding docstring states and its
+    ``MemoizedParseContractTests`` pin. Expansion is a handful of single-directory
+    globs, so repeating it per call costs far less than the parse it replaces.
+    A name whose glob matched nothing is dropped here rather than reported as an
+    empty member set.
+    """
+    resolved = {}
+    for name, specs in _bundle_target_specs(text, lib):
+        members = _expand_bundle_specs(specs)
+        if members is not None:
+            resolved[name] = members
+    return resolved
+
+
+@functools.lru_cache(maxsize=_IMAGE_PARSE_CACHE_SIZE)
+def _bundle_target_specs(text, lib):
+    """Parse bundle membership once per source, as unexpanded member specs.
+
+    A name is dropped — leaving its pins with the pre-existing refusal — when the
+    build is unresolvable, when two builds target the same name, or when the name
+    is reassigned after being built: the map is read for every site in the source,
+    and an ambiguous name cannot answer per line.
+    """
+    path_vars = _extended_path_vars(text, lib)
+    arrays = _bundle_arrays(text, lib, path_vars)
+    bundles = {}
+    ambiguous = set()
+    for _, line in join_logical_lines(text):
+        stripped = line.lstrip()
+        # Tokenizing is the expensive step on a source this size, so it runs only
+        # for a line that could name a builder at all.
+        tokens = (
+            tokenize(stripped)
+            if stripped
+            and not stripped.startswith("#")
+            and any(builder in stripped for builder in BUNDLE_BUILDERS)
+            else None
+        )
+        if tokens and _token_value(tokens[0]) in BUNDLE_BUILDERS:
+            if len(tokens) < 3:
+                continue
+            name = _bundle_variable_name(_token_value(tokens[2]))
+            if name is None:
+                continue
+            if name in bundles or name in ambiguous or line[:1] in {" ", "\t"}:
+                # A second build of the same name, or one inside an unmodeled
+                # compound, leaves the name ambiguous.
+                ambiguous.add(name)
+                bundles.pop(name, None)
+                continue
+            specs = _bundle_call_members(tokens[3:], arrays, lib, path_vars)
+            if specs is None:
+                ambiguous.add(name)
+                continue
+            bundles[name] = specs
+            continue
+        assign = _ASSIGNMENT_RE.match(line)
+        if assign is None:
+            continue
+        name = assign.group(1)
+        alias = _bundle_variable_name(assign.group(2).strip())
+        if alias is not None and alias in bundles:
+            if name not in ambiguous:
+                bundles[name] = bundles[alias]
+            continue
+        if name in bundles:
+            ambiguous.add(name)
+            bundles.pop(name)
+    return tuple(bundles.items())
+
+
 def _markdown_excluded_line_indices(text):
     """0-based indices of Markdown lines inside a properly closed fenced block.
 
@@ -2835,10 +3228,26 @@ def _markdown_prose_literal_lineno(text, literal):
     return fallback
 
 
+def _site_inspection_targets(site, repo_root):
+    """The file(s) a site's boundary is inspected against, as absolute paths.
+
+    Either the one statically resolved target, or — for a concatenated bundle
+    target (issue #956) — the resolved member files, in build order. An empty
+    tuple means the target could not be established at all.
+    """
+    if site.target_path is not None:
+        target = Path(site.target_path)
+        if not target.is_absolute():
+            target = Path(repo_root) / target
+        return (target,)
+    return tuple(Path(member) for member in site.target_members or ())
+
+
 def _literal_prose_resolution(site, repo_root, target_loader=None):
     """Return ``(relative_target, 1-based line)`` where ``site.literal`` resolves
-    into prose of its statically resolved target, or ``None`` when it does not
-    (not prose, unreadable, absent, or an unresolved target/literal).
+    into prose of its statically resolved target — or of the first bundle member
+    that resolves it (issue #956) — and ``None`` when it does not (not prose,
+    unreadable, absent, or an unresolved target/literal).
 
     The conservative issue-810 prose boundary: a heading, a whitespace-bearing
     visible Markdown phrase, or hash-comment text is prose; a standalone
@@ -2848,23 +3257,31 @@ def _literal_prose_resolution(site, repo_root, target_loader=None):
     weighed exactly as a static-helper or raw-``grep`` one, so routing a prose
     pin through ``pin_count`` no longer skips the question.
     """
-    if site.literal is None or site.target_path is None:
+    if site.literal is None:
         return None
-    target = Path(site.target_path)
-    if not target.is_absolute():
-        target = Path(repo_root) / target
+    for target in _site_inspection_targets(site, repo_root):
+        resolution = _literal_prose_in_target(
+            target, site.literal, repo_root, target_loader
+        )
+        if resolution is not None:
+            return resolution
+    return None
+
+
+def _literal_prose_in_target(target, literal, repo_root, target_loader):
+    """The per-file half of ``_literal_prose_resolution``, applied to one file."""
     ext = target.suffix.lower()
     text, error = _read_typed_target(target, target_loader)
-    if error is not None or site.literal not in text:
+    if error is not None or literal not in text:
         return None
     if ext in COMMENT_MD_EXTS:
-        if not _markdown_literal_is_prose(text, site.literal):
+        if not _markdown_literal_is_prose(text, literal):
             return None
-        lineno = _markdown_prose_literal_lineno(text, site.literal)
+        lineno = _markdown_prose_literal_lineno(text, literal)
     elif ext in COMMENT_HASH_EXTS:
         lineno = None
         for candidate_lineno, comment in hash_comment_regions(text.splitlines()):
-            if site.literal in comment:
+            if literal in comment:
                 lineno = candidate_lineno
                 break
         if lineno is None:
@@ -2891,33 +3308,41 @@ def _read_typed_target(target, target_loader):
 
 
 def _typed_pin_inspection_error(site, repo_root, target_loader=None):
-    """Return why a typed declaration's target boundary cannot be inspected."""
+    """Return why a typed declaration's target boundary cannot be inspected.
+
+    A bundle target is inspected against its whole member SET (issue #956): every
+    member must be inside the repository and readable, and the literal must be
+    present in at least one of them — the same two questions the single-file case
+    asks, with membership standing in for the one file.
+    """
     if site.declaration is None or site.declaration_error is not None:
         return None
     if not site.literal:
         return "typed structural declaration literal cannot be inspected"
-    if site.target_path is None:
+    targets = _site_inspection_targets(site, repo_root)
+    if not targets:
         return "typed structural declaration target cannot be inspected"
-    target = Path(site.target_path)
-    if not target.is_absolute():
-        target = Path(repo_root) / target
-    try:
-        root_path = os.path.abspath(repo_root)
-        target_path = os.path.abspath(target)
-        if os.path.commonpath((root_path, target_path)) != root_path:
+    literal_present = False
+    for target in targets:
+        try:
+            root_path = os.path.abspath(repo_root)
+            target_path = os.path.abspath(target)
+            if os.path.commonpath((root_path, target_path)) != root_path:
+                return (
+                    "typed structural declaration target cannot be inspected "
+                    "(outside repository)"
+                )
+        except ValueError:
+            return "typed structural declaration target cannot be inspected"
+        target_text, error = _read_typed_target(target, target_loader)
+        if error is not None:
             return (
                 "typed structural declaration target cannot be inspected "
-                "(outside repository)"
+                f"({error})"
             )
-    except ValueError:
-        return "typed structural declaration target cannot be inspected"
-    target_text, error = _read_typed_target(target, target_loader)
-    if error is not None:
-        return (
-            "typed structural declaration target cannot be inspected "
-            f"({error})"
-        )
-    if site.literal not in target_text:
+        if site.literal in target_text:
+            literal_present = True
+    if not literal_present:
         return (
             "typed structural declaration literal cannot be inspected "
             "(absent from target)"
@@ -3080,6 +3505,8 @@ def _raw_guard_site(
     lineno,
     line_end,
     lines,
+    bundle_targets=None,
+    extended_path_vars=None,
 ):
     """Resolve one syntactically executable raw presence match."""
     target_token = match.group("target")
@@ -3094,6 +3521,13 @@ def _raw_guard_site(
     target = path_vars.get(var_name) if var_name else None
     if target is None:
         target = _resolve_inline_var_path(target_token, lib, path_vars)
+    if target is None and extended_path_vars:
+        # The same extended-expansion fallback the helper path takes (issue #956),
+        # applied before the scratch-name carve-out below so that carve-out keeps
+        # firing only for a path that is otherwise unresolvable.
+        target = extended_path_vars.get(var_name) if var_name else None
+        if target is None:
+            target = _resolve_inline_var_path(target_token, lib, extended_path_vars)
     if target is None and "$" not in target_token:
         target = (
             target_token
@@ -3118,6 +3552,11 @@ def _raw_guard_site(
         and re.match(r"^(?:TMP|TEMP)(?:_|$)", var_name)
     ):
         return None
+    members = None
+    if target is None and var_name and bundle_targets:
+        # A raw `grep -qF … "$CI_BUNDLE"` reads the same concatenated bundle a
+        # helper pin does, so it resolves through the same member map (issue #956).
+        members = bundle_targets.get(var_name)
     target_abs = os.path.abspath(target) if target is not None else None
     if target_abs is not None:
         try:
@@ -3149,6 +3588,7 @@ def _raw_guard_site(
         target_abs,
         declaration,
         error,
+        members,
     )
 
 
@@ -3198,6 +3638,8 @@ def extract_guard_sites(text, source_path, repo_root):
         if name in wrapper_origins
     }
     maps_by_line = variable_maps_by_line(text, lib, {})
+    bundle_targets = resolve_bundle_targets(text, lib)
+    extended_path_vars = _extended_path_vars(text, lib)
     physical = text.splitlines()
     sites = []
     for lineno, logical_line, toks in tokenized_lines:
@@ -3229,6 +3671,18 @@ def extract_guard_sites(text, source_path, repo_root):
             target = _resolve_guard_target(
                 args, spec, literal_vars, path_vars, lib
             )
+            members = None
+            if target is None:
+                target_variable = _guard_target_variable(args, spec)
+                if target_variable is not None:
+                    members = bundle_targets.get(target_variable)
+                if members is None:
+                    # Not a bundle: retry the single target under the extended
+                    # expansions, so a pin anchored on a module root written
+                    # ``${OVERRIDE:-${LIB%/lib}}`` is inspectable too (issue #956).
+                    target = _resolve_guard_target(
+                        args, spec, literal_vars, extended_path_vars, lib
+                    )
             declaration, error = parse_structural_declaration(lines)
             sites.append(
                 GuardSite(
@@ -3241,6 +3695,7 @@ def extract_guard_sites(text, source_path, repo_root):
                     target,
                     declaration,
                     error,
+                    members,
                 )
             )
             continue
@@ -3314,6 +3769,8 @@ def extract_guard_sites(text, source_path, repo_root):
                 lineno=lineno,
                 line_end=_line_end(lineno, logical_line),
                 lines=lines,
+                bundle_targets=bundle_targets,
+                extended_path_vars=extended_path_vars,
             )
             if site is not None:
                 sites.append(site)
@@ -3441,6 +3898,7 @@ def scan_changed_sources(
                     old_site.helper,
                     old_site.literal,
                     old_site.target_path,
+                    old_site.target_members,
                     old_site.declaration,
                     old_site.declaration_error,
                 )
@@ -3449,6 +3907,7 @@ def scan_changed_sources(
                     new_site.helper,
                     new_site.literal,
                     new_site.target_path,
+                    new_site.target_members,
                     new_site.declaration,
                     new_site.declaration_error,
                 )

--- a/lib/test/run.sh
+++ b/lib/test/run.sh
@@ -2785,16 +2785,20 @@ assert_pin_unique "#312 item 8: Phase 2.3.0b names a doc-enumerated configuratio
 # ---- #754: throwaway-scaffold reuse lines on the three verification/fix-iteration surfaces ----
 # Each asserts its sentence exists on its surface, and each carries the structural-pin-ok
 # declaration the issue #666 gate requires. Their declarations are deliberately NOT uniform:
-# A2 below states the cross-file contract its ledger row records, while A3/A11, A8 and A10 keep
-# the older pre-vocabulary `surface-presence` wording. That is not an oversight — the gate
-# refuses to let those three be corrected (their targets are unresolvable, or their literals sit
-# in a frozen retirement manifest so a touch counts as a revival needing its own
-# authorization), so their text is frozen until issue #956 lands. Do not "unify" them by hand:
-# editing one of the three turns the required gate RED with no valid form available.
+# A2 and A3/A11 state the contract their own ledger rows record, while A8 and A10 keep the older
+# pre-vocabulary `surface-presence` wording. That is not an oversight. A3/A11 became correctable
+# with issue #956, which resolved its concatenated $MAXI_BUNDLE target to the member files the
+# bundle is built from. The other two are blocked by a cause #956 does not reach and deliberately
+# left alone: both literals sit in a frozen retirement manifest, so touching either line counts as
+# a REVIVAL, which needs its own authorization bundle plus a same-branch boundary adjudication
+# change. (A10's $IMPL_SKILL_BUNDLE target is additionally unresolvable — it is assembled by
+# looping over a phase-stem list, a build shape bundle resolution leaves unresolved rather than
+# resolve to a subset of real membership — but the revival contract is the operative blocker.)
+# Do not "unify" those two by hand: editing either turns the required gate RED.
 assert_pin_unique "#754 A2: receiving-code-review carries the rig-reuse principle (repo-agnostic)" \
   'Where your workflow offers no persistent channel, this reuse holds only within a single uninterrupted iteration span' "$ST_RCV"  # structural-pin-ok: cross-file-phase-contract -- the vendored receiving-code-review body carries the rig-reuse principle its consumer relies on
 assert_pin_unique "#754 A3/A11: fixing.md names the two-arm rig-location channel" \
-  'the workpad `--note` when implement-driven (`$ISSUE_NUMBER` present), otherwise the run-scoped' "$MAXI_BUNDLE"  # structural-pin-ok: surface-presence pin (advisory sentence exists; no code regression guarded)
+  'the workpad `--note` when implement-driven (`$ISSUE_NUMBER` present), otherwise the run-scoped' "$MAXI_BUNDLE"  # structural-pin-ok: routing-dispatch-contract -- the ledger records the two-arm durable-record routing this sentence keys on the invocation context
 assert_pin_unique "#754 A8: receiving gates reuse on the current code shape" \
   'only after confirming it still exercises the current code shape' "$ST_RCV"  # structural-pin-ok: surface-presence pin (advisory sentence exists; no code regression guarded)
 assert_pin_unique "#754 A10: phase-2 keeps the rig under an already-ignored scratch path" \

--- a/lib/test/test_pin_corpus_lint.py
+++ b/lib/test/test_pin_corpus_lint.py
@@ -16,9 +16,13 @@ The linter and census modules these tests drive do carry process-global
 ``functools.lru_cache`` stores, so tests landing in the same process share them.
 That is compatible with the requirement above for two separate reasons, not one.
 The per-source parse memos are keyed on the presented bytes — the census memos
-additionally on the source's name, the linter memos on the text alone — and on no
-``repo_root`` and no filesystem state, so a hit returns a value derived from
-exactly the bytes the caller presented. ``_load_mutation_census_module`` is
+additionally on the source's name, the linter memos on the text alone (the two
+bundle-membership parses of issue #956 additionally on the ``lib`` path the caller
+passed) — and on no ``repo_root`` and no filesystem state, so a hit returns a value
+derived from exactly what the caller presented. The bundle resolver's glob
+EXPANSION is deliberately left outside its memo for that reason;
+``BundleTargetInspection956Tests`` pins that a tree change between two calls is
+observed rather than answered from the cache. ``_load_mutation_census_module`` is
 different: it takes no arguments at all and hands every caller one module
 object; it is safe because nothing in that module is mutated after import beyond
 those same key-pure memos, not because of its key. Its other module-level
@@ -4600,6 +4604,301 @@ class PinRoutingLadder948Tests(unittest.TestCase):
             self.assertEqual(1, len(findings))
             self.assertIn("resolves into prose", findings[0])
             self.assertNotIn("no program consumer reads it", findings[0])
+
+
+class BundleTargetInspection956Tests(unittest.TestCase):
+    """Issue #956: a pin whose target is a bundle the source CONCATENATES at
+    runtime is inspected against the bundle's MEMBER FILES.
+
+    Every test states which direction it protects. The positive cases prove the
+    unfreeze (a typed declaration on such a pin is now inspectable, so its line
+    can be edited at all); the negative controls prove the fix is resolution, not
+    amnesty — an unresolvable target, an unmodeled build shape, an unreadable
+    member, an ambiguous name and a literal in no member all keep the refusal.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mod = load_linter()
+
+    MARKER = (
+        "# structural-pin-ok: cross-file-phase-contract -- "
+        "the sentence spells a contract the split surfaces share"
+    )
+    LITERAL = "the fix loop re-reads the reference before it edits"
+    SKIPPED_LITERAL = "this template sentence is not part of the bundle"
+
+    # The module shape the repository really uses: a root variable written with a
+    # default expansion over a suffix strip, an array seeded with one member, a
+    # for-loop over a directory glob with a basename skip, and one builder call.
+    BUILD = (
+        'ROOT="${DEVFLOW_MODULE_ROOT:-${LIB%/lib}}"\n'
+        'SKILL="$ROOT/skills/demo/SKILL.md"\n'
+        'BUNDLE="$SCRATCH/demo-bundle.md"\n'
+        '_members=("$SKILL")\n'
+        'for _ref in "$ROOT"/skills/demo/references/*.md; do\n'
+        '  case "${_ref##*/}" in template.md) continue ;; esac\n'
+        '  _members+=("$_ref")\n'
+        "done\n"
+        'devflow_module_build_bundle "demo" "$BUNDLE" "${_members[@]}"\n'
+    )
+
+    def _tree(self, td, *, literal=None, in_reference=True):
+        """Write the demo skill tree; return its repository root."""
+        root = Path(td)
+        skill = root / "skills/demo/SKILL.md"
+        skill.parent.mkdir(parents=True, exist_ok=True)
+        references = skill.parent / "references"
+        references.mkdir(parents=True, exist_ok=True)
+        body = literal if literal is not None else self.LITERAL
+        skill.write_text("# Demo\n\nThe root carries no contract.\n", encoding="utf-8")
+        (references / "fixing.md").write_text(
+            f"# Fixing\n\nStep two: {body}.\n" if in_reference else "# Fixing\n\nnone\n",
+            encoding="utf-8",
+        )
+        # The excluded template member: never part of the bundle, so a literal
+        # living only here must NOT satisfy inspection.
+        (references / "template.md").write_text(
+            f"# Template\n\n{self.SKIPPED_LITERAL}.\n", encoding="utf-8"
+        )
+        return root
+
+    def _sites(self, root, source, path="lib/test/mod.sh"):
+        return self.mod.extract_guard_sites(source, path, str(root))
+
+    def _pin(self, literal=None, target="$BUNDLE", marker=None):
+        marker = self.MARKER if marker is None else marker
+        return (
+            'devflow_module_pin_unique "demo contract" '
+            f"'{literal or self.LITERAL}' \"{target}\""
+            + (f"  {marker}" if marker else "")
+            + "\n"
+        )
+
+    def _site(self, root, source):
+        sites = [site for site in self._sites(root, source) if site.helper]
+        self.assertEqual(1, len(sites), sites)
+        return sites[0]
+
+    # ── the unfreeze ───────────────────────────────────────────────────────
+    def test_bundle_target_resolves_to_its_member_files(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = self._tree(td)
+            members = self.mod.resolve_bundle_targets(
+                self.BUILD, str(root / "lib")
+            )["BUNDLE"]
+            self.assertEqual(
+                [
+                    str(root / "skills/demo/SKILL.md"),
+                    str(root / "skills/demo/references/fixing.md"),
+                ],
+                list(members),
+                "the basename skip must EXCLUDE template.md, not merely resolve",
+            )
+
+    def test_typed_declaration_on_a_bundle_target_is_inspectable(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = self._tree(td)
+            site = self._site(root, self.BUILD + self._pin())
+            self.assertIsNone(site.target_path)
+            self.assertEqual(2, len(site.target_members))
+            self.assertIsNone(self.mod._typed_pin_inspection_error(site, str(root)))
+
+    def test_an_alias_of_a_resolved_bundle_is_inspectable_too(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = self._tree(td)
+            source = self.BUILD + 'ALIAS="$BUNDLE"\n' + self._pin(target="$ALIAS")
+            site = self._site(root, source)
+            self.assertIsNone(self.mod._typed_pin_inspection_error(site, str(root)))
+
+    def test_a_raw_grep_over_the_same_bundle_is_inspected_the_same_way(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = self._tree(td)
+            source = self.BUILD + (
+                'assert_eq "demo raw" "yes" '
+                f"\"$(grep -qF '{self.LITERAL}' \"$BUNDLE\" && echo yes || echo no)\""
+                f"  {self.MARKER}\n"
+            )
+            sites = [
+                site
+                for site in self._sites(root, source)
+                if site.family == "raw-presence"
+            ]
+            self.assertEqual(1, len(sites), sites)
+            self.assertIsNone(
+                self.mod._typed_pin_inspection_error(sites[0], str(root))
+            )
+
+    # ── the memo contract this resolver has to keep ─────────────────────────
+    def test_membership_is_not_answered_from_a_memo_after_the_tree_changes(self):
+        # The parse is memoized; the glob expansion must NOT be, or the memo would
+        # capture filesystem state and a co-resident sharded test could be answered
+        # from another fixture's tree (this file's module docstring forbids that).
+        with tempfile.TemporaryDirectory() as td:
+            root = self._tree(td)
+            lib = str(root / "lib")
+            self.assertEqual(
+                2, len(self.mod.resolve_bundle_targets(self.BUILD, lib)["BUNDLE"])
+            )
+            (root / "skills/demo/references/later.md").write_text(
+                "# Later\n\nadded after the first resolution\n", encoding="utf-8"
+            )
+            self.assertEqual(
+                3,
+                len(self.mod.resolve_bundle_targets(self.BUILD, lib)["BUNDLE"]),
+                "the expansion must be re-read, not served from the parse memo",
+            )
+
+    def test_each_caller_gets_its_own_mapping(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = self._tree(td)
+            lib = str(root / "lib")
+            first = self.mod.resolve_bundle_targets(self.BUILD, lib)
+            first["LEAKED_BUNDLE"] = ()
+            self.assertNotIn(
+                "LEAKED_BUNDLE", self.mod.resolve_bundle_targets(self.BUILD, lib)
+            )
+
+    # ── negative controls: the refusal still fires ──────────────────────────
+    def test_an_unresolvable_non_bundle_target_still_cannot_be_inspected(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = self._tree(td)
+            source = self._pin(target="$SOME_RUNTIME_TEMP")
+            site = self._site(root, source)
+            self.assertEqual(
+                "typed structural declaration target cannot be inspected",
+                self.mod._typed_pin_inspection_error(site, str(root)),
+            )
+
+    def test_a_literal_in_no_member_is_still_reported_absent(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = self._tree(td, in_reference=False)
+            site = self._site(root, self.BUILD + self._pin())
+            self.assertEqual(
+                "typed structural declaration literal cannot be inspected "
+                "(absent from target)",
+                self.mod._typed_pin_inspection_error(site, str(root)),
+            )
+
+    def test_a_literal_only_in_the_skipped_member_is_reported_absent(self):
+        # The sharp form of the exclusion test: membership is exact, so content
+        # the build skips can never satisfy a bundle pin.
+        with tempfile.TemporaryDirectory() as td:
+            root = self._tree(td)
+            site = self._site(
+                root, self.BUILD + self._pin(literal=self.SKIPPED_LITERAL)
+            )
+            self.assertEqual(
+                "typed structural declaration literal cannot be inspected "
+                "(absent from target)",
+                self.mod._typed_pin_inspection_error(site, str(root)),
+            )
+
+    def test_an_unreadable_member_fails_closed(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = self._tree(td)
+            build = self.BUILD.replace(
+                'devflow_module_build_bundle "demo" "$BUNDLE" "${_members[@]}"',
+                'devflow_module_build_bundle "demo" "$BUNDLE" "${_members[@]}" '
+                '"$ROOT/skills/demo/absent.md"',
+            )
+            site = self._site(root, build + self._pin())
+            self.assertEqual(
+                "typed structural declaration target cannot be inspected "
+                "(FileNotFoundError)",
+                self.mod._typed_pin_inspection_error(site, str(root)),
+            )
+
+    def test_an_unresolvable_member_word_leaves_the_bundle_unresolved(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = self._tree(td)
+            build = self.BUILD.replace(
+                '_members=("$SKILL")', '_members=("$SKILL" "$UNKNOWN_VAR")'
+            )
+            site = self._site(root, build + self._pin())
+            self.assertEqual(
+                "typed structural declaration target cannot be inspected",
+                self.mod._typed_pin_inspection_error(site, str(root)),
+            )
+
+    def test_an_unmodeled_loop_append_leaves_the_bundle_unresolved(self):
+        # run.sh also builds bundles by looping over a STEM list and appending an
+        # interpolated path. Resolving that array to "the words modeled so far"
+        # would yield a strict SUBSET of the real membership and could report a
+        # present literal as absent, so the shape must poison the bundle instead.
+        with tempfile.TemporaryDirectory() as td:
+            root = self._tree(td)
+            build = (
+                'ROOT="${DEVFLOW_MODULE_ROOT:-${LIB%/lib}}"\n'
+                'SKILL="$ROOT/skills/demo/SKILL.md"\n'
+                'STEMS="fixing"\n'
+                '_members=("$SKILL")\n'
+                "for _s in $STEMS; do\n"
+                '  _members+=("$ROOT/skills/demo/references/${_s}.md")\n'
+                "done\n"
+                'devflow_module_build_bundle "demo" "$BUNDLE" "${_members[@]}"\n'
+            )
+            site = self._site(root, build + self._pin())
+            self.assertEqual(
+                "typed structural declaration target cannot be inspected",
+                self.mod._typed_pin_inspection_error(site, str(root)),
+            )
+
+    def test_two_builds_of_one_name_leave_it_ambiguous(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = self._tree(td)
+            build = self.BUILD + (
+                'devflow_module_build_bundle "demo again" "$BUNDLE" "$SKILL"\n'
+            )
+            site = self._site(root, build + self._pin())
+            self.assertEqual(
+                "typed structural declaration target cannot be inspected",
+                self.mod._typed_pin_inspection_error(site, str(root)),
+            )
+
+    def test_an_empty_glob_expansion_is_not_treated_as_inspected(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = self._tree(td)
+            for reference in (root / "skills/demo/references").iterdir():
+                reference.unlink()
+            site = self._site(root, self.BUILD + self._pin())
+            self.assertEqual(
+                "typed structural declaration target cannot be inspected",
+                self.mod._typed_pin_inspection_error(site, str(root)),
+            )
+
+    # ── the ladder still decides, and the tag still cannot self-grant ───────
+    def test_bundle_member_prose_still_requires_a_ledger_boundary_row(self):
+        source = self.BUILD + self._pin()
+        with tempfile.TemporaryDirectory() as td:
+            root = self._tree(td)
+            key = self.mod._literal_adjudication_key(self.LITERAL)
+
+            def scan(**kwargs):
+                return self.mod.scan_changed_sources(
+                    {"lib/test/mod.sh": source},
+                    {"lib/test/mod.sh": ""},
+                    one_file_diff("lib/test/mod.sh", "", source),
+                    repo_root=str(root),
+                    **kwargs,
+                )
+
+            unrouted = scan()
+            self.assertEqual(1, len(unrouted))
+            self.assertIn(
+                "literal resolves into prose at skills/demo/references/fixing.md",
+                unrouted[0],
+                "prose resolution must follow the members, so the tag alone "
+                "cannot self-grant a bundle pin",
+            )
+            self.assertEqual(
+                [],
+                scan(
+                    current_adjudications={
+                        key: ("boundary", "maintainer adjudication: demo boundary")
+                    }
+                ),
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #956.

## The problem

A content-survival pin targets a bundle its test source **concatenates at runtime** from several repository files (`$CI_BUNDLE`, `$MAXI_BUNDLE`): the contract sentence must survive somewhere in a split skill, and which member holds it is an implementation detail the pin deliberately does not fix. That target is a scratch path no static resolution reached, so `_typed_pin_inspection_error` reported

```
typed structural declaration target cannot be inspected
```

for any *declared* pin on one. Because a site is classified whenever its lines land in the diff's added set, the whole logical line — declaration text included — was permanently uneditable. The pin's own assertion was always fine; only the declaration path was blocked.

## Which approach, and why not the others

**Approach 1 — resolve the bundle to its constituent files.** `pin-corpus-lint.py` now resolves a bundle variable back to the member files its own builder call (`_build_skill_bundle` / `devflow_module_build_bundle`) concatenates, and inspects the declaration against that **member set**: every member must be inside the repository and readable, and the literal must be present in at least one. That is the same pair of questions the single-file case asks, with membership standing in for the one file — the check is *resolved*, not relaxed.

Why not the other two:

- **Approach 2 (record the unresolvable target as a non-blocking limitation)** would make the tag self-granting for exactly the pins that cannot be inspected. Anything unresolvable would then pass, so the #948 ladder's step-2 rule — a tag *points at* an authorized ledger row, never grants itself — would be unenforceable precisely where verification is impossible. It also fails in the wrong direction on a real defect: a declaration whose literal is genuinely absent from its target would read as a recorded limitation instead of a finding.
- **Approach 3 (retarget each pin at one constituent file)** changes what each pin asserts. These pins exist *because* the sentence may move between the root and a reference (#529/#614); pinning one member goes RED on a legal re-partition, and it would have to be re-decided per pin, forever.

Reusing existing machinery was the tiebreaker, as #956 suspected: membership resolution is built on the module's own `tokenize` / `resolve_arg` / `join_logical_lines` / `_resolve_path_rhs`, and the classifier's `recover_override_names` — which already treats these names as runtime bundle targets — is what confirmed the *variable name* is the durable handle when the path is not.

## What the resolution accepts, and what it still refuses

Membership comes only from a **closed grammar**: a builder call, an array built from literal words and/or one `for` loop over a path glob with an optional `case "${ref##*/}" in …) continue` basename skip, plus whole-variable aliases of a resolved bundle. Two parameter expansions a module's root variable uses (`${VAR:-fallback}`, `${LIB%/lib}`) are resolved *locally* to this path rather than in the shared resolver, so the corpus-wide target resolution the meta-guards read is untouched.

Everything outside the grammar keeps the pre-existing refusal:

| still refused | why it must be |
|---|---|
| an unresolvable target that is not a bundle at all | the negative control below |
| a member word that does not resolve | a partially resolved bundle is not a bundle |
| an **unmodeled loop append** (run.sh also loops over a *stem list*, appending an interpolated path) | resolving that array to "the words modeled so far" yields a strict **subset** of real membership and could call a present literal absent |
| an indented build or append (inside a function, `if`, or `while read`) | reachability is not modeled, so it is not an unconditional member |
| two builds of one name, or a reassignment after a build | one map answers every site in the source; an ambiguous name cannot answer per line |
| an empty glob expansion | an empty member set must never read as inspected |
| an unreadable member | fail closed, naming the read error |
| a literal present in no member | still `literal cannot be inspected (absent from target)` |

The basename skip is **modeled**, not ignored, so membership is exact rather than a superset — content the build skips can never satisfy a bundle pin.

**Prose resolution follows the same member set.** Without that, a newly inspectable bundle pin would pass on its tag alone, which is the self-grant #948 designed step 2 to prevent. With it, such a pin still needs an authorized `boundary` row.

**Blast radius on other branches: none.** A site whose declaration is missing or ungrammatical is decided before inspection and is unaffected; a site with a *valid* declaration previously produced exactly one finding (the refusal) and now produces zero or one. So resolving a target can only remove the refusal finding, never introduce a new one on an in-flight PR — and the newly reachable ladder arms are the same ones every single-file-target pin has always faced.

## How many unfroze: 12

All 11 sites #956 measured, plus the one extra the same resolution reaches (below). Each declaration now carries a legal category authored from **that site's own recorded ledger rationale** — every one is an existing `boundary` row. **No ledger row, no census row and no `.devflow/logs/**` file changes here.**

Gate over the branch:

```
$ python3 lib/test/pin-corpus-lint.py mutation-routing-worktree "$(git rev-parse --show-toplevel)"
$ echo $?
0
```

It prints **nothing** — 0 bytes of stdout — and exits **rc 0**.

Proof the twelve were in the diff's **added set** rather than merely untouched (the gate's own extraction, over `git diff --unified=0 <merge-base>`):

```
== lib/test/modules/create-issue-contract.sh: 11 changed pin sites
   450  decl=generated-artifact-identity  decl_err=None  members=10  inspection=None
   452  decl=routing-dispatch-contract    decl_err=None  members=10  inspection=None
   454  decl=routing-dispatch-contract    decl_err=None  members=10  inspection=None
   456  decl=lifecycle-state-transition   decl_err=None  members=10  inspection=None
   462  decl=cross-file-phase-contract    decl_err=None  members=10  inspection=None
   464  decl=machine-sentinel-provenance  decl_err=None  members=0   inspection=None
   543  decl=helper-contract              decl_err=None  members=10  inspection=None
   545  decl=helper-contract              decl_err=None  members=10  inspection=None
   547  decl=helper-contract              decl_err=None  members=10  inspection=None
   562  decl=helper-contract              decl_err=None  members=10  inspection=None
  1380  decl=helper-contract              decl_err=None  members=0   inspection=None
== lib/test/run.sh: 1 changed pin sites
  2794  decl=routing-dispatch-contract    decl_err=None  members=9   inspection=None
```

`members=10` / `members=9` are the resolved bundles — create-issue: root + 9 references with the two template files correctly excluded; review-and-fix: root + 8 references — matching the counts each source asserts next to its own build.

**Two of the twelve had a cause #956 described differently, and it matters for the choice of fix.** `:464`'s target is an inline `$CI_ROOT/…` path and `:1380`'s (`$CI_DV`) is a single skill surface — neither is a bundle. Both were unresolvable for the *other* reason in the same family: the module reaches its repository root through `${DEVFLOW_…:-${LIB%/lib}}`, which the shared resolver does not model. `:1380` is the site #948 itself recorded — the one shipping a "READ THIS BEFORE TOUCHING" paragraph saying its declaration *cannot* be corrected and is "frozen until the target becomes inspectable". That paragraph is now replaced by one recording the history, and the declaration states the boundary its ledger row records.

Scanning the whole audited population with a legal category simulated on every tagged site, the sites that still cannot be corrected are down to **three**, every one of them a class #956 puts out of scope: `create-issue-contract.sh`'s `$1`-positional wrapper (unresolvable literal, no census row, so ladder step 2 has nothing to point at) and the two `#754` retirement-manifest literals in `run.sh` (a revival needing its own authorization bundle).

## The negative control

`test_an_unresolvable_non_bundle_target_still_cannot_be_inspected` asserts the **exact** pre-existing message for a declared pin on a plain unresolved variable, so "inspection never fails" cannot pass as the fix. It is one of eight negative controls in `BundleTargetInspection956Tests`, each pinning one row of the table above. The sharpest three:

- the **unmodeled-loop-append** case — the subset hazard, which would otherwise report a present literal as absent;
- the **skipped-member** case — a literal living only in an excluded template is still reported absent, so the exclusion is exact and not decorative;
- the **ladder** case — bundle-member prose with a valid tag but no ledger row is still a finding, and passes only once the row exists.

Two further tests pin the memo contract: the parse is memoized on the presented bytes, the glob **expansion deliberately is not**, so no memo in this module captures filesystem state — the property `test_pin_corpus_lint.py`'s sharding docstring states. That docstring and its mirror comment in `harness-python-guards.sh` are updated in the same commit, since the two new memos add the caller's `lib` path to their key. `CONTRIBUTING.md`'s statement that a concatenated bundle target is "still unfixable" is corrected in the same commit too.

## Not fixed, with reasons

- **Bundles built from a stem list** (`$IMPL_SKILL_BUNDLE`, `$REVIEW_BUNDLE`, `$DEF_SKILL`) stay unresolved. Their loops append an interpolated path rather than the loop variable; modeling that shape is a separate increment, and I took the fail-closed direction over a subset resolution that could misreport. Pins on those targets are no worse off than before, and a test pins that this shape resolves to *nothing* rather than to a subset.
- The two out-of-scope classes from #956 — retired literals needing a revival authorization, and sites with no census row — are untouched.
- `run.sh`'s remaining two `#754` sibling pins (A8, A10) keep the pre-vocabulary category. Rebased onto #955, its `#754` block header said the three non-A2 pins were frozen "until issue #956 lands" because "their targets are unresolvable, **or** their literals sit in a frozen retirement manifest". Measured on this tree, A3/A11 was the only one #956 unblocks, and **both** survivors are retirement-manifest cases — a revival needing its own authorization bundle, which this PR must not grant. A10's `$IMPL_SKILL_BUNDLE` target is *additionally* unresolvable (stem-list build), but that is not the operative blocker; the header now says so rather than leaving the disjunction for the next reader to re-measure.

## Verification

- `python3 lib/test/pin-corpus-lint.py mutation-routing-worktree <root>` → **rc 0, empty stdout**, all 12 sites in the diff's added set
- `python3 lib/test/test_pin_corpus_lint.py` → **OK**, 170 tests (+15 new in `BundleTargetInspection956Tests`)
- `python3 lib/test/test_pin_corpus_classifier.py` → **OK**, 17 tests
- `python3 lib/test/coverage_map_guard.py .` → rc 0
- `python3 lib/test/lint-tree-enumeration.py --root .` → rc 0 (the one glob carries a `# tree-walk-ok:` declaration: a closed non-recursive builder-call pattern mirroring the shell glob that assembles the bundle)
- `lib/test/run-module.sh create-issue-contract` → **215 passed, 0 failed**
- `shellcheck --severity=warning -e SC1091 --extended-analysis=false lib/test/run.sh` → clean (ShellCheck 0.11.0); both touched modules clean; `bash -n` clean
- `git ls-files '*.py' | xargs -r ruff check` → All checks passed
- Full desk suite → **`14092 passed, 0 failed`** on this exact tree (log complete: its own summary is the final line, **no skip clause**, zero `FAIL` and zero `NOTE` lines)
- CI on this branch (run 30544555639) → all six checks pass, including the required **`lib + python tests`**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
