### PR TITLE
fix(config): allow the renamed prflow-implementer[bot] to trigger DevFlow

### DIFF
--- a/.devflow/config.json
+++ b/.devflow/config.json
@@ -4,7 +4,7 @@
   "claude_model": "claude-opus-4-8",
   "devflow_version": "main",
   "devflow": {
-    "allowed_bots": "claude,dependabot,devflow-autopilot,prflow",
+    "allowed_bots": "claude,dependabot,devflow-autopilot,prflow,prflow-implementer",
     "allowed_users": "*",
     "workpad_marker": "<!-- devflow:workpad -->",
     "effort": "low",


### PR DESCRIPTION
## What

One line in `.devflow/config.json`:

```
devflow.allowed_bots
  before: claude,dependabot,devflow-autopilot,prflow
  after:  claude,dependabot,devflow-autopilot,prflow,prflow-implementer
```

Added alongside the existing entries. Nothing is removed.

## Why

PR #973 pre-emptively added `prflow` in anticipation of the App rename. The intended slug was **taken**, so the App actually resolved to the slug **`prflow-implementer`**, and its bot login is therefore **`prflow-implementer[bot]`**.

Confirmed against the API before editing:

```
GET /apps/prflow-implementer  -> slug=prflow-implementer, id=3102164, name="PRFlow (Implementer)"
GET /apps/prflow              -> 404
GET /apps/devflow-autopilot   -> 404
```

Same `app_id 3102164` as before, so this is the same App under a new slug.

`scripts/authorize-actor.sh` computes `actor_bare="${actor%\[bot\]}"` and matches each trimmed `allowed_bots` entry against **both** the raw actor and that bare form, so the entry `prflow-implementer` matches the actor `prflow-implementer[bot]`. A non-match is a **quiet decline** — no error, no log line — so today the App's triggers are being silently declined.

## Post-merge-only

`devflow.allowed_bots` is read by the trigger-time `config` job, which checks out the **default branch** (the grant-timing bootstrap, issue #593). This fix does nothing until it is on `main`; until then the App's triggers keep being declined.

## `prflow` is now inert

The `prflow` entry matches no actor and can be dropped later. It is deliberately left in place here — removing it is a separate tidy-up, not worth widening a one-line fix under time pressure.

## Verification

- No test pins this repo's live `.devflow/config.json` `allowed_bots` value — every `allowed_bots` assertion in the suite runs against purpose-built fixtures with their own literals. Re-verified for this change, not inherited from the prior pass.
- `allowed_bots` is typed `"string"` in `.devflow/config.schema.json` with no `enum`/`pattern`, so nothing validates the value; the API check above is the verification.
- No changeset: `.devflow/config.json` is this repo's own live config, not engine surface (`skills/`, `agents/`, `lib/`, `scripts/`, workflows, config schema). `config.example.json` and `config.schema.json` are unchanged. Matches the disposition of the identical PR #973.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
