### PR TITLE
fix(init): /prflow:init corrects a superseded App slug in devflow.allowed_bots

### DIFF
--- a/.changeset/init-corrects-stale-allowed-bots.md
+++ b/.changeset/init-corrects-stale-allowed-bots.md
@@ -1,0 +1,23 @@
+---
+bump: patch
+---
+
+### Fixed
+
+- **`/prflow:init` now corrects a superseded App slug left in `devflow.allowed_bots`, and
+  `install.sh` reports one it finds.** The PR-authoring GitHub App was renamed
+  `devflow-autopilot` → `prflow-implementer` (the app id behind `DEVFLOW_APP_ID` is
+  unchanged). Actor authorization compares bot logins for equality, so a consumer whose
+  config still names the old slug carries an entry that authorizes nothing — and the
+  failure is silent one run later: the implement and review stall-backstops post their
+  resume comment successfully and finish green, then the gate that comment re-enters
+  declines the App as an unknown actor, so the run never resumes. The config scaffolder is
+  add-only and can backfill a key but never rewrite a value, so an upgrade could not fix
+  this on its own. `/prflow:init` now reads an existing `.devflow/config.json`, renames the
+  stale entry (or drops it when the current login is already listed), preserves every other
+  value, reports exactly what it changed for review before committing, and is a no-op on a
+  config that is already correct; an unreadable, non-JSON, or wrong-shaped config leaves the
+  file untouched with a one-line breadcrumb and never stops the run. `install.sh` carries
+  the detection half only — it emits a `NOTICE` naming the entry and its replacement and
+  routes to `/prflow:init`, never rewriting `.devflow/config.json` for this, the same
+  detect-and-route split it already uses for `.claude/settings.json`.

--- a/docs/install.md
+++ b/docs/install.md
@@ -255,6 +255,19 @@ To finish healing an artifact you never edited, do either of these and re-run �
 
 Merge a sidecar by hand instead and the result still differs from the shipped bytes, so it stays `unverified` and is offered again next run — that is the same deliberate rule as an edit made *with* a manifest: the installer never adopts your bytes as its own provenance. Note also that a healing run does not tidy up: the old `<path>.devflow-new` is left where it is, so delete it yourself once you are done with it. Nothing is at risk either way — what a missing manifest costs you is sidecars to resolve, never overwritten bytes.
 
+#### Upgrade note: a superseded App slug in `devflow.allowed_bots` is reported, and `/prflow:init` corrects it
+
+The GitHub App that authors PRFlow's PRs was renamed `devflow-autopilot` → `prflow-implementer` (the app id you set as `DEVFLOW_APP_ID` is unchanged). Actor authorization compares bot logins for **equality**, so if you added the old slug to `devflow.allowed_bots` it now authorizes nothing — and the failure is silent, one run later: the implement and review stall-backstops post their resume comment successfully and finish green, then the gate that comment re-enters declines the App as an unknown actor, so the run never resumes.
+
+The config scaffolder is add-only — it backfills newly-added keys and never rewrites a value — so an upgrade cannot fix this on its own. `install.sh` therefore **reports** it and routes you to the one place that owns the correction:
+
+```
+devflow-install: NOTICE: .devflow/config.json still names superseded PRFlow identifiers
+(devflow.allowed_bots[devflow-autopilot -> prflow-implementer]). …
+```
+
+Run `/prflow:init`. It corrects the entry in place, preserves every other value, tells you exactly what it changed so you can review the diff before committing, and is a no-op on a config that is already correct. The installer never rewrites `.devflow/config.json` for this — same detect-and-route split it uses for `.claude/settings.json`.
+
 #### Upgrade note: the withheld automatic-review tier is surfaced, and removable on request
 
 If your repository installed the automatic pull-request-triggered review tier before it was withheld (issue #936), you still have `.github/workflows/devflow-review.yml`, `devflow-runner.yml` and `telemetry-push.yml`, they still run, and they keep you exposed to issues [#930](https://github.com/The01Geek/prflow/issues/930) and [#920](https://github.com/The01Geek/prflow/issues/920). Every upgrade now says so. Nothing is deleted unless you ask:

--- a/install.sh
+++ b/install.sh
@@ -901,6 +901,79 @@ devflow_report_superseded_identifiers() {
   log "NOTICE: .claude/settings.json still registers superseded DevFlow identifiers ($hits). This installer never writes that file — run /devflow:init, whose scripts/provision-local-settings.sh removes the superseded registrations and adds the current one."
 }
 
+# The same detect-and-route split, applied to `.devflow/config.json`. The GitHub App that
+# authors PRFlow's PRs was renamed `devflow-autopilot` -> `prflow-implementer` (the app id
+# behind DEVFLOW_APP_ID is unchanged), so a consumer who added the old slug to
+# `devflow.allowed_bots` now carries an entry that matches no live identity:
+# scripts/authorize-actor.sh compares logins for EQUALITY, so the stale slug authorizes
+# nothing and the implement/review stall-backstop resume comment is declined by the very
+# gate it re-enters — a green run that never resumes.
+#
+# NOT part of the generated plugin-identity region above, deliberately: that region is
+# compiled from lib/plugin-identity.json, which models plugin/marketplace identity. An App
+# slug is a different identity with a different lifecycle, so it is a plain assignment here
+# rather than a widening of a generated, sha-stamped region.
+#
+# The scaffolder is add-only and cannot rename a VALUE, and this installer does not write
+# the file for this purpose: `/devflow:init` owns the correction, so the installer DETECTS
+# and REPORTS and routes there, exactly as it does for .claude/settings.json above.
+#
+# Format: whitespace-separated `stale=current` pairs.
+DEVFLOW_STALE_BOT_LOGINS='devflow-autopilot=prflow-implementer'
+# Best-effort over a file a human hand-edits: EVERY unexpected shape (unreadable, not JSON,
+# a non-object root, `devflow` or `allowed_bots` of the wrong type, a valid-falsy empty
+# string) leaves stdout empty and exits 0, so the caller reports nothing and the install
+# proceeds. It never writes.
+DEVFLOW_CONFIG_SCAN_PY='
+import json, sys
+path = sys.argv[1]
+pairs = [p.split("=", 1) for p in sys.argv[2].split() if "=" in p]
+try:
+    with open(path, encoding="utf-8") as fh:
+        data = json.load(fh)
+except Exception:
+    sys.exit(0)
+if not isinstance(data, dict):
+    sys.exit(0)
+section = data.get("devflow")
+if not isinstance(section, dict):
+    sys.exit(0)
+raw = section.get("allowed_bots")
+# A bool is an int, not a str, so `false` lands here and exits silently like any other
+# wrong type; an explicit "" is a str and simply yields no entries.
+if not isinstance(raw, str):
+    sys.exit(0)
+entries = []
+for e in raw.split(","):
+    e = e.strip()
+    if e.endswith("[bot]"):
+        e = e[: -len("[bot]")]
+    if e:
+        entries.append(e)
+hits = []
+for stale, current in pairs:
+    if stale in entries:
+        hits.append("devflow.allowed_bots[" + stale + " -> " + current + "]")
+if hits:
+    sys.stdout.write(", ".join(hits))
+'
+devflow_report_stale_config_identifiers() {
+  local hits
+  # Same short-circuit shape as the settings report: with no pair declared there is nothing
+  # to find, so no python3 is spent. Re-read the assignment above before asserting which way
+  # this falls.
+  [ -n "$DEVFLOW_STALE_BOT_LOGINS" ] || return 0
+  [ -f .devflow/config.json ] || return 0
+  devflow_resolve_python || {
+    log "warning: no working python3 — could not check .devflow/config.json for superseded PRFlow identifiers; run /devflow:init to correct them."
+    return 0
+  }
+  hits="$("$DEVFLOW_PY" -c "$DEVFLOW_CONFIG_SCAN_PY" .devflow/config.json \
+      "$DEVFLOW_STALE_BOT_LOGINS" 2>/dev/null || printf '')"
+  [ -n "$hits" ] || return 0
+  log "NOTICE: .devflow/config.json still names superseded PRFlow identifiers ($hits). This installer never rewrites that file for this — run /devflow:init, which corrects them in place, preserves your other values, and reports the diff to review before you commit."
+}
+
 # ── The dry-run preview ─────────────────────────────────────────────────────
 # The preview is not a second implementation of the plan: it runs the REAL apply
 # function against a sandbox copy of the consumer's own tree and then diffs the
@@ -1151,6 +1224,11 @@ JSON
   # 8. Report (never rewrite) a consumer settings file still carrying a superseded
   #    plugin/marketplace identifier.
   devflow_report_superseded_identifiers
+
+  # 9. Same detect-and-route split for .devflow/config.json: report (never rewrite) a
+  #    superseded identifier the add-only scaffolder above cannot correct, and route the
+  #    consumer to /devflow:init, which owns that correction.
+  devflow_report_stale_config_identifiers
 )
 
 # When sourced by the test harness (DEVFLOW_SELFTEST=1), define the functions

--- a/lib/test/modules/installer-wiring.sh
+++ b/lib/test/modules/installer-wiring.sh
@@ -1136,6 +1136,128 @@ assert_eq "installer-upgrade identity: the shipped installer declares a non-empt
 
 rm -rf "$IU_P11"
 
+# ── Scenario 11c: the SAME detect-and-route split, applied to .devflow/config.json.
+# The PR-authoring App was renamed, and the config scaffolder is add-only — it can backfill
+# a key but never rename a VALUE — so a consumer's `devflow.allowed_bots` keeps naming an
+# App slug that authorizes nothing. The installer must REPORT that and route to
+# /devflow:init, and must not write the file itself.
+#
+# Driven end to end over a real fixture consumer first (the routing + the never-writes
+# invariant can only be established by an actual before/after), then at the FUNCTION level
+# for the adversarial shape matrix: this is a best-effort parser over a file a human
+# hand-edits, and a full installer run per row would obscure which shape produced which
+# answer.
+IU_C11C="$(_iu_consumer stale-config)"
+_iu_run "$IU_C11C" >/dev/null                     # scaffold a config the normal way
+python3 -c '
+import json, sys
+p = sys.argv[1] + "/.devflow/config.json"
+d = json.load(open(p))
+d.setdefault("devflow", {})["allowed_bots"] = "claude,devflow-autopilot,dependabot"
+json.dump(d, open(p, "w"), indent=2)
+' "$IU_C11C"
+_iu_allowed_bots() {  # $1 = consumer root -> the devflow.allowed_bots value, or RC
+  python3 -c '
+import json, sys
+try:
+    d = json.load(open(sys.argv[1] + "/.devflow/config.json"))
+    print(d["devflow"]["allowed_bots"])
+except Exception:
+    print("RC")
+' "$1"
+}
+IU_CFG11C_BEFORE="$(_iu_allowed_bots "$IU_C11C")"
+IU_O11C="$(_iu_run "$IU_C11C" --apply)"
+# The unchanged-ness asserted is the VALUE the notice is about, not the whole file: an
+# --apply upgrade legitimately re-stamps devflow_version (step 6) on the same file, so a
+# whole-file digest would assert something the installer never promised and would go green
+# for the wrong reason if it stopped re-stamping.
+assert_eq "installer-upgrade stale-config: a superseded App slug in devflow.allowed_bots is REPORTED, names the replacement, and the value itself is left untouched" "yes yes claude,devflow-autopilot,dependabot" \
+  "$(_iu_out_has "$IU_O11C" 'still names superseded PRFlow identifiers') $(_iu_out_has "$IU_O11C" 'devflow.allowed_bots[devflow-autopilot -> prflow-implementer]') $(_iu_allowed_bots "$IU_C11C")"
+assert_eq "installer-upgrade stale-config: the fixture really did carry the stale slug before the run (the invariant above is not comparing two absent values)" "claude,devflow-autopilot,dependabot" \
+  "$IU_CFG11C_BEFORE"
+assert_eq "installer-upgrade stale-config: the report routes to the ONE owner of the correction rather than growing a second copy of it" "yes" \
+  "$(_iu_out_has "$IU_O11C" 'run /devflow:init, which corrects them in place')"
+# MISS arm over its own consumer: the scaffolded default names no superseded slug, so the
+# report stays silent. Reusing the consumer above would make this vacuous.
+IU_C11D="$(_iu_consumer clean-config)"
+IU_O11D="$(_iu_run "$IU_C11D" --apply)"
+assert_eq "installer-upgrade stale-config: a config naming no superseded identifier is reported silently (the notice is an intersection, not a declared-set existence check)" "no" \
+  "$(_iu_out_has "$IU_O11D" 'still names superseded PRFlow identifiers')"
+# Non-vacuity control: the shipped installer really does declare a stale pair, so the
+# silence above is an empty intersection and not an empty declared set.
+assert_eq "installer-upgrade stale-config: the shipped installer declares a non-empty stale-bot-login set" "yes" \
+  "$(_iu_out_matches "$(cat "$IU_INSTALL")" "^DEVFLOW_STALE_BOT_LOGINS='[^']+'")"
+
+# The adversarial input-shape matrix. Every row must exit 0 and print NOTHING but the
+# genuine hit rows — a shape that detonates the scan, or one that is read as a hit, is the
+# bug class here. Root x {object, array, scalar}; `devflow` x {object, array, scalar,
+# missing}; `allowed_bots` x {string, array, object, valid-falsy, missing, wrong-type}.
+_iu_cfg_shape() {  # $1 = literal config bytes -> the scan's stdout (empty = no hit)
+  printf '%s' "$1" > "$IU_C11C/.devflow/config.json"
+  # shellcheck disable=SC1090  # sources install.sh at runtime under DEVFLOW_SELFTEST
+  ( cd "$IU_C11C" && DEVFLOW_SELFTEST=1 . "$IU_INSTALL" \
+      && "${DEVFLOW_PY:-python3}" -c "$DEVFLOW_CONFIG_SCAN_PY" .devflow/config.json \
+           "$DEVFLOW_STALE_BOT_LOGINS" ) 2>/dev/null
+}
+IU_CFG_HIT='devflow.allowed_bots[devflow-autopilot -> prflow-implementer]'
+assert_eq "installer stale-config matrix: the plain hit shape is detected (the matrix below is not vacuously silent)" "$IU_CFG_HIT" \
+  "$(_iu_cfg_shape '{"devflow": {"allowed_bots": "claude,devflow-autopilot"}}')"
+assert_eq "installer stale-config matrix: a [bot]-suffixed entry with surrounding whitespace is the same login" "$IU_CFG_HIT" \
+  "$(_iu_cfg_shape '{"devflow": {"allowed_bots": "claude,  devflow-autopilot[bot] , x"}}')"
+assert_eq "installer stale-config matrix: the stale entry is reported even when the replacement is ALREADY listed (a dead entry is still dead)" "$IU_CFG_HIT" \
+  "$(_iu_cfg_shape '{"devflow": {"allowed_bots": "prflow-implementer,devflow-autopilot"}}')"
+assert_eq "installer stale-config matrix: a login that merely CONTAINS the stale slug is not a hit (entries compare whole, never by substring)" "" \
+  "$(_iu_cfg_shape '{"devflow": {"allowed_bots": "not-devflow-autopilot-either"}}')"
+assert_eq "installer stale-config matrix: malformed JSON degrades silently rather than detonating the scan" "" \
+  "$(_iu_cfg_shape '{"devflow": {"allowed_bots": ')"
+assert_eq "installer stale-config matrix: an empty file degrades" "" "$(_iu_cfg_shape '')"
+assert_eq "installer stale-config matrix: a top-level ARRAY is not indexed as a mapping" "" \
+  "$(_iu_cfg_shape '[{"devflow": {"allowed_bots": "devflow-autopilot"}}]')"
+assert_eq "installer stale-config matrix: a top-level scalar degrades" "" "$(_iu_cfg_shape '42')"
+assert_eq "installer stale-config matrix: a devflow ARRAY is not indexed as a mapping" "" \
+  "$(_iu_cfg_shape '{"devflow": ["allowed_bots", "devflow-autopilot"]}')"
+assert_eq "installer stale-config matrix: a devflow scalar degrades" "" \
+  "$(_iu_cfg_shape '{"devflow": "devflow-autopilot"}')"
+assert_eq "installer stale-config matrix: an absent devflow section degrades" "" \
+  "$(_iu_cfg_shape '{"base_branch": "main"}')"
+assert_eq "installer stale-config matrix: an absent allowed_bots key degrades" "" \
+  "$(_iu_cfg_shape '{"devflow": {"effort": "high"}}')"
+assert_eq "installer stale-config matrix: an allowed_bots ARRAY is not read as a comma string" "" \
+  "$(_iu_cfg_shape '{"devflow": {"allowed_bots": ["devflow-autopilot"]}}')"
+assert_eq "installer stale-config matrix: an allowed_bots OBJECT degrades" "" \
+  "$(_iu_cfg_shape '{"devflow": {"allowed_bots": {"devflow-autopilot": true}}}')"
+# The valid-falsy row. An explicit "" / false / 0 is a real config state, not a missing
+# key, and none of them may be coerced into a shape the scan reads as a hit.
+assert_eq "installer stale-config matrix: a valid-falsy empty-string allowed_bots yields no hit" "" \
+  "$(_iu_cfg_shape '{"devflow": {"allowed_bots": ""}}')"
+assert_eq "installer stale-config matrix: a valid-falsy false allowed_bots is a wrong TYPE, not an empty string (a bool is an int in Python, never a str)" "" \
+  "$(_iu_cfg_shape '{"devflow": {"allowed_bots": false}}')"
+assert_eq "installer stale-config matrix: a valid-falsy 0 allowed_bots degrades" "" \
+  "$(_iu_cfg_shape '{"devflow": {"allowed_bots": 0}}')"
+assert_eq "installer stale-config matrix: a whitespace-and-comma-only allowed_bots yields no entries and no hit" "" \
+  "$(_iu_cfg_shape '{"devflow": {"allowed_bots": " , ,  "}}')"
+
+# The absent-file arm, at the function level: no .devflow/config.json at all must be a
+# strict no-op, not a warning about a file the consumer never had.
+IU_C11E="$(_iu_consumer no-config)"
+# shellcheck disable=SC1090  # sources install.sh at runtime under DEVFLOW_SELFTEST
+IU_O11E="$( cd "$IU_C11E" && DEVFLOW_SELFTEST=1 . "$IU_INSTALL" \
+    && devflow_report_stale_config_identifiers 2>&1 )"
+assert_eq "installer stale-config: an absent .devflow/config.json is a strict no-op" "" "$IU_O11E"
+# And the documented python3-absent degradation: a warning that names the remedy, never a
+# silent skip that would read as "nothing stale here".
+printf '{"devflow": {"allowed_bots": "devflow-autopilot"}}' > "$IU_C11C/.devflow/config.json"
+# PATH is exported as its OWN statement inside the subshell, never as a prefix on the
+# `.` builtin: a `VAR=x . file` prefix scopes to the sourcing alone, so the function call
+# after it would run with the real python3 back on PATH and this arm would silently test
+# the happy path instead.
+# shellcheck disable=SC1090  # sources install.sh at runtime under DEVFLOW_SELFTEST
+IU_O11F="$( cd "$IU_C11C" && export PATH="$IU_NOPY:$PATH" && DEVFLOW_SELFTEST=1 . "$IU_INSTALL" \
+    && devflow_report_stale_config_identifiers 2>&1 )"
+assert_eq "installer stale-config: with no working python3 the check says it could not run and names the remedy, rather than passing silently" "yes yes" \
+  "$(_iu_out_has "$IU_O11F" 'could not check .devflow/config.json for superseded PRFlow identifiers') $(_iu_out_has "$IU_O11F" 'run /devflow:init to correct them')"
+
 # ── Scenario 12 (#959): the documented python3-absent FAIL-SAFE, driven end to end.
 # This is the arm the original 11 scenarios could not reach, because every one of them
 # ran with a working python3 — which is exactly why the installer shipped doing the

--- a/lib/test/run.sh
+++ b/lib/test/run.sh
@@ -45811,7 +45811,7 @@ rm -rf "$D487"
 # registry and this full-suite call share the same lower-bound contract;
 # test_module_runner.py parses this operand and rejects any coupling drift.
 if ! devflow_run_full_suite_module "$LIB/test/modules/installer-wiring.sh" \
-  "installer-wiring" 213; then
+  "installer-wiring" 238; then
   printf 'ERROR: installer-wiring boundary could not record its result\n'
   exit 1
 fi

--- a/scripts/workflow-flight-recorder-registry.json
+++ b/scripts/workflow-flight-recorder-registry.json
@@ -33,8 +33,8 @@
     },
     "installer-wiring": {
       "path": "lib/test/modules/installer-wiring.sh",
-      "minimum_assertions": 213,
-      "description": "Focused installer and workflow-wiring coverage: the #487/#491 credential-refresher and fresh-gh wrapper workflow wiring, the #533 seven-output install-gh-wrapper.sh validation with its planted-defect controls, the #544 fingerprint-comparison symmetry, the #599 workflow-token and secret-file permission pins, and the #690 Windows mode-probe arms, and the consumer UPGRADE path driven end-to-end over fixture consumer repositories (provenance manifest, non-clobbering preservation, the dry-run preview, the withheld review tier, and name-agnostic identifier migration)"
+      "minimum_assertions": 238,
+      "description": "Focused installer and workflow-wiring coverage: the #487/#491 credential-refresher and fresh-gh wrapper workflow wiring, the #533 seven-output install-gh-wrapper.sh validation with its planted-defect controls, the #544 fingerprint-comparison symmetry, the #599 workflow-token and secret-file permission pins, and the #690 Windows mode-probe arms, and the consumer UPGRADE path driven end-to-end over fixture consumer repositories (provenance manifest, non-clobbering preservation, the dry-run preview, the withheld review tier, name-agnostic identifier migration, and the stale-config detect-and-route report with its adversarial input-shape matrix)"
     },
     "harness-python-guards": {
       "path": "lib/test/modules/harness-python-guards.sh",

--- a/skills/init/SKILL.md
+++ b/skills/init/SKILL.md
@@ -128,6 +128,20 @@ Read the scaffolder's output line and respond accordingly:
 - **`scaffolded …`** — a fresh `.devflow/config.json` was created. Every value has a working default, so it's usable as-is; tell the user they only need to edit it to customize (their editor validates against `config.schema.json`).
 - **`keeping existing …`** — they already had a `config.json`; their values were preserved. It may be followed by **`backfilled newly-added keys …`** when the upgrade added keys the example gained since their config was written (existing values and arrays untouched) — tell the user to review the small diff before committing. If only `keeping existing …` prints, the config already had every key and nothing changed.
 
+### Then: correct superseded identifiers in the existing config
+
+The scaffolder is add-only — it backfills keys and never renames a **value**, so an identifier that was correct when the config was written stays there after the thing it names is renamed. Read `.devflow/config.json` with your file-read tool and correct the one such value there is:
+
+- **`devflow.allowed_bots`** — an entry whose bare login (a trailing `[bot]` stripped, surrounding whitespace ignored) is `devflow-autopilot` must become `prflow-implementer`. That GitHub App was renamed; `scripts/authorize-actor.sh` compares logins for **equality**, so the old slug authorizes nothing. The failure is silent and lands one run later: the implement and review stall-backstops post their resume comment successfully and go green, then the gate that comment re-enters declines the App as an unknown actor, so the run never resumes.
+
+Apply it with your file-edit tool, and hold to all of these:
+
+- **Change nothing else.** Every other entry, its order, and the rest of the file stay byte-for-byte as they were. This is not a re-scaffold.
+- **Never duplicate.** If `prflow-implementer` is already listed, **drop** the stale entry instead of renaming it onto a collision.
+- **Idempotent.** A config with no stale entry is left untouched — report `no superseded identifiers in .devflow/config.json` and move on. Re-running must produce no second change.
+- **Report what you changed**, as a sibling of the scaffolder's own lines and in the same shape — `corrected superseded identifiers in .devflow/config.json (…)`, with the parenthetical naming which of the two edits you made: `devflow.allowed_bots: devflow-autopilot → prflow-implementer` when you renamed, or `devflow.allowed_bots: dropped devflow-autopilot, prflow-implementer already listed` when you dropped a collision. Tell the user to review that diff before committing.
+- **Degrade, never block.** If the file cannot be read, does not parse as JSON, or does not have the shape this reads (`devflow` not an object, `allowed_bots` not a string), leave it untouched, say so in one line, and carry on with the rest of the run. Nothing in this step may stop `/prflow:init` — that is this skill's standing ethos, not an exception granted here.
+
 The scaffolder also prints `devflow-detect:` lines from the language auto-detection. Read them and respond:
 
 - **`detected: <langs> — merged …`** — build/test tools for those languages were added to `config.json`. **Tell the user to review the additions before committing.** The `devflow_runner.allowed_tools` entries reach the automated reviewer only when `devflow_runner.provision_env: true` is set in the base-branch config, which runs the PR author's `setup.install` + build steps on `pull_request_target` with a write token. The flag and the freeform allowlist are read only from the base branch, so a PR can't enable it or grant itself tools, and the runner strips the deny-listed tier regardless; but enabling `provision_env` is opting into running untrusted build steps. If they want the reviewer read-only (the default), leave `provision_env` unset/false. The `devflow.allowed_tools` / `devflow_implement.allowed_tools` entries take effect in their own workflows.


### PR DESCRIPTION
## Why (no issue)

Filed without an issue by explicit decision — the defect is a single confirmed stale identifier with a bounded fix, and the investigation that established the scope is recorded below rather than in a ticket.

The PR-authoring GitHub App was renamed `devflow-autopilot` → `prflow-implementer` (the app id behind `DEVFLOW_APP_ID` is unchanged — `CHANGELOG.md` 2.28.5). `scripts/authorize-actor.sh` compares bot logins for **equality** (`[ "$bt" = "$actor" ] || [ "$bt" = "$actor_bare" ]`), so a consumer whose `.devflow/config.json` still names the old slug carries an entry that authorizes nothing.

The failure is silent, and it lands one run later — not in the backstop itself:

1. The implement stall-backstop posts its `/prflow:implement <n>` resume comment under the App token, the breadcrumb matches, `APP_TOKEN_PRESENT=true` → the backstop **exits 0, green**.
2. That comment fires a fresh `issue_comment`; the `gate` job runs `resolve-implement-trigger.sh` with `ALLOWED_BOTS` from config.
3. No entry matches, the App falls to the human path, `repos/…/collaborators/…/permission` 404s → declined with a `::warning::` and `should_run=false`. **Green run, no re-dispatch, workpad frozen.**

The review stall-backstop carries the identical prerequisite (`.devflow/config.schema.json`'s `devflow_review.stall_backstop` description).

The config scaffolder is **add-only** — it backfills a newly-added key but never rewrites a *value* — so an upgrade could not correct this on its own, and no existing migration pass touches config values.

## What changed

Extends the detect-and-route split `install.sh` already uses for `.claude/settings.json` to `.devflow/config.json`.

- **`skills/init/SKILL.md`** — a new post-scaffold step corrects the entry: rename `devflow-autopilot` → `prflow-implementer`, or **drop** it when the current login is already listed (never rename onto a collision). It changes nothing else, is idempotent, reports exactly what it changed as a sibling of the scaffolder's own `keeping existing …` / `backfilled newly-added keys …` lines, and **degrades rather than blocks** — an unreadable, non-JSON, or wrong-shaped config is left untouched with a one-line breadcrumb and the run continues, per this skill's nothing-blocks-init ethos. It uses the runner's file tools only, so it adds no command shape and no allowlist grant.
- **`install.sh`** — `devflow_report_stale_config_identifiers()` mirrors `devflow_report_superseded_identifiers()`: it emits a `NOTICE` naming the entry and its replacement and routes to `/prflow:init`. It **never writes `.devflow/config.json`** for this purpose, and a detection failure never aborts the install. The `devflow-autopilot=prflow-implementer` pair is a plain assignment, deliberately *not* a widening of the generated, sha-stamped plugin-identity region — that region is compiled from `lib/plugin-identity.json`, which models plugin/marketplace identity; an App slug is a different identity with a different lifecycle.
- **`lib/test/modules/installer-wiring.sh`** — 25 new assertions (module: 213 floor → 238 passing).
- **`docs/install.md`** — one upgrade note.

## Scope — what was rejected

The sweep covered every `devflow`-era **value** in the config and its example/schema. Only `allowed_bots` is genuinely stale. Rejected, with evidence:

| Value | Verdict |
|---|---|
| `telemetry.branch: devflow-telemetry` | **Frozen / still correct** — `refs/heads/devflow-telemetry` exists; renaming would orphan the telemetry history. |
| `deferred.labels: DevFlow,Deferred` | **Frozen** — `lib/scan.sh` / `lib/classify-pr-kind.jq` match the literal `DevFlow`. |
| `devflow.workpad_marker` | **Frozen** — renaming would strand every workpad comment already on a live issue. |
| `Bash(/home/runner/work/devflow-autopilot/devflow-autopilot/…)` grants | **Not stale** — `devflow-implement.yml`'s extract step re-anchors the prefix onto the live `$GITHUB_WORKSPACE` (issue #928), and `config.example.json` ships `allowed_tools: []`, so no consumer ever has them. |
| Config **keys** (`devflow`, `devflow_review`, `devflow_version`, …), `.devflow/`, `DEVFLOW_*`, the `DevFlow` label, `<!-- devflow:* -->`, `devflow-marketplace`, `lib + python tests`, workflow filenames | **Out of scope / frozen** by standing policy. |

Two things the sweep surfaced that this PR deliberately does **not** change — both reported rather than bundled:

1. **`devflow_review.agent_overrides`'s `devflow:`-namespaced keys are silently inert.** `resolve-review-overrides.py` looks up `.devflow_review.agent_overrides.<dispatched-id>` by exact key, and the engine dispatches `prflow:` ids, so a `devflow:code-reviewer` entry never applies and no drift warning fires (the namespace is an accepted alias). This repo's own config carries two. But `config.schema.json` **promises** the opposite — *"the `devflow:` alias, so an override committed before the plugin rename keeps resolving"* — so the correct fix is to make the resolver honor the documented alias, not to rewrite consumers' keys from init. That is a separate change against a different file, and rewriting the keys here would additionally un-freeze this repo's judge economics mid-window.
2. The brief's premise that the reviewer App posts as `prflow-reviewer[bot]` is **not** what the tree says — it is `DevFlow-Reviewer` / `devflow-reviewer[bot]`, unrenamed. No mapping was invented for it.

## Test evidence

Driven end to end over a real fixture consumer repository (the never-writes invariant can only be established by an actual before/after), plus the adversarial input-shape matrix at the function level:

- **Hit** — the notice fires, names `devflow.allowed_bots[devflow-autopilot -> prflow-implementer]`, routes to init, and `allowed_bots` is byte-identical afterward. (The assertion is on the *value*, not a whole-file digest: `--apply` legitimately re-stamps `devflow_version` on the same file, so a file digest would assert something the installer never promised.)
- **Miss** — a scaffolded default is silent, with a non-vacuity control proving the declared set is non-empty (so the silence is an empty *intersection*).
- **Shape matrix** — root × {object, array, scalar}; `devflow` × {object, array, scalar, missing}; `allowed_bots` × {string, array, object, valid-falsy, missing, wrong-type}; plus malformed/empty JSON, `[bot]`-suffix and whitespace normalization, a substring near-miss, and the already-listed-replacement case. Every row exits 0 and prints nothing but the genuine hits. The **valid-falsy** row is split deliberately: `""` is a real string that yields no entries, while `false`/`0` are wrong *types* (a bool is an int in Python, never a str).
- **Absent file** — strict no-op. **No working python3** — a warning naming the remedy, never a silent skip that would read as "nothing stale here". This arm exports `PATH` as its own statement inside the subshell; a `VAR=x . file` prefix scopes to the sourcing alone, and the first draft of this test silently exercised the happy path because of it.

The init-side correction is agent-executed prompt prose whose only reader is the runtime agent, so per this repo's recorded #843/#876 decision it carries **no automated regression coverage by design** — no pin was invented for it. Its compensating control is the review pass, and it was verified instead by the RED/GREEN/REFACTOR subagent runs below.

**Writing-skills evidence:** `superpowers:writing-skills` invoked before the `skills/init/SKILL.md` edit and its RED/GREEN/REFACTOR discipline followed.
- **RED** — a subagent running the *unmodified* skill over a stale fixture config produced a full init report that never mentioned the dead login.
- **GREEN** — the same scenario with the edit produced the correct rename, the exact report line, and no other change.
- **REFACTOR** — the collision arm (both logins present) correctly *dropped* rather than renamed, and surfaced a real gap: the report bullet specified only the rename wording, so the drop arm invented its own. Closed by specifying both shapes. The idempotent re-run and the malformed-config degrade arms were then verified to change nothing and continue the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
