### PR TITLE
test: make the python-pool probe coverage non-vacuous (#986 follow-up)

### DIFF
--- a/lib/test/run.sh
+++ b/lib/test/run.sh
@@ -49679,6 +49679,45 @@ assert_eq "python-pool selector: the predicate reports disabled at exactly 1" "d
   "$( ( DEVFLOW_SKIP_PYTHON_POOL=1; devflow_python_pool_enabled && echo enabled || echo disabled ) )"
 unset -f _pps_selector_probe
 
+# ── The join's POSITIVE reconciliation branch, in isolation ──
+# The selector probe above reaches only the else arm (no summary captured). The branch
+# that actually does arithmetic — positional field 1 + field 3 of the pooled suite's own
+# `N passed, M failed` line, compared against the verdict lines it contributed — is the
+# one that regresses on a summary-format change, and it is otherwise exercised only end
+# to end inside a 3-minute pooled run. Drive it directly by seeding the two reap-time
+# captures and stubbing devflow_pool_join.
+_pps_reconcile_probe() {  # summary  lines -> "pass=N fail=N"
+  (
+    _pps_res="$(mktemp)"; : > "$_pps_res"
+    RESULTS_FILE="$_pps_res"
+    unset DEVFLOW_SKIP_PYTHON_POOL
+    devflow_pool_join() { :; }
+    # Subscripts quoted: an unquoted associative-array subscript is read as a variable
+    # reference in an assignment context (SC2154), unlike the read sites above.
+    _DEVFLOW_POOL_SELFTALLY_SUMMARY["test_python_scripts.py"]="$1"
+    _DEVFLOW_POOL_SELFTALLY_LINES["test_python_scripts.py"]="$2"
+    devflow_python_suite_pool_join >/dev/null
+    printf 'pass=%s fail=%s\n' \
+      "$(grep -c '^PASS$' "$_pps_res" || true)" "$(grep -c '^FAIL$' "$_pps_res" || true)"
+    rm -f "$_pps_res" "$_pps_res.names"
+  ) 2>/dev/null | tail -1
+}
+# 7 + 2 = 9 contributed lines: the counts agree, so the reconciliation PASSES.
+assert_eq "python-pool join: the reconciliation passes when the contribution equals passed+failed" \
+  "pass=1 fail=0" "$(_pps_reconcile_probe '7 passed, 2 failed' 9)"
+# One verdict short — the uniformly-dropped-verdict shape the width-equality gate cannot
+# see. Must FAIL, or a silently truncated self-tally would report clean.
+assert_eq "python-pool join: a short contribution FAILS the reconciliation (the dropped-verdict shape)" \
+  "pass=0 fail=1" "$(_pps_reconcile_probe '7 passed, 2 failed' 8)"
+# Field 3 is read, not just field 1: a summary whose FAILED count is ignored would make
+# these two agree, so the failed-count half of the arithmetic is pinned separately.
+assert_eq "python-pool join: the FAILED field participates in the sum (field 3, not field 1 alone)" \
+  "pass=0 fail=1" "$(_pps_reconcile_probe '7 passed, 2 failed' 7)"
+# An unestablished line count is never silently accepted as agreement.
+assert_eq "python-pool join: an unestablished contribution count FAILS rather than reconciling" \
+  "pass=0 fail=1" "$(_pps_reconcile_probe '7 passed, 2 failed' '')"
+unset -f _pps_reconcile_probe
+
 # ── run-python-pool.sh's fail-closed arms, against a stub harness ──
 # The driver is exercised in a fixture tree whose module-harness.sh is a stub, so the
 # arms are reachable in milliseconds and the real suites never run. summary.sh is the
@@ -49705,6 +49744,24 @@ if [ -n "$PPS_SB" ] && [ -d "$PPS_SB" ]; then
     "$(printf '%s' "$PPS_MISSING_OUT" | grep -qF 'harness did not define devflow_python_suite_pool_open' && echo yes || echo no)"
   assert_eq "python-pool driver: the missing-function arm renders NO summary line (nothing for shard-tally to accept)" "yes" \
     "$(printf '%s' "$PPS_MISSING_OUT" | grep -qE '^[0-9]+ passed, [0-9]+ failed' && echo no || echo yes)"
+  # The gate names SIX functions, and the probe above can only ever exercise the two the
+  # harness provides — the four summary.sh-provided names cannot be absent while the
+  # fixture copies the real file, so deleting one of those four from the gate's list
+  # would stay green. Cover the other half of the list by making the fixture's
+  # summary.sh a stub that omits one, which is what makes the gate's coverage
+  # non-vacuous for the whole set rather than for two of six.
+  _pps_stub_harness 'devflow_python_suite_pool_open() { :; }
+devflow_python_suite_pool_join() { printf "PASS\n" >> "$RESULTS_FILE"; }'
+  {
+    printf '%s\n' 'devflow_render_test_summary() { printf "%s passed, %s failed\n" "$1" "$2"; }'
+    printf '%s\n' 'devflow_render_failure_recap() { :; }'
+    printf '%s\n' '# devflow_tally_is_derivable deliberately absent'
+  } > "$PPS_SB/lib/test/summary.sh"
+  PPS_NOSUM_OUT="$(bash "$PPS_SB/lib/test/run-python-pool.sh" 2>&1)"; PPS_NOSUM_RC=$?
+  assert_eq "python-pool driver: a summary.sh missing a gated function ALSO fails closed (rc 2)" "2" "$PPS_NOSUM_RC"
+  assert_eq "python-pool driver: that refusal names the summary.sh-provided function, not a pool entry point" "yes" \
+    "$(printf '%s' "$PPS_NOSUM_OUT" | grep -qF 'harness did not define devflow_tally_is_derivable' && echo yes || echo no)"
+  cp "$LIB/test/summary.sh" "$PPS_SB/lib/test/summary.sh"
 
   # (2) POSITIVE CONTROL on the same fixture: a harness that does record verdicts
   # renders the summary and exits 0 — so every refusal above and below is attributable
@@ -49856,7 +49913,7 @@ if [ -n "$PPS_TDIR" ] && [ -d "$PPS_TDIR" ]; then
 fi
 unset PPS_RUNSHARD PPS_DRIVER PPS_TALLY PPS_SB PPS_DSB PPS_TDIR PPS_MISSING_OUT PPS_MISSING_RC \
   PPS_OK_OUT PPS_OK_RC PPS_ZERO_OUT PPS_ZERO_RC PPS_UNDER_OUT PPS_UNDER_RC \
-  PPS_UNDERF_OUT PPS_UNDERF_RC PPS_REAL_GREP \
+  PPS_UNDERF_OUT PPS_UNDERF_RC PPS_REAL_GREP PPS_NOSUM_OUT PPS_NOSUM_RC \
   PPS_PP_INVOKED PPS_MONO_INVOKED PPS_MOD_INVOKED _pps_callee
 # ────────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Follow-up to #986, which merged while these were still in flight.

#986's third review pass returned **APPROVE** with three non-blocking Suggestions. Two of
them are the same defect class the round before blocked on — **an assertion that stays green
however the production path is broken** — so they are closed here rather than left filed.
Test-only: one file, `lib/test/run.sh`, no engine surface, so no changeset.

## 1. The driver's missing-function gate was covered for two of six names

`run-python-pool.sh` verifies six functions exist after sourcing. The probe added in #986
supplied them through a stub `module-harness.sh` plus a copy of the **real** `summary.sh` — so
the four `summary.sh`-provided names (`record_fail`, `devflow_render_test_summary`,
`devflow_render_failure_recap`, `devflow_tally_is_derivable`) could never be absent in the
fixture, and deleting one of them from the gate's list stayed green.

The fixture now also runs against a `summary.sh` stub that omits one name, asserting the
refusal is rc 2 and that it names **that** function rather than a pool entry point.

## 2. The join's reconciliation was reached only through its else arm

`devflow_python_suite_pool_join` compares the pooled suite's own `N passed, M failed` summary
(positional field 1 + field 3) against the verdict lines it contributed. The selector probe
drove only the *summary-not-captured* branch; the arithmetic — the part that regresses on a
summary-format change — was exercised only inside a 3-minute end-to-end pooled run.

It is now driven directly by seeding the two reap-time captures: agreement passes, a short
contribution fails (the uniformly-dropped-verdict shape the width-equality gate cannot see),
the FAILED field is proven to participate in the sum, and an unestablished count fails rather
than reconciling.

## 3. Not fixed, deliberately

The third Suggestion — a legitimately-empty `test_python_scripts.py` population would
reconcile `0 == 0` and report green — is **pre-existing**, inherited from issue #720 and only
relocated by #986, not weakened. The pool's own per-member "executed zero assertions" FAIL
still catches a whole-pool no-op. A minimum-population floor is a real idea but it is a change
to #720's contract, not to this split, and it belongs in its own change with its own
justification for whatever floor number it picks.

## RED-proof

Both new arm groups were mutation-proven, on top of the nine mutations #986 already carried.
Block baseline and post-restore: `34 passed, 0 failed`.

| # | mutation | observed |
|---|---|---|
| M9 | a `summary.sh`-provided name dropped from the driver's gate list | **2 failed** — `a summary.sh missing a gated function ALSO fails closed (rc 2)`; `that refusal names the summary.sh-provided function, not a pool entry point` |
| M10 | reconciliation: FAILED field (field 3) dropped from the sum | **2 failed** — `the reconciliation passes when the contribution equals passed+failed`; `the FAILED field participates in the sum (field 3, not field 1 alone)` |
| M11 | reconciliation: comparison made vacuous (value compared to itself) | **3 failed** — `a short contribution FAILS the reconciliation (the dropped-verdict shape)`; `the FAILED field participates in the sum`; `an unestablished contribution count FAILS rather than reconciling` |

The nine mutations from #986 were re-run against this head and all still go RED; M1 (inverted
selector gate) now trips 10 assertions rather than 6, because the reconciliation probes run
with the selector unset and the inverted gate silences them too.

## Tally

These are meta-probes on stubs — none runs a pooled suite. `+6` assertions, all on the
monolith shard; the `python-pool` shard's tally is expected to stay at 3186, unchanged.

## Verification

* `bash lib/test/run.sh` — `14342 passed, 0 failed` (plus the expected `#434` dirty-tree
  `blocking-gate` skip, which clears on commit; CI checks out clean)
* `shellcheck --severity=warning -e SC1091 --extended-analysis=false lib/test/run.sh`
* `git ls-files '*.py' | xargs -r ruff check`
* `coverage_map_guard.py`, `lint-carveout-guard.py`, `lint-tree-enumeration.py`
* the 11-mutation RED-proof above, each arm restored and the baseline re-verified
