### PR TITLE
chore: default reasoning effort to low in the shipped example config

### DIFF
--- a/.changeset/default-effort-low.md
+++ b/.changeset/default-effort-low.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+---
+
+### Changed
+
+- Default reasoning effort in the shipped `.devflow/config.example.json` is now `low` for `devflow.effort`, `devflow_implement.effort`, `devflow_runner.effort`, and the `devflow_review.agent_overrides` entries (`default`, `prflow:checklist-deduper`, `prflow:code-reviewer`). The coupled prose in `config.schema.json`, `docs/review-agent-overrides.md`, and the `lib/test/run.sh` guard comment is updated to match. The live `.devflow/config.json` already ran at `low`, so this only changes what fresh installs scaffold.

--- a/.devflow/config.example.json
+++ b/.devflow/config.example.json
@@ -7,14 +7,14 @@
     "allowed_bots": "claude,dependabot",
     "allowed_users": "*",
     "workpad_marker": "<!-- devflow:workpad -->",
-    "effort": "high",
+    "effort": "low",
     "allowed_tools": [],
     "execution_diagnostics_enabled": true,
     "execution_transcript_artifact_enabled": false,
     "attribute_commits_to_triggerer": false
   },
   "devflow_implement": {
-    "effort": "high",
+    "effort": "low",
     "implement_pr_state": "ready_for_review",
     "allowed_tools": [],
     "update_branch_checkpoints": true,
@@ -24,7 +24,7 @@
     }
   },
   "devflow_runner": {
-    "effort": "high",
+    "effort": "low",
     "provision_env": false,
     "allowed_tools": []
   },
@@ -49,15 +49,15 @@
     },
     "agent_overrides": {
       "default": {
-        "effort": "high"
+        "effort": "low"
       },
       "prflow:checklist-deduper": {
         "model": "claude-sonnet-5",
-        "effort": "medium"
+        "effort": "low"
       },
       "prflow:code-reviewer": {
         "model": "claude-opus-5",
-        "effort": "high",
+        "effort": "low",
         "iterations": "first-only"
       }
     }

--- a/.devflow/config.schema.json
+++ b/.devflow/config.schema.json
@@ -383,7 +383,7 @@
             "prflow:checklist-deduper": {
               "type": "object",
               "additionalProperties": false,
-              "description": "Pins Claude Sonnet 5 for the dedup pass with effort 'medium' (a cost-saving step down from the API default of 'high'; set it explicitly to avoid unexpected latency). NOTE: Claude Haiku rejects the `effort` parameter with HTTP 400 (effort is supported only on Opus 4.5\u20134.8, Opus 5, Sonnet 4.6, and Sonnet 5), so if you re-pin a Haiku id here the entry must NOT carry an `effort` key; scaffold-config.sh strips a stale `effort` from any Haiku-pinned override on re-scaffold.",
+              "description": "Pins Claude Sonnet 5 for the dedup pass with effort 'low' (a cost-saving step down from the API default of 'high'; set it explicitly to avoid unexpected latency). NOTE: Claude Haiku rejects the `effort` parameter with HTTP 400 (effort is supported only on Opus 4.5\u20134.8, Opus 5, Sonnet 4.6, and Sonnet 5), so if you re-pin a Haiku id here the entry must NOT carry an `effort` key; scaffold-config.sh strips a stale `effort` from any Haiku-pinned override on re-scaffold.",
               "properties": {
                 "model": {
                   "type": "string"
@@ -609,7 +609,7 @@
             "devflow:checklist-deduper": {
               "type": "object",
               "additionalProperties": false,
-              "description": "Pins Claude Sonnet 5 for the dedup pass with effort 'medium' (a cost-saving step down from the API default of 'high'; set it explicitly to avoid unexpected latency). NOTE: Claude Haiku rejects the `effort` parameter with HTTP 400 (effort is supported only on Opus 4.5\u20134.8, Opus 5, Sonnet 4.6, and Sonnet 5), so if you re-pin a Haiku id here the entry must NOT carry an `effort` key; scaffold-config.sh strips a stale `effort` from any Haiku-pinned override on re-scaffold.",
+              "description": "Pins Claude Sonnet 5 for the dedup pass with effort 'low' (a cost-saving step down from the API default of 'high'; set it explicitly to avoid unexpected latency). NOTE: Claude Haiku rejects the `effort` parameter with HTTP 400 (effort is supported only on Opus 4.5\u20134.8, Opus 5, Sonnet 4.6, and Sonnet 5), so if you re-pin a Haiku id here the entry must NOT carry an `effort` key; scaffold-config.sh strips a stale `effort` from any Haiku-pinned override on re-scaffold.",
               "properties": {
                 "model": {
                   "type": "string"

--- a/docs/review-agent-overrides.md
+++ b/docs/review-agent-overrides.md
@@ -126,7 +126,7 @@ Each value optionally sets `model`, `effort`, and/or `iterations`:
 > **Claude Haiku rejects `effort`.** The `effort` parameter is supported only on Opus 4.5–4.8, Opus 5, Sonnet 4.6, and
 > Sonnet 5; Claude Haiku rejects it with **HTTP 400**. So any entry that pins a Haiku model (a
 > `claude-haiku-*` id) **must not** also carry an `effort` key. The shipped `prflow:checklist-deduper`
-> override pins Claude Sonnet 5 (which *does* support `effort`) with effort `medium`, so it is exempt;
+> override pins Claude Sonnet 5 (which *does* support `effort`) with effort `low`, so it is exempt;
 > the constraint matters if you re-pin a Haiku id there. The schema does not enforce this (it is a model-API fact, not a structural
 > one), so the constraint is documented on the `prflow:checklist-deduper` property in
 > `config.schema.json` and guarded by the shipped-example test in `lib/test/run.sh`.

--- a/lib/test/run.sh
+++ b/lib/test/run.sh
@@ -11502,7 +11502,7 @@ assert_eq "init-memory-nudge: recommends the built-in /init" "yes" \
 echo "shipped agent_overrides: deduper pins Sonnet 5 w/ effort; no Haiku override carries effort"
 # ────────────────────────────────────────────────────────────────────────────
 # The shipped checklist-deduper override pins Claude Sonnet 5 (which DOES
-# support `effort`) with effort "medium" — a cost-saving step down from the API
+# support `effort`) with effort "low" — a cost-saving step down from the API
 # default of "high"; set it explicitly to avoid unexpected latency. A
 # positive sentinel, not a bare has("effort"): a refactor that drops/renames the
 # entry, swaps the model, or strips the effort each FAIL loudly rather than


### PR DESCRIPTION
## Summary

Sets every `effort` value in the shipped `.devflow/config.example.json` to `low`:

- `devflow.effort`, `devflow_implement.effort`, `devflow_runner.effort` (were `high`)
- `devflow_review.agent_overrides.default.effort` and `prflow:code-reviewer.effort` (were `high`)
- `devflow_review.agent_overrides["prflow:checklist-deduper"].effort` (was `medium`)

The live `.devflow/config.json` was **already** `low` at all six sites, so it is unchanged — the file the request named as `config.sample.json` is `config.example.json` in this repo.

Coupled prose that quoted the old literals is updated in the same change:

- `.devflow/config.schema.json` — the two `prflow:checklist-deduper` descriptions (`effort 'medium'` → `'low'`)
- `docs/review-agent-overrides.md` — the Haiku-exemption note's claim about the shipped override
- `lib/test/run.sh` — the guard-block comment above the deduper pin

The pins themselves are value-agnostic (they assert the entry exists, pins Sonnet 5, and *has* an `effort` key; and that no Haiku-pinned override carries `effort`), so no assertion changed.

Changeset: `.changeset/default-effort-low.md` (`bump: patch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)