### PR TITLE
ci: request a standalone review when CI goes green (this repo only)

### DIFF
--- a/.changeset/ci-auto-review-on-green.md
+++ b/.changeset/ci-auto-review-on-green.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: Added
+---
+
+- **Ask for a standalone review automatically when CI goes green — in this repository only.** A new `auto-review notification` job in `.github/workflows/ci.yml` posts the bare review-trigger comment under a downscoped GitHub App token once both CI jobs pass on a non-draft, same-repository pull request, deduped per head SHA by a `<!-- prflow:ci-review-trigger sha=… -->` marker read from the pull request's comments. The post-or-skip selection lives in the new `scripts/post-ci-review-trigger.sh` so the suite can drive each arm; an unreadable comment list fails **closed** (a duplicate standalone review is unrecoverable spend, a missed one is recoverable by the pre-existing human-comment path). **Nothing changes for consumers:** `install.sh` ships only `devflow.yml` and `devflow-implement.yml`, so no consumer repository has `ci.yml`, nothing consumer-facing calls the new helper, and a collaborator commenting the trigger remains the supported review path everywhere else.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -390,16 +390,25 @@ jobs:
   # somehow made would use GITHUB_TOKEN and be swallowed by the recursion guard.
   # The fix-loop command is the opposite on both counts — it mints the App token
   # and pushes with it, outside the recursion guard — so widening this payload
-  # would re-run CI, re-post, and loop without bound. lib/test/modules/review-trigger-helpers.sh
-  # drives the composed body through the real standalone-command detector; that
-  # assertion is the structural brake on exactly that edit.
+  # would re-run CI, re-post, and loop without bound. The review-trigger-helpers
+  # test module drives the composed body through the real standalone-command
+  # detector; that assertion is the structural brake on exactly that edit.
   #
-  # NAMED FOR ITS SKIPPED STATE. scripts/summarize-ci-checks.sh renders every job's
-  # name and conclusion into the engine-ground-truth block of every review prompt,
-  # and this job reads `skipped` on most runs — draft pull requests, fork pull
-  # requests, pushes to main. In a repo whose governing rule is that a skip is never
-  # laundered into a pass, the name has to make a skipped row self-evidently a
-  # notification that was not sent rather than a verification that did not run.
+  # NAMED FOR ITS SKIPPED STATE. The CI-signal summarizer that composes the review
+  # engine's injected engine-ground-truth block renders every job's name and
+  # conclusion into it, and this job reads `skipped` on most runs — draft pull
+  # requests, fork pull requests, pushes to main. In a repo whose governing rule is
+  # that a skip is never laundered into a pass, the name has to make a skipped row
+  # self-evidently a notification that was not sent rather than a verification that
+  # did not run.
+  #
+  # EDITING THIS COMMENT BLOCK: do not name a `<something>.sh` helper here unless
+  # you mean it. The #312 endpoint-permission lint attributes every such basename it
+  # finds in a job's lines — comments included — to that job's permission
+  # requirement, and a comment block sitting ABOVE a job key parses as part of the
+  # PREVIOUS job. Naming the summarizer here required `checks`/`actions` of the lint
+  # job, which calls neither. It fails closed (RED), so the suite catches it, but the
+  # diagnosis lands two jobs away from the edit.
   auto_review_trigger:
     name: auto-review notification (not a check; skipped = not sent)
     needs: [test, lint]
@@ -425,14 +434,26 @@ jobs:
       github.actor != 'dependabot[bot]' &&
       vars.DEVFLOW_APP_ID != ''
     runs-on: ubuntu-latest
-    # Job-scoped and read-only. `pull-requests: write` is deliberately NOT added at
-    # workflow level: that would widen `shard`, `test`, and `lint`, which run
-    # arbitrary pull-request code. It is also unnecessary — an App installation
-    # token ignores the job's `permissions:` block entirely, so the mint's
-    # `permission-*` inputs below are the sole least-privilege enforcement on it,
-    # and this block governs only the built-in GITHUB_TOKEN the checkout uses.
+    # JOB-SCOPED, never workflow-level. Raising `pull-requests: write` to the file's
+    # top-level block would widen `shard`, `test`, and `lint`, which run arbitrary
+    # pull-request code; declared here it reaches this job alone.
+    #
+    # It is declared even though the POST does not use it. The comment is written
+    # with the minted App installation token, whose scope comes from the mint's
+    # `permission-*` inputs and ignores this block entirely — so these keys are not
+    # what authorizes the call. They are here because the repo's own #312
+    # endpoint-permission lint requires a job to declare the permission for every
+    # `gh api` endpoint family it or its helpers invoke, and this job invokes the
+    # issues-comments family. Declaring it is also the honest fallback posture: if
+    # the mint were ever removed the step would still work.
+    #
+    # The grant is safe in a job that checks out pull-request code because the
+    # built-in GITHUB_TOKEN never reaches that code — the checkout persists no
+    # credential, and no step interpolates the token into the environment. Only
+    # GH_TOKEN, the already-downscoped App token, is in the helper's environment.
     permissions:
       contents: read
+      pull-requests: write
     steps:
       # A checkout, taken deliberately over the smaller checkout-less shape. The
       # post-or-skip decision is a branch selection over a user-visible outcome, and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,3 +354,125 @@ jobs:
           # explicit, reviewable bump rather than a silent tree-wide breakage.
           python3 -m pip install --quiet 'ruff==0.15.*'
           git ls-files '*.py' | xargs -r ruff check
+
+  # Ask for a standalone review the moment CI is green on a pull request, so the
+  # review the repo already expects before merge does not wait on a human
+  # remembering to type the trigger. THIS REPO ONLY: install.sh's workflow copy
+  # loop ships devflow.yml and devflow-implement.yml and NOT this file, so no
+  # consumer repo gains an auto-trigger and the shipped documentation's standing
+  # "a collaborator comments the trigger" statement stays literally true.
+  #
+  # Deliberately NOT once-per-PR and NOT once-per-red-to-green transition: it
+  # notifies on EVERY green head, deduped only at an identical head SHA. Replayed
+  # against a real busy PR's history that is several standalone reviews in an
+  # afternoon. That cost was weighed and accepted; a reviewer's HEAD is the unit
+  # that matters, and a review of a superseded commit is worth less than the
+  # spend it saved.
+  #
+  # Deliberately NOT a `workflow_run` listener, which would have been the other
+  # obvious shape: that trigger needs a `workflows:` name list (a strandable
+  # surface — the guard that used to police it went with the withheld review tier
+  # in issue #936), it runs the DEFAULT BRANCH's copy of the workflow rather than
+  # the PR's, so a change to this job could never be exercised by the PR that
+  # makes it, and it fires for fork pull requests too, which is precisely what the
+  # head-repo gate below exists to prevent.
+  #
+  # WHY AN APP TOKEN, AND WHY THAT IS THE WHOLE MECHANISM: a comment posted with
+  # the built-in GITHUB_TOKEN does not trigger workflows (the same recursion guard
+  # this file's `on:` comment relies on for the bot's own pushes). A comment posted
+  # with a GitHub App installation token DOES. So the mint is not a convenience
+  # here — it is the only thing that makes the trigger fire at all, and it is the
+  # pattern scripts/post-review-backstop-comment.sh already uses from devflow.yml.
+  #
+  # LOOP SAFETY. The payload is the PLAIN review command and must stay that way.
+  # devflow.yml skips its `app-token` mint on a `/prflow:review ` command, so that
+  # path runs under the read-only reviewer token and pushes nothing; even a push it
+  # somehow made would use GITHUB_TOKEN and be swallowed by the recursion guard.
+  # The fix-loop command is the opposite on both counts — it mints the App token
+  # and pushes with it, outside the recursion guard — so widening this payload
+  # would re-run CI, re-post, and loop without bound. lib/test/modules/review-trigger-helpers.sh
+  # drives the composed body through the real standalone-command detector; that
+  # assertion is the structural brake on exactly that edit.
+  #
+  # NAMED FOR ITS SKIPPED STATE. scripts/summarize-ci-checks.sh renders every job's
+  # name and conclusion into the engine-ground-truth block of every review prompt,
+  # and this job reads `skipped` on most runs — draft pull requests, fork pull
+  # requests, pushes to main. In a repo whose governing rule is that a skip is never
+  # laundered into a pass, the name has to make a skipped row self-evidently a
+  # notification that was not sent rather than a verification that did not run.
+  auto_review_trigger:
+    name: auto-review notification (not a check; skipped = not sent)
+    needs: [test, lint]
+    # BOTH jobs, because `lint` is not downstream of `test` — the only `needs:`
+    # elsewhere in this file is `test: needs: [shard]`. Gating on `test` alone
+    # would ask for a review of a head whose ruff or shellcheck run was red.
+    #
+    # Every guard is GitHub-evaluated, so an ineligible run reaches no shell and,
+    # more importantly, mints no credential. The head-repo comparison is the fork
+    # gate and it is the actual security property of this job: it excludes fork
+    # pull requests BEFORE the App token is minted, rather than relying on secrets
+    # being withheld from fork runs. Dependabot branches live in this repo, so they
+    # satisfy the head-repo test and need their own exclusion. The `pull_request`
+    # test is load-bearing rather than cosmetic: this workflow also runs on pushes
+    # to main, where `github.event.pull_request` is null and the draft comparison
+    # would read as satisfied.
+    if: >-
+      needs.test.result == 'success' &&
+      needs.lint.result == 'success' &&
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]' &&
+      vars.DEVFLOW_APP_ID != ''
+    runs-on: ubuntu-latest
+    # Job-scoped and read-only. `pull-requests: write` is deliberately NOT added at
+    # workflow level: that would widen `shard`, `test`, and `lint`, which run
+    # arbitrary pull-request code. It is also unnecessary — an App installation
+    # token ignores the job's `permissions:` block entirely, so the mint's
+    # `permission-*` inputs below are the sole least-privilege enforcement on it,
+    # and this block governs only the built-in GITHUB_TOKEN the checkout uses.
+    permissions:
+      contents: read
+    steps:
+      # A checkout, taken deliberately over the smaller checkout-less shape. The
+      # post-or-skip decision is a branch selection over a user-visible outcome, and
+      # this repo's convention is that such a selection lives in a scripts/*.sh
+      # helper the suite can drive arm by arm rather than inline in YAML — which
+      # needs the helper on disk. The trade is that this checks out the pull
+      # request's own code, so a collaborator's branch controls the helper that then
+      # runs alongside a token holding `pull-requests: write`. The fork gate above
+      # bounds that to people who already have write access to this repository, and
+      # the minted token is strictly NARROWER than the access they already hold, so
+      # there is no escalation to reach for. Checking out the base ref instead would
+      # close even that, but at a cost that is not worth paying: a change to this
+      # helper could then never be exercised by the pull request that makes it.
+      # persist-credentials: false because nothing here talks to git over the
+      # network — gh authenticates from GH_TOKEN — so the checkout leaves no
+      # credential behind for later steps to inherit.
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      # Downscoped to the single permission the helper needs. The issues-comments
+      # endpoints accept the Pull requests permission when the target is a pull
+      # request, which is the only target this job ever has — the same grant
+      # devflow.yml's `dedupe_app_token` uses to post on a PR. No checkout token is
+      # seeded from it (issue #357 governs PUSHING jobs; this one pushes nothing and
+      # hands its token straight to gh, like devflow.yml's `gate` and
+      # `review_dedupe` mints).
+      - name: Mint downscoped comment token
+        id: app_token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.DEVFLOW_APP_ID }}
+          private-key: ${{ secrets.DEVFLOW_APP_PRIVATE_KEY }}
+          permission-pull-requests: write
+
+      # Keyed on the pull request's HEAD sha, not the merge commit github.sha —
+      # the head is what a review reviews and what the marker must dedupe on.
+      - name: Request a review for this head
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          PR: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: bash scripts/post-ci-review-trigger.sh

--- a/lib/test/modules/coverage-map.json
+++ b/lib/test/modules/coverage-map.json
@@ -418,6 +418,10 @@
       "note": "",
       "owner": "unmodularized"
     },
+    "scripts/post-ci-review-trigger.sh": {
+      "note": "ci.yml auto-review notification: the bare review-trigger payload contract and the per-SHA post-or-skip arms",
+      "owner": "review-trigger-helpers"
+    },
     "scripts/post-issue-comment.sh": {
       "note": "",
       "owner": "unmodularized"

--- a/lib/test/modules/review-trigger-helpers.inventory.md
+++ b/lib/test/modules/review-trigger-helpers.inventory.md
@@ -31,6 +31,7 @@ drift out of it silently.
 | Implement trigger | `resolve-implement-trigger.sh`, `dedupe-implement-run.sh` | implement-trigger section | trigger resolution and the single-flight dedupe of an implement run |
 | Actor authorization | `authorize-actor.sh (allowed_users filter)` | authorization section | the `allowed_users` filter's allow/deny arms and deny reasons |
 | Standalone command routing | `detect-standalone-command.sh`, `resolve-command-trigger.sh` | command-routing section | both the resolver and `review_dedupe` route through the one shared detector, and the detector extraction fails open only under an `if !` guard |
+| CI auto-review notification | *(no former section — added with `scripts/post-ci-review-trigger.sh`)* | `post-ci-review-trigger.sh` section | the composed comment body is fed through the REAL standalone-command detector and must resolve to the plain review command — the structural brake against widening the payload to the fix-loop command, whose App-token pushes escape GitHub's recursion guard — plus the per-SHA post-or-skip arms and the fail-closed unreadable-comment-list arm |
 
 The generic test harness, registry validation, module registration, full-suite
 boundary, and module-runner tests stay global so deleting this module cannot also

--- a/lib/test/modules/review-trigger-helpers.sh
+++ b/lib/test/modules/review-trigger-helpers.sh
@@ -2952,3 +2952,115 @@ devflow_module_pin_unique "rct #321: review_dedupe routes through the shared det
 # reverting it to a bare `CMD=$(...)` assignment re-opens the fail-CLOSED swallow.
 devflow_module_pin_unique "rct #321: review_dedupe detector extraction fails open on a run failure (if!-guarded)" \
   'if ! CMD="$(printf '"'"'%s'"'"' "$BODY" | bash "$DETECTOR" | sed -n '"'"'s/^command=//p'"'"')"' "$RCT_WF_DEVFLOW"
+
+# ────────────────────────────────────────────────────────────────────────────
+echo "post-ci-review-trigger.sh (ci.yml auto-review notification)"
+# ────────────────────────────────────────────────────────────────────────────
+# The composed comment body is a MACHINE-CONSUMED contract, not prose: it is
+# parsed by scripts/detect-standalone-command.sh (which decides whether the
+# comment is a standalone command at all, and which one) and substring-tested by
+# devflow.yml's gate `if:`. It is therefore asserted through the REAL detector on
+# the REAL composer's output rather than by grepping the composer's source.
+# structural-pin-ok: routing-dispatch-contract -- the body is the dispatch token the
+# shared standalone-command detector and devflow.yml's trigger gate both read.
+#
+# This block is also the structural brake on ONE specific future edit. Widening
+# the payload to the fix-loop command would mint an App token and push with it,
+# and an App-token push is not covered by GitHub's recursion guard, so it would
+# re-run CI, re-post, and loop without bound. Plain review mints no App token
+# (devflow.yml skips that step on a `/prflow:review ` command) and pushes nothing.
+PCRT="$LIB/../scripts/post-ci-review-trigger.sh"
+PCRT_SHA="0123456789abcdef0123456789abcdef01234567"
+PCRT_BODY="$(MODE=compose PR=7 HEAD_SHA="$PCRT_SHA" bash "$PCRT" 2>/dev/null)"
+PCRT_DET="$(printf '%s' "$PCRT_BODY" | bash "$LIB/../scripts/detect-standalone-command.sh")"
+
+assert_eq "pcrt: the composed body resolves to the PLAIN review command through the real detector" \
+  "command=/prflow:review" "$(printf '%s\n' "$PCRT_DET" | grep '^command=')"
+assert_eq "pcrt: the composed body carries no explicit number, so the resolver targets the event's own PR" \
+  "number=" "$(printf '%s\n' "$PCRT_DET" | grep '^number=')"
+assert_eq "pcrt: the composed body mentions no @claude (the partition invariant with Anthropic's claude.yml)" \
+  "0" "$(printf '%s' "$PCRT_BODY" | grep -c '@claude')"
+assert_eq "pcrt: the composed body carries no implement token in EITHER namespace" \
+  "0" "$(printf '%s' "$PCRT_BODY" | grep -cE '/(pr|dev)flow:implement')"
+assert_eq "pcrt: the composed body carries the SHA-keyed dedupe marker" \
+  "1" "$(printf '%s' "$PCRT_BODY" | grep -cF "<!-- prflow:ci-review-trigger sha=$PCRT_SHA -->")"
+# Negative control: the assertions above would also pass on a body that is nothing
+# but the marker, so prove the detector really is reading a command line here.
+assert_eq "pcrt: negative control — the marker alone resolves to NO command" \
+  "command=" "$(printf '%s\n' "<!-- prflow:ci-review-trigger sha=$PCRT_SHA -->" \
+                 | bash "$LIB/../scripts/detect-standalone-command.sh" | grep '^command=')"
+
+# --- the post-or-skip selection, arm by arm ---------------------------------
+# The whole reason the decision lives in a helper rather than inline in ci.yml:
+# a reordered or broken arm here posts a duplicate paid review, or silently posts
+# nothing, and inline YAML could not be driven at all.
+PCRT_SB="$(mktemp -d)"
+cat > "$PCRT_SB/gh" <<'EOS'
+#!/usr/bin/env bash
+# gh stub. A POST is recorded to $PCRT_REC and honours $PCRT_POST_RC; anything
+# else is the comment-list read, which honours $PCRT_LIST_RC and serves
+# $PCRT_LIST_OUT (the ids the helper's marker filter would have matched).
+case "$*" in
+  *"--method POST"*)
+    printf '%s\n' "$*" >> "$PCRT_REC"
+    [ "${PCRT_POST_RC:-0}" = 0 ] || { echo "HTTP 403" >&2; exit 1; }
+    printf '{"id":1}\n'; exit 0 ;;
+esac
+[ "${PCRT_LIST_RC:-0}" = 0 ] || { echo "HTTP 500" >&2; exit 1; }
+printf '%s' "${PCRT_LIST_OUT-}"
+exit 0
+EOS
+chmod +x "$PCRT_SB/gh"
+
+# Runs the helper under the stub, leaving its stdout in $PCRT_OUT and the recorded
+# POST count in $PCRT_POSTS.
+pcrt_run() {  # $@ = extra command-prefix env assignments
+  : > "$PCRT_SB/rec"
+  PCRT_OUT="$(env PCRT_REC="$PCRT_SB/rec" DEVFLOW_GH="$PCRT_SB/gh" \
+                  PR=7 HEAD_SHA="$PCRT_SHA" "$@" bash "$PCRT" 2>/dev/null)"
+  PCRT_POSTS="$(grep -c . "$PCRT_SB/rec")"
+}
+
+pcrt_run PCRT_LIST_OUT=""
+assert_eq "pcrt: no existing marker for this head → the trigger is POSTed" \
+  "1" "$PCRT_POSTS"
+assert_eq "pcrt: a successful post is annotated as a notice naming the head" \
+  "1" "$(printf '%s\n' "$PCRT_OUT" | grep -c "^::notice::ci auto-review trigger: posted the review trigger on PR #7 for $PCRT_SHA")"
+
+pcrt_run PCRT_LIST_OUT="4242"
+assert_eq "pcrt: an existing marker for THIS head → nothing is posted (per-SHA dedupe)" \
+  "0" "$PCRT_POSTS"
+assert_eq "pcrt: the already-posted arm annotates a notice, never a warning" \
+  "1-0" "$(printf '%s\n' "$PCRT_OUT" | grep -c 'already carries a trigger comment')-$(printf '%s\n' "$PCRT_OUT" | grep -c '^::warning::')"
+
+pcrt_run PCRT_LIST_RC=1
+assert_eq "pcrt: an unreadable comment list → FAIL-CLOSED, nothing is posted" \
+  "0" "$PCRT_POSTS"
+assert_eq "pcrt: the fail-closed arm warns and names the choice, so a missed review is never silent" \
+  "1" "$(printf '%s\n' "$PCRT_OUT" | grep -c '^::warning::ci auto-review trigger: could not read PR #7 comments.*fail-closed')"
+
+pcrt_run PCRT_LIST_OUT="" PCRT_POST_RC=1
+assert_eq "pcrt: a POST that fails is NEVER annotated as a fired trigger (the #408 lesson)" \
+  "0-1" "$(printf '%s\n' "$PCRT_OUT" | grep -c 'posted the review trigger')-$(printf '%s\n' "$PCRT_OUT" | grep -c 'did NOT post')"
+
+# A missing/blank head SHA cannot key the marker, so dedupe would be impossible —
+# refuse rather than post an unkeyed comment on every run.
+pcrt_run HEAD_SHA=""
+assert_eq "pcrt: an unusable head SHA → nothing is posted, with its own warning" \
+  "0-1" "$PCRT_POSTS-$(printf '%s\n' "$PCRT_OUT" | grep -c '^::warning::.*head SHA')"
+
+rm -rf "$PCRT_SB"
+
+# --- coupled-invariant pins (ci.yml ↔ this helper) --------------------------
+# The job's eligibility guards are GitHub-evaluated and therefore unreachable by
+# the suite; what IS assertable is that the two guards whose loss is silent are
+# still present. The head-repo comparison is the fork gate and it is the security
+# property of the job — it must exclude fork pull requests BEFORE any credential
+# is minted, so its removal would be invisible until a fork ran.
+PCRT_WF_CI="$LIB/../.github/workflows/ci.yml"
+devflow_module_pin_unique "pcrt: ci.yml gates the trigger job on the head repo being this repo (the fork gate)" \
+  'github.event.pull_request.head.repo.full_name == github.repository' "$PCRT_WF_CI"
+# Both, not just `test`: `lint` is not downstream of `test`, so gating on `test`
+# alone would request a review of a head whose ruff/shellcheck run was red.
+devflow_module_pin_unique "pcrt: ci.yml gates the trigger job on BOTH the test and lint jobs" \
+  'needs: [test, lint]' "$PCRT_WF_CI"

--- a/lib/test/modules/review-trigger-helpers.sh
+++ b/lib/test/modules/review-trigger-helpers.sh
@@ -3051,16 +3051,11 @@ assert_eq "pcrt: an unusable head SHA → nothing is posted, with its own warnin
 
 rm -rf "$PCRT_SB"
 
-# --- coupled-invariant pins (ci.yml ↔ this helper) --------------------------
-# The job's eligibility guards are GitHub-evaluated and therefore unreachable by
-# the suite; what IS assertable is that the two guards whose loss is silent are
-# still present. The head-repo comparison is the fork gate and it is the security
-# property of the job — it must exclude fork pull requests BEFORE any credential
-# is minted, so its removal would be invisible until a fork ran.
-PCRT_WF_CI="$LIB/../.github/workflows/ci.yml"
-devflow_module_pin_unique "pcrt: ci.yml gates the trigger job on the head repo being this repo (the fork gate)" \
-  'github.event.pull_request.head.repo.full_name == github.repository' "$PCRT_WF_CI"
-# Both, not just `test`: `lint` is not downstream of `test`, so gating on `test`
-# alone would request a review of a head whose ruff/shellcheck run was red.
-devflow_module_pin_unique "pcrt: ci.yml gates the trigger job on BOTH the test and lint jobs" \
-  'needs: [test, lint]' "$PCRT_WF_CI"
+# DELIBERATELY NOT COVERED, and the absence is the decision (the issue-#843 rule).
+# The calling job's eligibility guards — the fork gate, the draft test, the two
+# `needs.*.result` tests — are GitHub-evaluated expressions. No tool or consumer in
+# this repository reads them, the suite cannot evaluate one, and a source-presence
+# pin over them would be exactly the wording-only pin #375/#666/#810 prohibit. The
+# compensating control is the review pass that reads the workflow, not a pin. What
+# IS covered here is everything a program does read: the payload the detector parses
+# and the post-or-skip arms.

--- a/lib/test/run.sh
+++ b/lib/test/run.sh
@@ -15127,7 +15127,7 @@ echo "review/implement trigger helpers (derive-review-verdict.sh … resolve-com
 # together, or test_module_runner.py's tranche test goes RED.
 # See the module's .inventory.md for the coverage map back to these locations.
 if ! devflow_run_full_suite_module "$LIB/test/modules/review-trigger-helpers.sh" \
-  "review-trigger-helpers" 554; then
+  "review-trigger-helpers" 552; then
   printf 'ERROR: review-trigger-helpers boundary could not record its result\n'
   exit 1
 fi

--- a/lib/test/run.sh
+++ b/lib/test/run.sh
@@ -15127,7 +15127,7 @@ echo "review/implement trigger helpers (derive-review-verdict.sh … resolve-com
 # together, or test_module_runner.py's tranche test goes RED.
 # See the module's .inventory.md for the coverage map back to these locations.
 if ! devflow_run_full_suite_module "$LIB/test/modules/review-trigger-helpers.sh" \
-  "review-trigger-helpers" 538; then
+  "review-trigger-helpers" 554; then
   printf 'ERROR: review-trigger-helpers boundary could not record its result\n'
   exit 1
 fi

--- a/scripts/post-ci-review-trigger.sh
+++ b/scripts/post-ci-review-trigger.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 Daniel Radman
+# SPDX-License-Identifier: MIT
+# post-ci-review-trigger.sh — post the bare standalone review-trigger comment on a
+# pull request, at most once per head SHA.
+#
+# SOLE CALLER: the `auto_review_trigger` job in .github/workflows/ci.yml. That
+# workflow is REPO-INTERNAL — install.sh's copy loop ships only devflow.yml and
+# devflow-implement.yml, so no consumer repo has ci.yml, nothing consumer-facing
+# calls this helper, and the standing "a collaborator posts the review comment"
+# statement in the shipped docs is untouched.
+#
+# Division of labour with the calling job:
+#   * The job's `if:` decides ELIGIBILITY, entirely in GitHub-evaluated expressions
+#     so no credential is minted for an ineligible run: both CI jobs green, a
+#     non-draft `pull_request` whose head repo IS this repo (the fork gate), not
+#     dependabot, and an App configured.
+#   * This helper owns the remaining POST-or-SKIP selection. That is a branch
+#     selection over a user-visible outcome, so it lives in a script the suite can
+#     drive arm by arm rather than inline in YAML — the scripts/describe-denial-count.sh
+#     precedent CLAUDE.md names.
+#
+# CONTRACT
+#   * ALWAYS exits 0 (best-effort notification; it must never redden CI). Every
+#     no-post arm leaves a DISTINCT annotation naming the condition that fired, so
+#     a silent no-op is impossible to confuse with a posted trigger.
+#   * The idempotency read FAILS CLOSED. When the comment list cannot be
+#     established the helper does NOT post. The two costs are asymmetric: a missed
+#     notification is recoverable (a collaborator can still comment the trigger by
+#     hand — the pre-existing supported path — and the next green head fires again),
+#     while a duplicate is unrecoverable paid review spend that repeats on every
+#     workflow re-run for as long as the read stays broken. A dedupe guard that
+#     posts when it cannot verify has no bounding property at all, which is exactly
+#     the "a guard whose comparand can be absent fails open where it claims to fail
+#     closed" class CLAUDE.md warns about.
+#   * The success annotation is gated on post-issue-comment.sh's own success
+#     breadcrumb, never on its exit code — that helper is best-effort and always
+#     exits 0, so a failed POST would otherwise be annotated as a fired trigger
+#     (the review stall backstop's issue-#408 lesson).
+#
+# THE PAYLOAD IS DELIBERATELY BARE: the SHA-keyed dedupe marker, a blank line, and
+# the plain review command alone on its own line. Nothing else. devflow.yml's gate
+# substring-tests the WHOLE body, detect-standalone-command.sh requires the command
+# to be the sole content of its line, and any extra prose is a hazard rather than a
+# courtesy. It must never widen to the fix-loop command: that path mints an App
+# token and pushes with it, and an App-token push is NOT covered by GitHub's
+# recursion guard, so it would re-run CI, re-post, and loop without bound. The
+# review path mints no App token (devflow.yml's `app-token` step is skipped on a
+# `/prflow:review ` command) and pushes nothing.
+#
+# Inputs (env):
+#   PR        the pull-request number the comment goes on (required, numeric)
+#   HEAD_SHA  the reviewed head commit (required, lowercase hex 7..40) — it keys
+#             the marker, so dedupe is per-SHA and a new head always re-notifies
+#   MODE      `post` (default) or `compose`
+#   GH_TOKEN  consumed by gh; the caller sets it to the minted App token
+#
+# MODE=compose writes ONLY the composed body to stdout and touches no network. It
+# is the seam the suite drives the payload contract through, so the body the test
+# inspects is byte-identical to the body a real run posts.
+set -uo pipefail
+
+_PCRT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# gh binary: the single-source execution-verified resolver; an explicit DEVFLOW_GH
+# still wins with no probe, so the suite's stubs are untouched. Guarded source so a
+# partial copy degrades with a breadcrumb instead of aborting under `set -u`.
+# shellcheck source=../lib/resolve-gh.sh
+. "$_PCRT_DIR/../lib/resolve-gh.sh" \
+  || echo "devflow: resolve-gh.sh could not be sourced from ../lib relative to ${BASH_SOURCE[0]} — using bare 'gh' (set DEVFLOW_GH to override)" >&2
+if type devflow_resolve_gh >/dev/null 2>&1; then
+  : "${DEVFLOW_GH:=$(devflow_resolve_gh)}"
+else
+  # Partial-copy degradation only: the `:-` form is the sanctioned fallback shape
+  # — the #245 peer-completeness pin forbids a bare `:=gh` default.
+  DEVFLOW_GH="${DEVFLOW_GH:-gh}"
+fi
+
+PR="${PR:-}"
+HEAD_SHA="${HEAD_SHA:-}"
+MODE="${MODE:-post}"
+
+# Annotation sink. In `post` mode the runner parses workflow commands off this
+# step's stdout, so annotations go there. In `compose` mode stdout is reserved for
+# the composed body — a breadcrumb mixed into it would corrupt the payload the
+# caller is asking for — so they go to stderr instead.
+_note() {  # $1=notice|warning  $2=message
+  if [ "$MODE" = compose ]; then
+    printf 'devflow: %s: %s\n' "$1" "$2" >&2
+  else
+    printf '::%s::%s\n' "$1" "$2"
+  fi
+}
+
+# Validate BEFORE composing. HEAD_SHA is interpolated into the marker and into the
+# jq filter that reads the comment list, so a non-hex value is refused rather than
+# embedded: it keeps the marker's shape a machine-comparable constant and leaves
+# the filter free of anything jq or the shell would treat as special.
+case "$PR" in
+  ''|*[!0-9]*)
+    _note warning "ci auto-review trigger: PR number '$PR' is missing or non-numeric; no trigger comment posted."
+    exit 0 ;;
+esac
+if ! [[ "$HEAD_SHA" =~ ^[0-9a-f]{7,40}$ ]]; then
+  _note warning "ci auto-review trigger: head SHA '$HEAD_SHA' is missing or not a lowercase hex commit id; no trigger comment posted for PR #$PR."
+  exit 0
+fi
+
+# The dedupe marker. Keyed on the head SHA, so a re-run over the SAME head is
+# suppressed while every NEW green head notifies again — the deliberate design,
+# not a first-time-only latch.
+MARKER="<!-- prflow:ci-review-trigger sha=$HEAD_SHA -->"
+
+# Compose the body. One function so `compose` mode and the POST path can never
+# drift into two different payloads.
+_compose_body() {
+  printf '%s\n\n' "$MARKER"
+  printf '/prflow:review\n'
+}
+
+if [ "$MODE" = compose ]; then
+  _compose_body
+  exit 0
+fi
+
+# --- Idempotency read (fail-closed) -----------------------------------------
+# `{owner}/{repo}` placeholders, which gh fills from the git remote, NOT an
+# interpolated $GITHUB_REPOSITORY: this file lives under scripts/ and so is a
+# surface that can run outside Actions, where that variable has no producer and
+# the path would collapse to `repos//issues/…` while gh wrote the HTTP error body
+# to stdout (issue #664; lib/test/lint-gh-api-repo-path.py enforces it here).
+# --paginate so a long-lived PR whose marker sits past page one is still seen.
+# The filter emits one comment id per hit; a page with no hit emits nothing.
+LIST_ERR="$(mktemp 2>/dev/null || echo /dev/null)"
+if ! LIST_OUT="$("$DEVFLOW_GH" api --paginate "repos/{owner}/{repo}/issues/${PR}/comments" \
+      --jq ".[] | select((.body // \"\") | contains(\"$MARKER\")) | .id" 2>"$LIST_ERR")"; then
+  _note warning "ci auto-review trigger: could not read PR #$PR comments to check for an existing trigger ($(tr '\n' ' ' < "$LIST_ERR")); NOT posting (fail-closed — a duplicate standalone review is unrecoverable spend, a missed one is not)."
+  [ "$LIST_ERR" = /dev/null ] || rm -f "$LIST_ERR"
+  exit 0
+fi
+[ "$LIST_ERR" = /dev/null ] || rm -f "$LIST_ERR"
+
+# Decide with bash builtins only. `tr`/`sed`/`wc` are not preflight-guaranteed, and
+# a missing one would empty the pipeline and silently flip this selection to
+# "post" — the un-guaranteed-tool trap CLAUDE.md names. (The `tr` above is inside a
+# breadcrumb, where a missing tool only empties a diagnostic.)
+ALREADY=false
+while IFS= read -r _id; do
+  case "$_id" in
+    ''|*[!0-9]*) : ;;
+    *) ALREADY=true ;;
+  esac
+done <<EOF
+$LIST_OUT
+EOF
+
+if [ "$ALREADY" = true ]; then
+  _note notice "ci auto-review trigger: PR #$PR already carries a trigger comment for $HEAD_SHA; nothing to post."
+  exit 0
+fi
+
+# --- Post -------------------------------------------------------------------
+# Body through a FILE so newlines never traverse shell quoting. mktemp is guarded
+# distinctly: an unguarded failure would leave BODY_FILE empty and misdiagnose as a
+# POST failure.
+BODY_FILE="$(mktemp)" || {
+  _note warning "ci auto-review trigger: mktemp failed; could not compose the trigger comment for PR #$PR (nothing posted)."
+  exit 0
+}
+_compose_body > "$BODY_FILE"
+
+POST="$_PCRT_DIR/post-issue-comment.sh"
+if [ ! -f "$POST" ]; then
+  _note warning "ci auto-review trigger: post-issue-comment.sh absent at $POST; trigger comment not posted for PR #$PR."
+  rm -f "$BODY_FILE"
+  exit 0
+fi
+# post-issue-comment.sh is best-effort and ALWAYS exits 0, so its exit code is not a
+# success signal. Gate the success annotation on its exact breadcrumb instead.
+POST_OUT="$(bash "$POST" "$PR" "$BODY_FILE" 2>&1)"
+printf '%s\n' "$POST_OUT"
+rm -f "$BODY_FILE"
+if printf '%s\n' "$POST_OUT" | grep -qxF "devflow: posted comment on #$PR"; then
+  _note notice "ci auto-review trigger: posted the review trigger on PR #$PR for $HEAD_SHA."
+else
+  _note warning "ci auto-review trigger: the review trigger comment did NOT post on PR #$PR for $HEAD_SHA; no review was requested."
+fi
+exit 0

--- a/scripts/workflow-flight-recorder-registry.json
+++ b/scripts/workflow-flight-recorder-registry.json
@@ -53,7 +53,7 @@
     },
     "review-trigger-helpers": {
       "path": "lib/test/modules/review-trigger-helpers.sh",
-      "minimum_assertions": 538,
+      "minimum_assertions": 554,
       "description": "Focused review and implement trigger-helper contracts: derive-review-verdict.sh and derive-review-preconditions.sh (both RETAINED and still covered after issue #936 withheld the auto PR-triggered review tier — their workflow caller is gone but an installed consumer copy still resolves them, so the helpers ship and their sections stay live), parse-engine-error.sh, surface-execution-diagnostics.sh (#329) with its workflow wiring (#331), the execution-transcript artifact config key and scrub/gate hardening (#409), resolve-implement-trigger.sh, dedupe-implement-run.sh, authorize-actor.sh, detect-standalone-command.sh and resolve-command-trigger.sh"
     },
     "review-stall-backstop": {

--- a/scripts/workflow-flight-recorder-registry.json
+++ b/scripts/workflow-flight-recorder-registry.json
@@ -53,7 +53,7 @@
     },
     "review-trigger-helpers": {
       "path": "lib/test/modules/review-trigger-helpers.sh",
-      "minimum_assertions": 554,
+      "minimum_assertions": 552,
       "description": "Focused review and implement trigger-helper contracts: derive-review-verdict.sh and derive-review-preconditions.sh (both RETAINED and still covered after issue #936 withheld the auto PR-triggered review tier — their workflow caller is gone but an installed consumer copy still resolves them, so the helpers ship and their sections stay live), parse-engine-error.sh, surface-execution-diagnostics.sh (#329) with its workflow wiring (#331), the execution-transcript artifact config key and scrub/gate hardening (#409), resolve-implement-trigger.sh, dedupe-implement-run.sh, authorize-actor.sh, detect-standalone-command.sh and resolve-command-trigger.sh"
     },
     "review-stall-backstop": {


### PR DESCRIPTION
## What

Adds an `auto_review_trigger` job to `.github/workflows/ci.yml`. When CI goes green on a **non-draft, same-repository** pull request, it posts the bare review-trigger comment under a downscoped GitHub App token, so the standalone review this repo already expects before merge no longer waits on a human remembering to type it.

**The mechanism is the App token, and that is the whole trick.** A comment posted with the built-in `GITHUB_TOKEN` does not fire workflows; one posted with a GitHub App installation token does. This repo already ships that pattern — `scripts/post-review-backstop-comment.sh` posts a review re-trigger under a minted App token from `devflow.yml`'s stall backstop — and this job follows its shape.

**Consumers are unchanged, and no documentation moves.** `install.sh`'s copy loop is `for w in devflow devflow-implement`, so `ci.yml` is not shipped: no consumer repository gains an auto-trigger, nothing consumer-facing calls the new helper, and the standing "a collaborator comments the trigger" statement stays literally true in every doc that makes it.

## Cost, accepted deliberately

- Fires on **every green head**, not just the first and not only on red→green transitions.
- Deduped only at an **identical head SHA**, via a paginated SHA-keyed marker read over the PR's comments.
- Replayed against a real busy PR's history that is roughly eight standalone reviews in an afternoon.

That was weighed and accepted before this was written. A reviewer's HEAD is the unit that matters, and a review of a superseded commit is worth less than the spend it saved. Please do not "fix" this into once-per-PR without revisiting that decision.

## The guards

All GitHub-evaluated, so an ineligible run reaches no shell and — more importantly — **mints no credential**:

```
needs.test.result == 'success' && needs.lint.result == 'success' &&
github.event_name == 'pull_request' &&
github.event.pull_request.draft == false &&
github.event.pull_request.head.repo.full_name == github.repository &&
github.actor != 'dependabot[bot]' &&
vars.DEVFLOW_APP_ID != ''
```

- **`needs: [test, lint]` — both.** `lint` is not downstream of `test`; `ci.yml`'s only `needs:` is `test: needs: [shard]` (re-verified on current `main`). Gating on `test` alone would ask for a review of a head whose `ruff` or ShellCheck run was red.
- **The head-repo comparison is the fork gate and is the job's actual security property.** It excludes fork pull requests *before* the token is minted, rather than relying on secrets being withheld from fork runs. Dependabot's branches live in this repo and satisfy that test, so its exclusion is separately load-bearing.
- **The `pull_request` test is not cosmetic.** This workflow also runs on pushes to `main`, where `github.event.pull_request` is null and GitHub's numeric coercion would read `null == false` as satisfied.
- **`pull-requests: write` is deliberately not added at *workflow* level** — that would widen `shard`/`test`/`lint`, which run arbitrary PR code. It is declared at **job** level, for a reason that only surfaced when the suite went red; see "Two failures the first head caught" below. It is not what authorizes the POST: an App installation token ignores the job's `permissions:` block, so the mint's `permission-*` inputs remain the sole least-privilege enforcement on the credential actually used.

## Design tension 1 — checkout vs. the extract-branch-selecting-shell convention

**Resolved in favour of the checkout.** `CLAUDE.md` requires that inline shell in a workflow which *selects a branch* be extracted into a `scripts/*.sh` helper the suite can drive arm by arm (the `scripts/describe-denial-count.sh` precedent), and post-or-skip is exactly such a selection. A checkout-less job cannot have a helper on disk, and the alternative — an untestable branch chain inline in YAML, whose failure mode is either a duplicate paid review or a silent no-post — is the specific thing that convention exists to prevent. The RED proof below is only possible because the helper exists.

**The trust consideration, stated plainly.** `actions/checkout` under `pull_request` checks out the PR's own code, so a collaborator's branch controls the helper that then runs in a job holding a `pull-requests: write` App token. The fork gate bounds "collaborator" to people who already have push access to this repository, and the minted token is **strictly narrower** than the access they already hold — there is no escalation to reach for, and a collaborator who wanted to post that comment could simply post it. **I consider this acceptable.**

Checking out the base ref instead (the `devflow-runner.yml` `baseprovision` pattern) would close even that residue, and I rejected it for a concrete reason: on the introducing PR — and on every future PR that edits this helper — the base ref does not contain the helper, so the change could never be exercised by the pull request that makes it. That is a worse property than the residue it removes.

`persist-credentials: false`, because nothing here talks to git over the network (`gh` authenticates from `GH_TOKEN`), so the checkout leaves no credential for later steps to inherit.

**One consequence worth flagging, because it inverts the spec I was given.** The `.github/workflows/` entry in `lib/test/lint-gh-api-repo-path.py`'s `EXCLUDED_PREFIXES` is justified by checkout-less jobs having no remote for `{owner}/{repo}` to resolve from. **My job does not match that rationale** — it has a checkout and therefore a remote. And the helper lives under `scripts/`, which is *not* excluded, so an interpolated `$GITHUB_REPOSITORY` path there would turn the suite RED by design. Both REST calls therefore use the `{owner}/{repo}` placeholders, which is the stronger `#664` convention and is what the existing `scripts/post-issue-comment.sh` already does. The POST routes through that helper (`gh api --method POST`, `-F body=@file` — never `gh pr comment` porcelain, never `-f body=@file`).

## Design tension 2 — the job's name

`scripts/summarize-ci-checks.sh` renders every job's name and conclusion into the engine-ground-truth block of **every** review prompt, and this job reads `skipped` on most runs (draft PRs, fork PRs, pushes to `main`). In a repo whose governing rule is that a skip is never laundered into a pass, the name has to make a skipped row self-evidently a notification that was not sent rather than a verification that did not run. It is:

```
auto-review notification (not a check; skipped = not sent)
```

which renders as `auto-review notification (not a check; skipped = not sent): skipped`. ASCII only, because that renderer strips non-printable-ASCII from names as a security control.

## Fail-open vs fail-closed on the idempotency read

**Fail CLOSED.** An unresolvable comment read does not post, and warns loudly naming the choice.

The costs are asymmetric in a way that only points one direction. A **missed** notification is recoverable: a collaborator can still comment the trigger by hand — the pre-existing, still-documented supported path — and the next green head fires again by itself. A **duplicate** is unrecoverable paid review spend, and under a *persistent* read failure it repeats on every workflow re-run for as long as the failure lasts.

The decisive argument is structural, though: the SHA marker is the only thing bounding this job's spend, and a dedupe guard that posts when it cannot verify has no bounding property at all — precisely the "a guard whose comparand can be absent fails open exactly where it claims to fail closed" class `CLAUDE.md` names. Failing closed is loud (a `::warning::` naming the cause), never silent, per the `#456` rule that a skip is never laundered into a pass.

Note this is the *opposite* choice from `devflow.yml`'s `review_dedupe`, which fails open on purpose. That is not an inconsistency: there, failing open costs a duplicate of a review a **human asked for**, and failing closed would swallow that human's request. Here nobody asked, so the direction that spends nothing wins.

## Loop safety — verified, not assumed

Confirmed on current `main`: `devflow.yml`'s `app-token` mint carries `if: ${{ vars.DEVFLOW_APP_ID != '' && !startsWith(needs.gate.outputs.command, '/prflow:review ') }}`, and `resolve-command-trigger.sh` emits `command=<cmd> <n>`, so the plain-review path **skips** the mint. Its checkout token falls back to `secrets.GITHUB_TOKEN` and its `github_token` resolves to the read-only reviewer token (`permission-contents: read`). The review path pushes nothing; even a push it somehow made would use `GITHUB_TOKEN` and be swallowed by GitHub's recursion guard — the same guard `ci.yml`'s own `on:` comment already depends on.

The fix-loop command is the opposite on both counts: it mints the App token and pushes with it, outside the recursion guard. Widening the payload to it would re-run CI, re-post, and loop without bound at real cost. **That is why the one test exists.**

## The test (one, and its RED proof)

`lib/test/modules/review-trigger-helpers.sh` feeds the composed body through the **real** `scripts/detect-standalone-command.sh` and asserts it resolves to the plain review command, carries no explicit number, mentions no `@claude`, and carries no implement token in either namespace — plus a negative control proving the detector is really reading a command line, and the post-or-skip arms. This is permitted under the `#810`/`#843` policy because the body is a **machine-consumed contract** (parsed by that detector, substring-tested by `devflow.yml`'s gate `if:`), not prose; the block is declared `# structural-pin-ok: routing-dispatch-contract`.

RED proof — each defect planted separately against the finished code, then reverted:

| Planted defect | Result |
| --- | --- |
| Payload widened to the fix-loop command | `FAIL pcrt: the composed body resolves to the PLAIN review command through the real detector` |
| Read failure falls through and posts anyway (fail-open) | `FAIL pcrt: an unreadable comment list -> FAIL-CLOSED, nothing is posted` |

Restored: `552 passed, 0 failed`. The module's assertion floor moved in both coupled sites (the registry and the `lib/test/run.sh` call-site literal), and `lib/test/modules/coverage-map.json` gained the new helper's ownership row (`coverage_map_guard.py` was RED without it).

**Deliberately not covered, and the absence is the decision.** I first wrote two extra pins over `ci.yml`'s `if:` — one on the fork gate, one on `needs: [test, lint]` — and the `#810` red-on-removal retirement manifest correctly turned RED on them: they are source-presence pins over content **no tool in this repository reads** (GitHub Actions evaluates the expression), which is exactly the wording-only pin `#375`/`#666`/`#810` prohibit, and adjudicating them would have asked the delta-gated ledger to bless a guard nothing needed. **Removed.** So the job's eligibility guards — the fork gate included — carry no automated coverage, per the recorded `#843` decision; the compensating control is the review pass that reads the workflow. Stating it rather than laundering it: **deleting the fork gate would not turn this suite red.**

## Two failures the first head caught, and what they taught

Worth reading, because one of them is a trap in this repo's own lint that the next editor will otherwise hit two jobs away from their edit.

**1. `#312` endpoint-permission lint, 3 violations.** Two were manufactured by *prose*. That lint attributes every `<name>.sh` basename it finds in a job's lines — **comment lines included** — to that job's permission requirement, and a comment block sitting *above* a job key parses as part of the **previous** job. Naming the CI-signal summarizer in my comment block above `auto_review_trigger:` therefore required `checks` and `actions` of the **`lint`** job, which calls neither. Reworded to describe that helper instead of naming its file, with an in-place note so this is not rediscovered.

The third violation was **genuine**, and it is the one place I diverge from the brief. The job really does invoke the issues-comments family through its helper, so `pull-requests: write` is now declared — at **job** level, never workflow level, so `shard`/`test`/`lint` are untouched and the brief's actual constraint is honored exactly. It is *not* what authorizes the POST (the minted App token ignores the permissions block, as the brief says), but this repo's own lint requires a job to declare every endpoint family it invokes, and the declaration is the honest fallback posture if the mint were ever removed. It is safe in a job that checks out PR code because the built-in `GITHUB_TOKEN` never reaches that code: the checkout persists no credential and no step puts the token in the environment — only the already-downscoped App token is in the helper's env.

**2. `#810` red-on-removal retirement manifest.** The two prohibited pins described above. Removed rather than adjudicated.

Both failures reproduced identically on CI and at the desk.

## Changeset — yes, deliberately

`CLAUDE.md` lists `scripts/` and workflows in the engine surface (changeset required) but exempts internal-only changes. This sits on the seam: `ci.yml` ships to no consumer, yet `scripts/post-ci-review-trigger.sh` is a new file inside the vendored payload, so a consumer who upgrades receives bytes they did not have. A reviewer applying the surface rule mechanically would FAIL a changeset-less PR, and the cost of including one is a single small file — so `.changeset/ci-auto-review-on-green.md` is included at `bump: patch`, and its prose says explicitly that the behavior is repo-internal and consumer-inert. Flagging it here so the Phase 3 gate is not a surprise in either direction.

## Related issues — read, not touched

- **#990** (the consumer-facing 51-AC proposal) is left **open**. This is a strict subset of it; its consumer half — a documented snippet plus the `allowed_bots` precondition — still has value. Its body is partly stale (pre-rename path references); not edited.
- **#1030** (verdict identity) and **#1026** are open and interact with auto-triggering; nothing changed there. One interaction observed and worth recording: `devflow.yml`'s `review_dedupe` Candidate-C signal (#989) suppresses a `/prflow:` review request while a review of the same PR is already in flight, so back-to-back green heads are damped by an existing mechanism rather than each guaranteeing a full review.

## Verification

- `actionlint`: 10 findings, byte-identical to the pre-change baseline (all pre-existing `shellcheck reported issue` info/style notes in `devflow-runner.yml`, `devflow.yml`, `matcher-probe.yml`); `actionlint .github/workflows/ci.yml` alone is clean.
- ShellCheck (`lib` + `scripts`, and `lib/test/run.sh` with `--extended-analysis=false` under 0.11.0): clean.
- `ruff`: all checks passed.
- `lint-gh-api-repo-path.py` (271/271 files), `lint-tree-enumeration.py` (90/90), `lint-carveout-guard.py`, `coverage_map_guard.py`, `pin-corpus-lint.py mutation-routing-worktree`, `test_red_on_removal_retirement_manifest.py`, and the `#312` endpoint-permission lint driven standalone (0 violations): all clean.
- Full local suite, run as a direct leading token with `SIGINT` restored to `SIG_DFL` in a new session, read from the log's own trailing summary rather than a task exit code:

  ```
  15201 passed, 0 failed
  ```

  Exit code 0, and **zero skipped** — the renderer prints `N passed, M failed, K skipped` plus one line per skip whenever `K > 0`, and there is no such clause and no `NOTE` line in the log.

## It triggered itself — the live test passed

`pull_request` runs the PR's own copy of the workflow, so this PR exercised the feature end to end:

- CI green on `09281630` at 22:35, all six jobs `success` including `auto-review notification (not a check; skipped = not sent)`.
- `prflow-implementer[bot]` posted, at 22:35:16Z, exactly the composed payload and nothing else:

  ```
  <!-- prflow:ci-review-trigger sha=0928163014de449560369bd115eb287b6055edac -->

  (the plain review command, alone on its own line)
  ```

- `devflow.yml` run `30721588757` started **2 seconds later**, at 22:35:18Z, on the `issue_comment` event — confirming the premise the whole design rests on: an App-installation-token comment fires workflows where a `GITHUB_TOKEN` one does not.
- `review_dedupe` did not suppress it; `gate` authorized the bot (`prflow-implementer` is already in `prflow.allowed_bots`, so no config change was needed and issue #593's grant-timing bootstrap never bit).
- **Loop safety confirmed live, not just by reading:** in the `command` job, `Mint workflow-capable token (optional): skipped`. The write-capable App token is never minted on this path; the run falls through to the read-only `DevFlow-Reviewer` token. The review proceeded and posts no commits.

On the first head the job did what it should have: `lib + python tests` was red, so it evaluated to `skipped` and minted nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
