### PR TITLE
fix: state that agent-authored prose is not hard-wrapped

### DIFF
--- a/.changeset/no-hard-wrap-agent-authored-prose.md
+++ b/.changeset/no-hard-wrap-agent-authored-prose.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+---
+
+### Fixed
+
+- The shared writing standard now states that agent-authored prose is not hard-wrapped: each paragraph and bullet is one line and the renderer wraps it. Drafted issue bodies were arriving with prose broken at a fixed column, which GitHub renders as ragged short lines and which makes every later edit rewrap the whole paragraph. Nothing in the write path reflowed the bytes — no rule existed in either direction, so the drafting agent's habit decided it.

--- a/lib/writing-standard.md
+++ b/lib/writing-standard.md
@@ -23,6 +23,8 @@ Write for a competent developer who does not know this codebase. They understand
 
 5. **Define a coined term at first use, and prefer a standard term.** When a word already exists for the thing, use it rather than inventing one. When no word exists and you must coin one, define it where it first appears. Do not invent ALL-CAPS taxonomies, and do not attach serial tags such as `R7`, `META`, or `CORRECTION` — the surrounding structure already classifies the content.
 
+6. **Do not hard-wrap.** Write each paragraph and each bullet as one line and let the renderer wrap it. GitHub and every other markdown renderer reflows prose to the reader's width, so a hand-inserted fixed-column break survives into the rendered output as a ragged short line, and it makes every later edit rewrap the whole paragraph. Line breaks inside a fenced code block are content rather than wrapping, so leave those alone.
+
 ## Machine-consumed structure comes first
 
 Some of this content is parsed by tools, not only read by people. An `## Acceptance Criteria` heading, a `- [ ]` checkbox row, an HTML marker block, and a literal cross-reference token such as `PR #<N>` are read by downstream code that matches them exactly. These structures are exempt from the rules above and survive verbatim. When a rule here would push you to reword one of them, the structure wins.


### PR DESCRIPTION
## Problem

Drafted issue bodies have been arriving hard-wrapped at a fixed column. Issue #1104's prose lines sit at 96–101 characters; #1103 and #1105 are the same. GitHub reflows markdown prose to the reader's width, so a hand-inserted break renders as a ragged short line, and any later edit rewraps the whole paragraph.

## Root cause: authoring habit, not a tool

Nothing in the write or staging path reflows the draft bytes, and no rule existed anywhere in either direction.

- `git grep` for `textwrap` / `fold` / `fmt -w` / `COLUMNS` across `scripts/`, `lib/`, `skills/` and `.github/` returns no hit on any drafting or posting path — the only matches are test helpers and unrelated TSV column tuples.
- `issue-audit-state.py`'s `emit-body` reads the canonical draft with `Path(source).read_bytes()` and writes it with `sys.stdout.buffer.write(body)`. It is byte-exact by construction, which is what the recorded body digest attests.
- The wrap **width varies**: ~84–90 in issue #950, ~96–101 in #1103/#1104/#1105, ~104 in #1090. A tool wrapping at a fixed column would produce one width.
- Wrapped and unwrapped issues are **interleaved within minutes**: #1073 (18:53) is wrapped, #1076 (18:55) is not; #1049 (04:23) is wrapped, #1051 (04:24) is not. No commit lands between them.
- It is also not new. #950 (2026-07-30) is wrapped at ~85, which predates the shared writing standard entirely. What changed recently is only how often it happens.

So the cause is (a) from the brief: a drafting habit with nothing prohibiting it. The repo's own reference files — `skills/create-issue/references/issue-template.md`, the skill bodies — are themselves hard-wrapped at ~85 columns, which is the house style a drafter sees while composing.

## Fix

One rule added to `lib/writing-standard.md`, the shared prose standard that `/prflow:create-issue` already reads at its compose point ("Before composing the draft prose, read the shared writing standard … and follow it"). Placing it there rather than in the skill keeps it single-sourced and fixes the same class for the other surfaces that take the same read — PR descriptions, review verdict reports, the docs family, retrospective issues.

The rule scopes itself to prose and explicitly exempts line breaks inside fenced code blocks, so a drafter does not unwrap a shell snippet. `lib/writing-standard.md` is `non_code_exempt` in `coverage-map.json` and carries no test pin, so nothing else needed reconciling.

No test is added: this is agent-executed prompt prose whose only reader is the runtime agent, which under the recorded decision in `CLAUDE.md` (#843, generalised by #876) carries no automated regression coverage by design, and a wording-only pin is prohibited by #375/#666/#810.

## Deliberately left alone

- The ~85-column hard wrapping of `issue-template.md` and the skill bodies themselves. Reflowing them is a large, purely cosmetic diff across the create-issue bundle and would collide with concurrent work; it is a separate change if wanted.
- `skills/create-issue/SKILL.md` and the `references/` routing table are untouched, so the marker contract needs no reconciliation.

## Concurrency note

Two other agents are working right now — one on CI for PR #1101 (`prflow/issue-1050`), one implementing issue **#1104, which is itself about `/prflow:create-issue` Step 3.6 staged writes** and may touch `skills/create-issue/`. This PR deliberately touches neither `skills/create-issue/` nor `scripts/issue-audit-state.py`, so it should not conflict with either.

## Verification

- `lib/test/run-module.sh create-issue-contract` — 221 passed, 0 failed
- `git ls-files '*.sh' | grep -v '^lib/test/' | xargs -r shellcheck --severity=warning -e SC1091` — clean
- `shellcheck --severity=warning -e SC1091 --extended-analysis=false lib/test/run.sh` (ShellCheck 0.11.0) — clean
- `git ls-files '*.py' | xargs -r ruff check` — All checks passed
- Full suite via `lib/test/run-parallel.sh` — see the follow-up comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)
