### PR TITLE
Resolve cloud implement plugin root to the vendored subtree (#1049) — redo with the marketplace path spelling corrected

### DIFF
--- a/.changeset/issue-1049-vendored-marketplace-resolution.md
+++ b/.changeset/issue-1049-vendored-marketplace-resolution.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: Fixed
+---
+
+- **This repository's cloud implement run now resolves the plugin root to the vendored subtree, matching every consumer.** The repo-root marketplace sources the `prflow` plugin at `./`, so this repo's cloud implement run resolved `$CLAUDE_SKILL_DIR` to `<workspace>/skills/<name>` while every consumer resolves it from `.prflow/vendor/prflow` — leaving the shipped helper-path shape with no coverage here. The `claude` job now composes a job-local marketplace rooted at `./.prflow/vendor` (via `scripts/compose-vendor-marketplace.sh`) and swaps the repo-root `./` marketplace entry for it, implement tier only. The tracked `.claude-plugin/marketplace.json` and the baked marketplace baseline literal are untouched; the manual-command and review tiers keep `./`. The composition degrades on a partial/absent vendored tree with a `::warning::` naming `prflow_version`. This supersedes the reverted first attempt, which emitted the entry as a bare relative path and was rejected by `claude-code-action`'s marketplace-input validator; the emitted entry is now normalized to the `./`-prefixed local-path form the action accepts. (#1049)

--- a/.github/workflows/devflow-implement.yml
+++ b/.github/workflows/devflow-implement.yml
@@ -34,7 +34,11 @@ run-name: "DevFlow implement (issue ${{ github.event.issue.number }})"
 # flows in devflow.yml, without inflating every command's cost.
 #
 # Keep the plugin_marketplaces, plugins, and claude_args sections in sync with
-# devflow.yml so the skill surface is identical across listeners.
+# devflow.yml so the skill surface is identical across listeners. ONE deliberate
+# exception (issue #1049): the plugin_marketplaces action INPUT is consumed from the
+# implement-only `vendor_marketplace` step, which resolves the prflow plugin root to the
+# vendored subtree — do NOT "re-sync" it back to steps.plugins. The skill surface stays
+# identical; only the resolution root differs.
 
 on:
   issue_comment:
@@ -1038,6 +1042,59 @@ jobs:
             fi
           fi
 
+      # Resolve the prflow plugin root to the VENDORED subtree (issue #1049) — the
+      # implement tier ONLY (devflow.yml and devflow-runner.yml deliberately keep the
+      # repo-root `./`). The composed marketplace list from the step above registers
+      # `devflow-marketplace` from the repo-root `./`: the tracked marketplace.json
+      # sources `prflow` at `./`, so here $CLAUDE_SKILL_DIR resolves to
+      # <workspace>/skills/<name> and the portable helper anchor lands at the repo root.
+      # A CONSUMER instead resolves the same shipped bytes from `.prflow/vendor/prflow`.
+      # This step swaps the `./` marketplace entry for a job-local marketplace rooted at
+      # `./.prflow/vendor` (written by the helper, `prflow` sourced at `./prflow`), so the
+      # anchor lands under `.prflow/vendor/prflow/scripts/` here too — the shape this
+      # repo emits becomes the shape a consumer emits, and a denial here is a denial
+      # there. It leaves the tracked marketplace.json AND the baked baseline literal
+      # untouched (issue #1049 constraints): only this composed, job-local list is
+      # rewritten, and `plugins` passes through steps.plugins unchanged. The composed-
+      # vs-degraded branch selection lives in compose-vendor-marketplace.sh, driven by
+      # lib/test/run.sh (the describe-denial-count.sh extraction convention); the outer
+      # file-absent guard is the #505-class vendored-helper skew arm and names
+      # prflow_version, mirroring the compose step's HELPER guard. Best-effort: the helper
+      # never hard-fails (always exits 0) and every non-clean path is audited (never a
+      # silently-wrong resolution). THE `./` PREFIX ON THE EMITTED ENTRY IS LOAD-BEARING:
+      # claude-code-action validates every plugin_marketplaces entry and rejects a bare
+      # relative path outright (`Invalid marketplace URL format`), which broke every cloud
+      # implement run in this repo when PR #1137 first shipped this step; the helper
+      # normalizes it, and lib/test/run.sh asserts the emitted value satisfies the
+      # action's local-path predicate. The step itself runs under `set -euo pipefail`, so a
+      # mktemp/output-write failure would fail loudly (never silently) — consistent with
+      # the compose step above, which likewise mktemps under set -euo.
+      - name: Resolve plugin root to the vendored subtree (issue #1049)
+        id: vendor_marketplace
+        env:
+          COMPOSED_MK: ${{ steps.plugins.outputs.plugin_marketplaces }}
+        run: |
+          set -euo pipefail
+          VENDORMK=.prflow/vendor/prflow/scripts/compose-vendor-marketplace.sh
+          MKF="$(mktemp)"; printf '%s\n' "$COMPOSED_MK" > "$MKF"
+          if [ -f "$VENDORMK" ]; then
+            bash "$VENDORMK" "$MKF" .prflow/vendor \
+              || echo "::warning::devflow compose-vendor-marketplace.sh failed (rc≠0); the prflow plugin resolves from the repo-root marketplace (./)."
+          else
+            echo "::warning::devflow compose-vendor-marketplace.sh not found at $VENDORMK — a pinned prflow_version predating issue #1049 running an upgraded workflow; the prflow plugin resolves from the repo-root marketplace (./). Bump prflow_version in .prflow/config.json."
+          fi
+          # Re-read the (possibly transformed) list via bash builtins (guard-class 2 —
+          # no cat/tr/sed/wc/cut/head for the emitted marketplace list). Blank lines are
+          # dropped deliberately, so an empty entry never reaches plugin_marketplaces.
+          OUT=""
+          while IFS= read -r mkline || [ -n "$mkline" ]; do
+            [ -z "$mkline" ] && continue
+            OUT="${OUT:+$OUT$'\n'}$mkline"
+          done < "$MKF"
+          rm -f "$MKF"
+          vdelim="MKV_EOF_$(date +%s%N)_$$"
+          { printf 'plugin_marketplaces<<%s\n' "$vdelim"; printf '%s\n' "$OUT"; printf '%s\n' "$vdelim"; } >> "$GITHUB_OUTPUT"
+
       # AC13 boundary 2 (issue #537): record the "Claude job provisioning complete"
       # startup checkpoint immediately before the action, AFTER runtime provisioning
       # and plugin composition, so its timestamp marks the actual action boundary.
@@ -1212,7 +1269,11 @@ jobs:
           # baked baseline (byte-identical across the three call sites — run.sh
           # pins it) PLUS the entries .claude/settings.json declares. Kept in sync
           # with devflow.yml so both listeners expose the same skill surface.
-          plugin_marketplaces: ${{ steps.plugins.outputs.plugin_marketplaces }}
+          # Consumed here from the `vendor_marketplace` step (issue #1049), which
+          # post-processes that composed list so `devflow-marketplace` resolves from
+          # the vendored subtree instead of the repo-root `./` — implement tier only;
+          # devflow.yml/devflow-runner.yml still consume steps.plugins directly.
+          plugin_marketplaces: ${{ steps.vendor_marketplace.outputs.plugin_marketplaces }}
 
           # code-review@ and claude-md-management@ are ambient-command conveniences (the
           # /code-review and /revise-claude-md slash commands), NOT engine dependencies —

--- a/docs/cloud-allowlist.md
+++ b/docs/cloud-allowlist.md
@@ -752,6 +752,45 @@ and the portable anchor's `/../../scripts/` lands at the repository root, never 
 granted `.prflow/vendor/prflow/scripts/` subtree. Both shapes were granted in
 response, for each of the 25 helpers.
 
+**Issue #1049 closed this resolution fidelity gap for the implement tier.** The
+observation above — this repo's cloud implement run resolving `$CLAUDE_SKILL_DIR` to
+`<workspace>/skills/<name>` while every consumer resolves the same shipped bytes from
+`.prflow/vendor/prflow` — meant the shipped `.prflow/vendor/prflow/scripts/` helper-path
+shape had **no coverage in this repo** (the #824 fidelity gap): a denial a consumer
+would hit was invisible here. `devflow-implement.yml`'s `claude` job now runs an
+implement-tier-only `vendor_marketplace` step (`scripts/compose-vendor-marketplace.sh`)
+that composes a **job-local** marketplace rooted at `./.prflow/vendor` (plugin `prflow`
+sourced at `./prflow`) and swaps the repo-root `./` entry in the composed marketplace
+list for it, so this repo's implement run now resolves `$CLAUDE_SKILL_DIR` to
+`<workspace>/.prflow/vendor/prflow/skills/<name>` — the **same subtree a consumer
+resolves**, so the shipped helper-path shape finally has coverage here and a denial in
+this repo is a denial there. The composition is best-effort (always exits 0) and
+degrades on an absent/partial vendored tree with a `::warning::` naming `prflow_version`.
+The tracked `.claude-plugin/marketplace.json`, the baked marketplace baseline literal,
+and the **review/manual tiers** are untouched — those still resolve from the repo-root
+`./` and continue to exercise the workspace-absolute / repo-root-relative shapes above.
+Per the usual grant timing (#593), the workflow change is **inert for its own PR's
+implementing run** and live for subsequent cloud runs (verified post-merge).
+
+**The `./` prefix on the emitted marketplace entry is load-bearing, and it is the one
+thing no gate in this repo can check.** `claude-code-action` validates every
+`plugin_marketplaces` entry it is handed (`base-action/src/install-plugins.ts`): an entry
+is treated as a local path only when it begins with `./`, `../`, `/`, or a Windows drive
+prefix, and anything else must match its `^https://….git$` marketplace-URL regex. The
+first shipped version of this step emitted the bare relative `.prflow/vendor`, which
+matched neither arm, so the action aborted **every** cloud implement run in this
+repository with `Invalid marketplace URL format: .prflow/vendor` (PR #1137, reverted
+by #1144 forty-six minutes later). That validator executes only inside a real cloud run:
+the desk suite, the CI shards, and the review engine all pass a change that breaks it —
+#1137 was reviewed clean across four rounds and CI-green with zero skips. This belongs in
+the same class as the matcher semantics documented elsewhere on this page: **a runtime
+contract with an external action, provable only by a real dispatch.** A change that alters
+the inputs handed to `claude-code-action` wants a canary run at merge time. The
+normalization now lives in `compose-vendor-marketplace.sh` at the single point that emits
+the entry, and `lib/test/run.sh` asserts the emitted value satisfies the action's
+local-path predicate — which narrows the gap without closing it, since it re-states the
+validator rather than executing it.
+
 **The workspace-absolute literal embeds the repository name twice.** A rename moves
 `$GITHUB_WORKSPACE`, every such token stops matching, and — per this tier's defining
 property — an ungranted head is **silently denied**. The failure mode is a run that

--- a/lib/test/modules/coverage-map.json
+++ b/lib/test/modules/coverage-map.json
@@ -237,6 +237,10 @@
       "note": "",
       "owner": "unmodularized"
     },
+    "scripts/compose-vendor-marketplace.sh": {
+      "note": "issue #1049 implement-tier vendored-marketplace composition; covered by the #1049 block in lib/test/run.sh",
+      "owner": "unmodularized"
+    },
     "scripts/config-get.sh": {
       "note": "",
       "owner": "unmodularized"
@@ -721,6 +725,10 @@
     "1046": {
       "note": "",
       "owner": "review-trigger-helpers"
+    },
+    "1049": {
+      "note": "",
+      "owner": "unmodularized"
     },
     "1050": {
       "note": "",

--- a/lib/test/run.sh
+++ b/lib/test/run.sh
@@ -37803,8 +37803,17 @@ for _f in devflow-implement devflow devflow-runner; do
   assert_eq "#505 AC4: $_f.yml carries the baked plugins baseline literal" "1" "$(grep -cF "$_505_BP" "$_505_WF/$_f.yml")"
   assert_eq "#505 AC4: $_f.yml carries the baked marketplaces baseline literal" "1" "$(grep -cF "$_505_BM" "$_505_WF/$_f.yml")"
   assert_eq "#505 AC4: $_f.yml has a Compose plugin inputs step" "1" "$(grep -c 'name: Compose plugin inputs' "$_505_WF/$_f.yml")"
-  assert_eq "#505 AC4: $_f.yml plugin_marketplaces consumes the step output" "1" \
-    "$(grep -cF 'plugin_marketplaces: ${{ steps.plugins.outputs.plugin_marketplaces }}' "$_505_WF/$_f.yml")"
+  # devflow-implement.yml consumes plugin_marketplaces from the issue-#1049
+  # vendor_marketplace step (which post-processes steps.plugins' composed list);
+  # the other two tiers still consume steps.plugins directly. The action input must
+  # name exactly the right producing step per tier.
+  if [ "$_f" = devflow-implement ]; then
+    _505_EXPMK='plugin_marketplaces: ${{ steps.vendor_marketplace.outputs.plugin_marketplaces }}'
+  else
+    _505_EXPMK='plugin_marketplaces: ${{ steps.plugins.outputs.plugin_marketplaces }}'
+  fi
+  assert_eq "#505 AC4: $_f.yml plugin_marketplaces action input consumes the right composed step" "1" \
+    "$(grep -cF "$_505_EXPMK" "$_505_WF/$_f.yml")"
   assert_eq "#505 AC4: $_f.yml plugins consumes the step output" "1" \
     "$(grep -cF 'plugins: ${{ steps.plugins.outputs.plugins }}' "$_505_WF/$_f.yml")"
   assert_eq "#505 AC: $_f.yml routes the annotation through describe-plugin-compose.sh" "yes" \
@@ -38086,6 +38095,235 @@ PY
   rm -rf "$_505_FIXROOT" "$_505_TRUST"; rm -f "$_505_WSTEP" "$_505_WSTEP2" "$_505_RSTEP"
 else
   skip "#513 I3 compose-step behavioral block" host-capability "python3+pyyaml unavailable; compose steps covered by static pins only this run"
+fi
+
+# ── #1049 vendored-marketplace resolution: compose-vendor-marketplace.sh + the
+#    implement-tier vendor_marketplace step ──────────────────────────────────────
+# This repo's cloud implement run resolved the plugin root to <workspace>/skills (the
+# repo-root marketplace's ./ source) while every consumer resolves it from
+# .prflow/vendor/prflow — so the shipped helper-path shape had no coverage here. The
+# fix composes a job-local marketplace rooted at the vendored subtree and swaps the ./
+# entry for it, implement-tier only. Constraints: the tracked marketplace.json and the
+# baked baseline literal stay untouched; the composed-vs-degraded branch selection lives
+# in the helper (describe-denial-count.sh extraction convention) and is driven here.
+echo "compose-vendor-marketplace.sh + vendor_marketplace step (issue #1049)"
+_1049_CVM="$LIB/../scripts/compose-vendor-marketplace.sh"
+assert_eq "#1049 AC1: compose-vendor-marketplace.sh exists" "yes" "$([ -f "$_1049_CVM" ] && echo yes || echo no)"
+assert_eq "#1049 AC1: compose-vendor-marketplace.sh SPDX header" "yes" \
+  "$(grep -q 'SPDX-License-Identifier: MIT' "$_1049_CVM" && echo yes || echo no)"
+# guard-class 2: the emitted marketplace-list swap is a bash read-loop, so no
+# tr/sed/wc/cut/head command may derive it.
+assert_eq "#1049 AC1: no tr/sed/wc/cut/head command derives the emitted list (guard-class 2)" "0" \
+  "$(grep -cE '^[[:space:]]*(tr|sed|wc|cut|head)([[:space:]]|$)' "$_1049_CVM")"
+
+# Behavioral driver: a fixture vendor tree + a marketplace-list file, run the helper,
+# capture the rewritten list and the stdout annotation.
+_1049_mkvendor() {  # $1=root  $2=complete|partial  → make .prflow/vendor[/prflow/.claude-plugin/plugin.json]
+  mkdir -p "$1/.prflow/vendor/prflow/scripts"
+  if [ "$2" = complete ]; then
+    mkdir -p "$1/.prflow/vendor/prflow/.claude-plugin"
+    printf '%s\n' '{"name":"prflow"}' > "$1/.prflow/vendor/prflow/.claude-plugin/plugin.json"
+  fi
+}
+_1049_run() {  # $1=vendor-root-arg  $2=marketplaces-file-content  (cwd=$_1049_FX)
+  _1049_MKF="$_1049_FX/mk.txt"; printf '%s\n' "$2" > "$_1049_MKF"
+  _1049_ANN="$( cd "$_1049_FX" && bash "$_1049_CVM" "$_1049_MKF" "$1" 2>&1 )"; _1049_RC=$?
+  _1049_LIST="$(cat "$_1049_MKF")"
+}
+# (a) composed arm: complete vendor + a list containing ./ → ./ swapped for the vendor
+# root, marketplace.json written (devflow-marketplace, prflow sourced ./prflow), ::notice::
+_1049_FX="$(mktemp -d)"; _1049_mkvendor "$_1049_FX" complete
+_1049_run .prflow/vendor "$(printf '%s\n%s' 'https://github.com/anthropics/claude-plugins-official.git' './')"
+assert_eq "#1049 composed: helper always exits 0" "0" "$_1049_RC"
+assert_eq "#1049 composed: ./ entry swapped for the vendor root" \
+  "$(printf '%s\n%s' 'https://github.com/anthropics/claude-plugins-official.git' './.prflow/vendor')" "$_1049_LIST"
+# THE regression that reverted PR #1137. claude-code-action validates every
+# plugin_marketplaces entry (base-action/src/install-plugins.ts): an entry is a local path
+# only if it starts with ./, ../, / or a Windows drive prefix, and anything else must match
+# its ^https://….git$ URL regex. The un-prefixed `.prflow/vendor` matched neither, so the
+# action aborted every cloud implement run with `Invalid marketplace URL format`. That
+# validator runs only inside a real cloud run — no desk lint, CI shard, or review verdict
+# reaches it — so the emitted entry's prefix is asserted here, at the one point that can.
+# Assert the PREDICATE the action applies, not the literal, so it still holds if the
+# vendor root moves.
+_1049_SWAPPED_ENTRY="${_1049_LIST##*$'\n'}"
+assert_eq "#1049 composed: the emitted marketplace entry is a local path claude-code-action accepts (./, ../ or / prefix)" "yes" \
+  "$(case "$_1049_SWAPPED_ENTRY" in ./*|../*|/*) echo yes ;; *) echo no ;; esac)"
+assert_eq "#1049 composed: emits a ::notice:: audit line" "yes" \
+  "$(printf '%s' "$_1049_ANN" | grep -q '::notice::' && echo yes || echo no)"
+assert_eq "#1049 composed: no ::warning:: on the clean composed arm" "no" \
+  "$(printf '%s' "$_1049_ANN" | grep -q '::warning::' && echo yes || echo no)"
+assert_eq "#1049 composed: job-local marketplace.json is named devflow-marketplace" "yes" \
+  "$(grep -q '"name": "devflow-marketplace"' "$_1049_FX/.prflow/vendor/.claude-plugin/marketplace.json" && echo yes || echo no)"
+assert_eq "#1049 composed: job-local marketplace sources prflow at ./prflow" "yes" \
+  "$(grep -q '"source": "./prflow"' "$_1049_FX/.prflow/vendor/.claude-plugin/marketplace.json" && echo yes || echo no)"
+rm -rf "$_1049_FX"
+# (b) degraded arm: partial vendor (no plugin.json) → list UNCHANGED, ::warning:: names prflow_version
+_1049_FX="$(mktemp -d)"; _1049_mkvendor "$_1049_FX" partial
+_1049_run .prflow/vendor "$(printf '%s\n%s' 'https://github.com/anthropics/claude-plugins-official.git' './')"
+assert_eq "#1049 degraded: partial vendor → list left UNCHANGED (still ./)" \
+  "$(printf '%s\n%s' 'https://github.com/anthropics/claude-plugins-official.git' './')" "$_1049_LIST"
+assert_eq "#1049 degraded: ::warning:: names prflow_version as the remedy" "yes" \
+  "$(printf '%s' "$_1049_ANN" | grep -q '::warning::' && printf '%s' "$_1049_ANN" | grep -q 'prflow_version' && echo yes || echo no)"
+assert_eq "#1049 degraded: no marketplace.json written on the degraded arm" "no" \
+  "$([ -f "$_1049_FX/.prflow/vendor/.claude-plugin/marketplace.json" ] && echo yes || echo no)"
+rm -rf "$_1049_FX"
+# (c) usage arm: missing args → ::warning::, exit 0, no crash
+_1049_FX="$(mktemp -d)"
+_1049_ANN="$( cd "$_1049_FX" && bash "$_1049_CVM" 2>&1 )"; _1049_RC=$?
+assert_eq "#1049 usage: missing args exits 0" "0" "$_1049_RC"
+assert_eq "#1049 usage: missing args emits a ::warning::" "yes" \
+  "$(printf '%s' "$_1049_ANN" | grep -q '::warning::' && echo yes || echo no)"
+rm -rf "$_1049_FX"
+# (d) swap-miss arm: complete vendor but the list has NO ./ entry → marketplace.json is
+# written but a ::warning:: flags that nothing consumed it (never a silent resolution).
+_1049_FX="$(mktemp -d)"; _1049_mkvendor "$_1049_FX" complete
+_1049_run .prflow/vendor 'https://github.com/anthropics/claude-plugins-official.git'
+assert_eq "#1049 swap-miss: no ./ in the list → ::warning:: (not silent)" "yes" \
+  "$(printf '%s' "$_1049_ANN" | grep -q '::warning::' && echo yes || echo no)"
+rm -rf "$_1049_FX"
+# (e) write-failure arm: complete vendor, but the job-local marketplace.json cannot be
+# written. The helper runs under `set -u` and NOT `set -e`, so the write is checked
+# explicitly and the swap is GATED on it — otherwise the list would be repointed at
+# $VENDOR_ROOT while the marketplace.json it depends on does not exist, i.e. a
+# silently-wrong resolution wearing a green ::notice::. Without a driver for that gate a
+# refactor hoisting the swap above it (or downgrading the annotation to a notice) ships
+# green, so drive it here. Fixture: a regular FILE where the helper needs to mkdir
+# `<vendor-root>/.claude-plugin` — portable and root-insensitive, unlike a chmod.
+_1049_FX="$(mktemp -d)"; _1049_mkvendor "$_1049_FX" complete
+printf '%s\n' 'not a directory' > "$_1049_FX/.prflow/vendor/.claude-plugin"
+_1049_run .prflow/vendor "$(printf '%s\n%s' 'https://github.com/anthropics/claude-plugins-official.git' './')"
+assert_eq "#1049 write-failure: marketplace.json unwritable → list left UNCHANGED (no swap without a confirmed write)" \
+  "$(printf '%s\n%s' 'https://github.com/anthropics/claude-plugins-official.git' './')" "$_1049_LIST"
+assert_eq "#1049 write-failure: emits a ::warning:: and NO ::notice:: (never a broken resolution reported as clean)" "yes" \
+  "$(printf '%s' "$_1049_ANN" | grep -q '::warning::' && ! printf '%s' "$_1049_ANN" | grep -q '::notice::' && echo yes || echo no)"
+rm -rf "$_1049_FX"
+# (f) rewrite-failure arm: complete vendor AND a `./` entry present, but the marketplaces
+# FILE itself cannot be rewritten. Sibling of (e): (e) gates on the marketplace.json write,
+# this gates on the write that actually repoints the list. Left unchecked, the run keeps
+# the repo-root `./` resolution while the success ::notice:: affirms the vendored subtree —
+# the same "non-clean path reported as clean" shape (e) guards one write earlier, and the
+# one the whole helper exists to prevent.
+#
+# FIXTURE CHOICE IS LOAD-BEARING — the read must SUCCEED and only the write fail, or the
+# test is vacuous. A path whose read also fails (a directory, a missing parent) leaves
+# SWAPPED=0, so the swap-miss ::warning:: fires and the assertion below would pass with
+# the gate REMOVED; a directory additionally aborts the helper on `set -u` (the read never
+# assigns `line`) before the write is reached. Mode 0444 is the one portable mechanism
+# that separates read from write, and root bypasses it — so prove the fixture is effective
+# rather than trusting the mode, and take an auditable skip when it is not (#456).
+_1049_FX="$(mktemp -d)"; _1049_mkvendor "$_1049_FX" complete
+_1049_ROF="$_1049_FX/mk.txt"
+printf '%s\n%s\n' 'https://github.com/anthropics/claude-plugins-official.git' './' > "$_1049_ROF"
+chmod 444 "$_1049_ROF" 2>/dev/null || true
+if [ ! -w "$_1049_ROF" ]; then
+  _1049_ANN="$( cd "$_1049_FX" && bash "$_1049_CVM" "$_1049_ROF" .prflow/vendor 2>&1 )"; _1049_RC=$?
+  _1049_LIST="$(cat "$_1049_ROF")"
+  assert_eq "#1049 rewrite-failure: unwritable marketplaces file → ::warning:: and NO ::notice:: (nothing may claim a swap that never took effect)" "yes" \
+    "$(printf '%s' "$_1049_ANN" | grep -q '::warning::' && ! printf '%s' "$_1049_ANN" | grep -q '::notice::' && echo yes || echo no)"
+  assert_eq "#1049 rewrite-failure: the list still carries the repo-root ./ the run actually resolves from" \
+    "$(printf '%s\n%s' 'https://github.com/anthropics/claude-plugins-official.git' './')" "$_1049_LIST"
+  assert_eq "#1049 rewrite-failure: helper still exits 0 (best-effort; a compose bug never breaks the credentialed run)" "0" "$_1049_RC"
+else
+  # Root (or a mode-ignoring filesystem) can write the 0444 fixture, so the write cannot be
+  # made to fail here and the arm is unreachable. Auditable skip, never a silent absence.
+  skip "#1049 rewrite-failure arm" host-capability \
+    "chmod 444 did not make the marketplaces file unwritable (running as root, or a permissive filesystem)"
+fi
+chmod 644 "$_1049_ROF" 2>/dev/null || true
+rm -rf "$_1049_FX"
+# (g) baseline coupling: the helper's swap arm matches the literal `./`, but nothing
+# above ties that to what the baked marketplaces baseline actually emits — every fixture
+# supplies its own `./`. The #505 AC4 pins lock $_505_BM byte-identical across the three
+# workflows and say nothing about whether the helper matches any line it produces, so a
+# baseline respelling (`.`, a trailing slash, an absolute path) would silently take the
+# swap-miss arm in production while the suite stayed green. Couple them BEHAVIORALLY
+# rather than by grepping the two literals at each other: derive the baseline's emitted
+# entries from the pinned literal (the same `printf '%s\n' ` prefix strip the #505 AC4
+# block uses) and drive the REAL helper over them. The composed ::notice:: fires only
+# when SWAPPED=1, so this goes RED if either side moves — and it survives a refactor of
+# the match itself (case → if, a variable), which a literal-to-literal pin would not.
+_1049_FX="$(mktemp -d)"; _1049_mkvendor "$_1049_FX" complete
+_1049_BM_ENTRIES="${_505_BM##*"' "}"
+# shellcheck disable=SC2086  # deliberate word-split: reproduce the baseline printf's lines
+_1049_run .prflow/vendor "$(printf '%s\n' $_1049_BM_ENTRIES)"
+assert_eq "#1049 baseline coupling: the baked marketplaces baseline emits an entry the helper's swap arm matches" "yes" \
+  "$(printf '%s' "$_1049_ANN" | grep -q '::notice::' && ! printf '%s' "$_1049_ANN" | grep -q '::warning::' && echo yes || echo no)"
+rm -rf "$_1049_FX"
+
+# Workflow wiring: the vendor_marketplace step is implement-tier ONLY.
+_1049_IMPL="$_505_WF/devflow-implement.yml"
+assert_eq "#1049 wiring: devflow-implement.yml has the vendor_marketplace step" "1" \
+  "$(grep -c 'id: vendor_marketplace' "$_1049_IMPL")"
+assert_eq "#1049 wiring: the step invokes compose-vendor-marketplace.sh at the vendored path" "yes" \
+  "$(grep -qF 'bash "$VENDORMK" "$MKF" .prflow/vendor' "$_1049_IMPL" && echo yes || echo no)"
+assert_eq "#1049 wiring: the step's vendored-helper-absent skew arm names prflow_version" "yes" \
+  "$(grep -qF 'compose-vendor-marketplace.sh not found' "$_1049_IMPL" && grep -q 'Bump prflow_version' "$_1049_IMPL" && echo yes || echo no)"
+# Implement-tier ONLY: the manual-command and review tiers must NOT reference either the
+# step id or the helper, so their plugin root stays the repo-root ./ (out of scope here).
+for _f in devflow devflow-runner; do
+  assert_eq "#1049 wiring: $_f.yml does NOT reference vendor_marketplace (implement-tier only)" "0" \
+    "$(grep -c 'vendor_marketplace' "$_505_WF/$_f.yml")"
+  assert_eq "#1049 wiring: $_f.yml does NOT reference compose-vendor-marketplace.sh (implement-tier only)" "0" \
+    "$(grep -c 'compose-vendor-marketplace.sh' "$_505_WF/$_f.yml")"
+done
+
+# Execute the extracted vendor_marketplace step against fixtures (mirrors the #513 I3
+# harness): the swap must actually happen when the vendored helper is present, and the
+# list must pass through unchanged (repo-root ./) when it is absent.
+if command -v python3 >/dev/null 2>&1 && python3 -c 'import yaml' >/dev/null 2>&1; then
+  _1049_extract() {  # $1=workflow  $2=step id → run: script on stdout
+    python3 - "$1" "$2" <<'PY'
+import sys, yaml
+doc = yaml.safe_load(open(sys.argv[1]))
+for job in doc["jobs"].values():
+    for s in job.get("steps", []):
+        if s.get("id") == sys.argv[2] and "run" in s:
+            sys.stdout.write("#!/usr/bin/env bash\n" + s["run"]); raise SystemExit
+raise SystemExit("step %s not found" % sys.argv[2])
+PY
+  }
+  _1049_VSTEP="$(mktemp)"; _1049_extract "$_1049_IMPL" vendor_marketplace > "$_1049_VSTEP"
+  # guard-class 2 on the STEP's own inline re-read loop (not just the helper): the step
+  # re-derives the emitted plugin_marketplaces list via a bash while-read loop and its
+  # comment claims guard-class 2, so pin that the extracted step body invokes no
+  # tr/sed/wc/cut/head to derive that emitted value.
+  assert_eq "#1049 step exec: the vendor_marketplace step derives no emitted value via tr/sed/wc/cut/head (guard-class 2)" "0" \
+    "$(grep -cE '^[[:space:]]*(tr|sed|wc|cut|head)([[:space:]]|$)' "$_1049_VSTEP")"
+  _1049_vstep_run() {  # $1=cwd  $2=COMPOSED_MK → sets _1049_OUT (plugin_marketplaces heredoc value)
+    local out; out="$(mktemp)"
+    ( cd "$1" && COMPOSED_MK="$2" GITHUB_OUTPUT="$out" bash "$_1049_VSTEP" >/dev/null 2>&1 )
+    _1049_OUT="$(awk '/^plugin_marketplaces<</{f=1;next} f&&/^MKV_EOF_/{f=0} f' "$out")"; rm -f "$out"
+  }
+  # helper present + complete vendor → ./ swapped to .prflow/vendor
+  _1049_FX="$(mktemp -d)"; _1049_mkvendor "$_1049_FX" complete
+  cp "$_1049_CVM" "$_1049_FX/.prflow/vendor/prflow/scripts/compose-vendor-marketplace.sh"
+  _1049_vstep_run "$_1049_FX" "$(printf '%s\n%s' 'https://github.com/anthropics/claude-plugins-official.git' './')"
+  # End-to-end through the real workflow step: the value that actually reaches the action's
+  # plugin_marketplaces input must carry the ./ prefix its validator requires (see the
+  # composed-arm assertion above for why this is the one gate that can catch it).
+  assert_eq "#1049 step exec: helper present → ./ resolved to the vendored marketplace root, ./-prefixed for the action's validator" \
+    "$(printf '%s\n%s' 'https://github.com/anthropics/claude-plugins-official.git' './.prflow/vendor')" "$_1049_OUT"
+  rm -rf "$_1049_FX"
+  # helper PRESENT but vendor PARTIAL (no plugin.json) → the helper exits 0 without
+  # swapping (its internal degraded arm), the workflow's `|| echo warning` does NOT fire,
+  # and the step's re-read loop must pass the list through unchanged (repo-root ./ kept).
+  # This is a distinct end-to-end path from both cases below — the outer file-absent guard
+  # is a different branch than the helper's internal manifest-absent arm.
+  _1049_FX="$(mktemp -d)"; _1049_mkvendor "$_1049_FX" partial
+  cp "$_1049_CVM" "$_1049_FX/.prflow/vendor/prflow/scripts/compose-vendor-marketplace.sh"
+  _1049_vstep_run "$_1049_FX" "$(printf '%s\n%s' 'https://github.com/anthropics/claude-plugins-official.git' './')"
+  assert_eq "#1049 step exec: helper present + partial vendor → list passes through unchanged (repo-root ./ kept)" \
+    "$(printf '%s\n%s' 'https://github.com/anthropics/claude-plugins-official.git' './')" "$_1049_OUT"
+  rm -rf "$_1049_FX"
+  # helper absent (skew) → list passes through unchanged (repo-root ./ kept)
+  _1049_FX="$(mktemp -d)"; mkdir -p "$_1049_FX/.prflow/vendor"
+  _1049_vstep_run "$_1049_FX" "$(printf '%s\n%s' 'https://github.com/anthropics/claude-plugins-official.git' './')"
+  assert_eq "#1049 step exec: helper absent → list passes through unchanged (repo-root ./ kept)" \
+    "$(printf '%s\n%s' 'https://github.com/anthropics/claude-plugins-official.git' './')" "$_1049_OUT"
+  rm -rf "$_1049_FX"; rm -f "$_1049_VSTEP"
+else
+  skip "#1049 vendor_marketplace step behavioral block" host-capability "python3+pyyaml unavailable; step covered by static pins only this run"
 fi
 
 # ── #456 skip tally, summary renderer, and the NOTE-emit meta-assertion ───────────────

--- a/scripts/compose-vendor-marketplace.sh
+++ b/scripts/compose-vendor-marketplace.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 Daniel Radman
+# SPDX-License-Identifier: MIT
+# compose-vendor-marketplace.sh — resolve this repository's cloud implement plugin
+# root to the VENDORED subtree, so the shipped helper-path shape a consumer emits is
+# the shape this repo emits too (issue #1049).
+#
+# Why this exists. `.claude-plugin/marketplace.json` at the repo root declares the
+# `prflow` plugin with `"source": "./"`, so in THIS repo's cloud implement run
+# `$CLAUDE_SKILL_DIR` resolves to `<workspace>/skills/<name>` and the portable helper
+# anchor lands at `<workspace>/scripts/<helper>` (the repo root). A CONSUMER's
+# install.sh instead composes a marketplace whose source is `./.prflow/vendor/prflow`,
+# so the consumer resolves to `<workspace>/.prflow/vendor/prflow/skills/<name>` and the
+# anchor lands under `.prflow/vendor/prflow/scripts/`. Two different resolutions of the
+# same shipped bytes; no run in this repo ever exercises the consumer one. This helper
+# closes that gap for the cloud implement tier by composing a JOB-LOCAL marketplace
+# rooted at the vendored parent dir and rewriting the composed marketplace list to use
+# it in place of the repo-root `./` entry — WITHOUT touching the tracked
+# `.claude-plugin/marketplace.json` (constraint from issue #1049: this repo is its own
+# marketplace and must keep its `source` at `./`; re-pointing that file at the vendored
+# path would diverge the tracked repo-root marketplace from the shape the repo requires,
+# so the constraint is enforced by the issue's own authoring rule, not by a suite pin).
+#
+# It does NOT edit the baked marketplace baseline literal (the three-way #505 AC4 sync
+# pin): the workflow computes the combined marketplace list from that untouched baseline
+# and hands it here as a file; this helper only swaps the resolved `./` entry for the
+# job-local vendored marketplace directory. Adding a job-local entry, never mutating the
+# baseline — exactly the shape issue #1049 prescribes.
+#
+# Usage: compose-vendor-marketplace.sh <marketplaces-file> <vendor-root>
+#   marketplaces-file  a file with one marketplace entry per line (the workflow's
+#                      COMBINED_MK). Rewritten IN PLACE on the composed arm.
+#   vendor-root        the vendored parent dir, e.g. `.prflow/vendor`. The plugin is
+#                      expected at `<vendor-root>/prflow`.
+#
+# Arms (the branch selection lives HERE, driven by lib/test/run.sh — the
+# describe-denial-count.sh extraction convention, so no arm is left inline-and-
+# unasserted in the workflow YAML):
+#   composed  — the vendored plugin is present AND complete
+#               (`<vendor-root>/prflow/.claude-plugin/plugin.json` is a regular file).
+#               Write `<vendor-root>/.claude-plugin/marketplace.json` (a job-local
+#               marketplace named `devflow-marketplace`, `prflow` sourced at `./prflow`),
+#               rewrite the marketplaces file so the repo-root `./` entry becomes
+#               `./<vendor-root>` (the `./` prefix is REQUIRED — see the normalization
+#               note at the swap), emit one `::notice::` audit line. A directory's
+#               presence is NOT proof the helper set exists, so completeness is proven by
+#               the plugin manifest, not the directory. Some sub-cases warn instead of
+#               that notice, so this arm is not unconditionally a `::notice::`: an
+#               unwritable `marketplace.json` gates the swap OFF (list left unchanged),
+#               an unwritable marketplaces file gates the notice OFF (the list was not
+#               repointed, and may be truncated), and a combined list carrying no `./`
+#               entry composes the marketplace but splices nothing in. Every write that
+#               a later annotation would vouch for is checked before it is claimed, and
+#               each sub-case is driven by the suite.
+#   degraded  — the vendored tree is absent or partial (the #505-class skew: a pinned
+#               prflow_version predating this change, or an incomplete vendor fetch).
+#               Leave the marketplaces file UNCHANGED (the run keeps resolving from the
+#               repo-root `./` marketplace) and emit one `::warning::` naming
+#               prflow_version as the remedy — never a hard failure, never a silent skip.
+#   usage     — a missing argument. stderr breadcrumb + `::warning::`; leave any file
+#               unchanged. Best-effort: ALWAYS exits 0 so a compose bug can never break
+#               the credentialed run.
+#
+# ALWAYS exits 0. Every annotation goes to STDOUT (where GitHub Actions parses workflow
+# commands); the caller does not capture this helper's stdout.
+
+set -u
+
+MK_FILE="${1:-}"
+VENDOR_ROOT="${2:-}"
+
+if [ -z "$MK_FILE" ] || [ -z "$VENDOR_ROOT" ]; then
+    echo "compose-vendor-marketplace: usage: compose-vendor-marketplace.sh <marketplaces-file> <vendor-root>" >&2
+    echo "::warning::devflow compose-vendor-marketplace.sh called without both arguments; the prflow plugin resolves from the repo-root marketplace (./)."
+    exit 0
+fi
+
+PLUGIN_DIR="$VENDOR_ROOT/prflow"
+PLUGIN_MANIFEST="$PLUGIN_DIR/.claude-plugin/plugin.json"
+
+# Completeness is proven by the plugin manifest, not the directory's mere presence:
+# an incomplete vendor fetch can leave the directory without the plugin.
+if [ ! -f "$PLUGIN_MANIFEST" ]; then
+    echo "::warning::devflow compose-vendor-marketplace.sh: $PLUGIN_MANIFEST is absent — the vendored plugin is missing or partial (a pinned prflow_version predating issue #1049, or an incomplete vendor fetch); the prflow plugin resolves from the repo-root marketplace (./). Bump prflow_version in .prflow/config.json."
+    exit 0
+fi
+
+# ── composed arm ────────────────────────────────────────────────────────────────
+# Write the job-local marketplace rooted at the vendored PARENT dir. Its `prflow`
+# plugin source `./prflow` stays INSIDE the marketplace root (mirroring the repo-root
+# marketplace's `"source": "./"` with the plugin at the root), so $CLAUDE_SKILL_DIR
+# resolves to `<workspace>/.prflow/vendor/prflow/skills/<name>` — byte-identical to a
+# consumer. Named `devflow-marketplace` so the baked `prflow@devflow-marketplace`
+# plugin spec resolves against it once the `./` entry is swapped out below. This path
+# is under the gitignored `.prflow/` tree (never staged by the agent's git add -A) and
+# is distinct from the vendor-slice-pruned `<vendor-root>/prflow/.claude-plugin/
+# marketplace.json`, so there is no collision.
+MK_DIR="$VENDOR_ROOT/.claude-plugin"
+# The script runs under `set -u` but NOT `set -e`, so the write is checked explicitly:
+# if the mkdir or the marketplace.json write fails (unwritable dir, full/read-only FS),
+# the swap below would repoint the list at $VENDOR_ROOT while the marketplace.json it
+# depends on does not exist — a silently-wrong resolution wearing a green ::notice::.
+# Gate the swap + success notice on a confirmed write; otherwise warn and leave the list
+# on the repo-root `./` (never a non-clean path reported as clean).
+# Static JSON (no interpolated values) — printf, so no apostrophe/heredoc hazard.
+if ! mkdir -p "$MK_DIR" 2>/dev/null || ! printf '%s\n' \
+'{' \
+'  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",' \
+'  "name": "devflow-marketplace",' \
+'  "owner": { "name": "Daniel Radman" },' \
+'  "renames": { "devflow": "prflow" },' \
+'  "plugins": [' \
+'    { "name": "prflow", "source": "./prflow" }' \
+'  ]' \
+'}' > "$MK_DIR/marketplace.json"; then
+    echo "::warning::devflow compose-vendor-marketplace.sh: could not write $MK_DIR/marketplace.json (unwritable dir or full/read-only FS); the prflow plugin resolves from the repo-root marketplace (./). The composed marketplace list is left unchanged."
+    exit 0
+fi
+
+# The marketplace entry emitted below is validated by `claude-code-action` before it ever
+# reaches Claude Code: `base-action/src/install-plugins.ts` treats an input as a LOCAL
+# PATH only when it starts with `./`, `../`, `/`, or a Windows drive prefix — anything
+# else must match its `^https://….git$` marketplace-URL regex. A bare relative
+# `.prflow/vendor` carries none of those prefixes, so it fell through to the regex and the
+# action aborted EVERY cloud implement run in this repo with
+# `Invalid marketplace URL format: .prflow/vendor` (PR #1137, reverted by #1144).
+# `./.prflow/vendor` satisfies `startsWith("./")`, which the action accepts at any depth
+# and passes verbatim to `claude plugin marketplace add`.
+#
+# Normalize HERE — at the single point that emits the entry — rather than requiring the
+# caller to pass an already-prefixed path: the caller's argument also names filesystem
+# paths (the manifest probe, the marketplace.json write), so a prefix obligation split
+# across the boundary is exactly the shape that was missed once already. Derived with a
+# bash `case` (guard-class 2: a value that decides the EMITTED result must not come from
+# a non-preflight PATH tool). The Windows drive form is deliberately NOT an arm — the
+# cloud implement runner is Linux (issue #1049's environment steelman), and `./`-prefixing
+# a drive-lettered path would be wrong rather than merely unnecessary.
+case "$VENDOR_ROOT" in
+    ./*|../*|/*) MK_ENTRY="$VENDOR_ROOT" ;;
+    *)           MK_ENTRY="./$VENDOR_ROOT" ;;
+esac
+
+# Rewrite the marketplaces file: swap the repo-root `./` entry for the vendored
+# marketplace root. Bash builtins only (while-read + case) — guard-class 2: a value
+# that decides the EMITTED marketplace list must not be derived through a non-preflight
+# PATH tool (tr/sed/wc/cut/head).
+SWAPPED=0
+OUT=""
+while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in
+        "./")
+            OUT="${OUT:+$OUT$'\n'}$MK_ENTRY"
+            SWAPPED=1
+            ;;
+        *)
+            OUT="${OUT:+$OUT$'\n'}$line"
+            ;;
+    esac
+done < "$MK_FILE"
+# Same gate as the marketplace.json write above, for the same reason: this rewrite is the
+# step that actually repoints the list at the vendored root, so an UNCHECKED write lets
+# the success notice below affirm a resolution that never took effect (a `./` list wearing
+# a green ::notice::). Two distinct failure shapes reach here — the open fails outright
+# (unwritable path: the list keeps its previous contents, so the run resolves from the
+# repo-root `./`), or the open succeeds and the write is truncated part-way (full FS: the
+# list is left incomplete or empty). The annotation names both rather than promising the
+# clean fallback, which only the first shape actually delivers.
+if ! printf '%s\n' "$OUT" > "$MK_FILE"; then
+    echo "::warning::devflow compose-vendor-marketplace.sh: could not rewrite $MK_FILE (unwritable path or full/read-only FS); the job-local marketplace was composed but the marketplace list was NOT repointed at it, so the prflow plugin does not resolve from the vendored subtree. If the write was truncated part-way the list may also be incomplete."
+    exit 0
+fi
+
+if [ "$SWAPPED" -eq 1 ]; then
+    # The emitted entry is named in the notice so a live run shows the exact spelling the
+    # action will validate — the diagnostic that was missing when the un-prefixed form
+    # shipped (PR #1137).
+    echo "::notice::devflow: composed a job-local marketplace at $MK_DIR/marketplace.json and emitted the marketplace entry '$MK_ENTRY'; the prflow plugin now resolves from the vendored subtree ($PLUGIN_DIR), matching a consumer's resolution (issue #1049)."
+else
+    # The baseline `./` entry was not found in the combined list — the marketplace.json
+    # was written but nothing consumes it. Surface it rather than resolving silently.
+    echo "::warning::devflow compose-vendor-marketplace.sh: the repo-root './' marketplace entry was not present in the combined list, so the vendored marketplace was composed but not spliced in; the prflow plugin still resolves from whatever marketplace the baked baseline registered."
+fi
+exit 0


### PR DESCRIPTION
Closes #1049.

This restores the work that merged as #1137 and was reverted 46 minutes later by #1144, with the single defect that caused the revert corrected at its source.

## What the change does

This repository's `.claude-plugin/marketplace.json` sources the `prflow` plugin at `./`, so a cloud implement run here resolved `$CLAUDE_SKILL_DIR` to `<workspace>/skills/<name>` and the portable helper anchor landed at the repository root. Every **consumer** resolves the same shipped bytes from `.prflow/vendor/prflow`, so the helper-path shape a consumer's engine actually emits had **no coverage in this repository at all**.

`devflow-implement.yml`'s `claude` job now runs an implement-tier-only `vendor_marketplace` step (`scripts/compose-vendor-marketplace.sh`) that composes a **job-local** marketplace rooted at the vendored parent directory and swaps the repo-root `./` entry in the composed marketplace list for it. This repository's implement run therefore resolves `$CLAUDE_SKILL_DIR` to `<workspace>/.prflow/vendor/prflow/skills/<name>` — the same subtree a consumer resolves — so a denial here is a denial there.

Untouched, per the issue's constraints: the tracked `.claude-plugin/marketplace.json`, the baked marketplace baseline literal (the three-way `#505 AC4` sync pin), `lib/capability-profiles.json`, `lib/review-profile.tokens`, the generated review `TOOLS='…'` literal, and the review and manual-command tiers.

## Why #1137 was reverted, and what changed here

#1137 emitted the marketplace entry as the bare relative path `.prflow/vendor`. `claude-code-action` validates every `plugin_marketplaces` entry it is handed (`base-action/src/install-plugins.ts`, read at the commit `v1` resolves to): an entry is treated as a **local path** only when it starts with `./`, `../`, `/`, or a Windows drive prefix, and anything else must match its `^https://….git$` marketplace-URL regex. The bare form matched neither arm, so the action aborted **every** cloud implement run in this repository with:

```
##[error]Action failed with error: Invalid marketplace URL format: .prflow/vendor
```

`./.prflow/vendor` satisfies `startsWith("./")`, which the action accepts at any depth and passes verbatim to `claude plugin marketplace add` (its own `base-action/test/install-plugins.test.ts` carries a test asserting exactly that for a path of this shape).

The fix normalizes the emitted entry **inside the helper, at the single point that emits it**, rather than requiring the caller to pass an already-prefixed path. That placement is deliberate: the caller's argument also names filesystem paths (the plugin-manifest probe, the `marketplace.json` write), so a prefix obligation split across that boundary is precisely the shape that was missed once already. The normalization is a bash `case` (guard-class 2 — a value that decides the emitted result must not come from a non-preflight PATH tool), and it is idempotent: an already-prefixed or absolute vendor root passes through unchanged.

## ⚠️ Honest caveat — this needs one real dispatch before it is trusted

**The evidence assembled here proves `claude-code-action` *accepts* the spelling. It does not prove Claude Code then resolves that path to a usable marketplace root.** That second half was never exercised on a live run, in #1137 or here.

This is not a gap the repository's gates can close. That validator executes **only inside a real cloud run** — no desk lint, no CI shard, and no review verdict reaches it. #1137 is the proof: it was reviewed clean by five agents across four rounds, had three Important findings fixed and mutation-checked, and passed CI with zero skips, and it still broke the entire fleet on merge. This belongs in the same class as this repository's existing rule that matcher semantics are provable only by a real dispatch.

**So this should land behind one real dispatch that confirms end-to-end resolution, not on validator evidence alone.** The new assertions re-state the action's predicate; they do not execute it. Treat them as narrowing the gap, not closing it.

## Trigger-time inertness (issue #593)

Per the grant-timing bootstrap, this change is **inert in its own pull request**. `devflow-implement.yml`'s `config` job checks out the **default branch** at trigger time, and under `issue_comment` the workflow definition itself is the default branch's — so a workflow change this PR ships does not govern this PR's own implementing run. **No acceptance criterion is discharged by an in-run observation**, and no completion claim here rests on one. In-PR verification is limited to what the suite and the lint gates establish at the desk; the resolution itself is verified post-merge.

## Verification

- `scripts/compose-vendor-marketplace.sh` driven directly over all of its arms (composed, degraded/partial vendor, usage, swap-miss, write-failure, rewrite-failure), plus the two normalization edge cases (an already-`./`-prefixed root does not double-prefix; an absolute root passes through unchanged).
- The `vendor_marketplace` step is extracted from the workflow YAML and executed against fixtures, so the value that actually reaches the action's `plugin_marketplaces` input is asserted end-to-end — including that it carries the `./` prefix.
- The regression assertion checks the **predicate the action applies** (`./`, `../` or `/` prefix) rather than the literal, so it still holds if the vendor root moves.
- `shellcheck` and `ruff` gates; the aggregate signal is CI.

## Recovery method

Recovered by reverting the revert (`eeacc253`) onto current `origin/main` rather than rewriting from scratch. The revert-of-revert applied with no conflicts, and nothing on `main` has touched any of the five affected files since — so this is byte-exact recovery of the four-rounds-reviewed implementation, plus the path-spelling correction and its guarding assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
