### PR TITLE
docs: correct the grounding-block caller set and the hoisted allowed-tools prose

### DIFF
--- a/docs/cloud-allowlist.md
+++ b/docs/cloud-allowlist.md
@@ -595,9 +595,9 @@ normalizer statement outright — leaving the resolved labels non-empty but the
 **normalized list empty**, so the applies silently did nothing (caught at the
 desk). Use the granted `tr` / `sed` / `grep` instead.
 
-Consequence for the label call sites: `devflow-implement.yml`'s baked literal
-grants `apply-labels.sh` / `ensure-label.sh` explicitly, and **all four label call
-sites** — Phase 3.1's `PRFlow` provenance apply, Phase 4.0/4.0.5's
+Consequence for the label call sites: `devflow-implement.yml`'s generated
+`implement` literal grants `apply-labels.sh` / `ensure-label.sh` explicitly, and
+**all four label call sites** — Phase 3.1's `PRFlow` provenance apply, Phase 4.0/4.0.5's
 `deferred.labels` applies, and Phase 4.1's `Documented` apply — are reworked to
 **agent-level single-leading-token calls that read their inputs from printed tool
 output** (a shell variable does not survive into a later separate command).
@@ -611,7 +611,8 @@ source (#275) and resolves it at runtime — so it stays **prose-discipline**.
 ## Implement-profile head guard + inline-engine surface (issue #484)
 
 Phase 3 of `/prflow:implement` runs the review engine **inline** under
-`devflow-implement.yml`'s baked `--allowed-tools` (**not** the review profile), so
+`devflow-implement.yml`'s resolved `--allowed-tools` — the `Resolve allowed-tools`
+step's hoisted `TOOLS='…'` output (**not** the review profile) — so
 **every helper the normal inline flow can reach needs an implement-profile
 grant** — the review engine is shared.
 
@@ -742,7 +743,9 @@ vendored-literal token
 leading-token form) to the `implement` profile in `lib/capability-profiles.json`
 and regenerating. That **one edit** rewrites:
 
-- `devflow-implement.yml`'s baked `--allowed-tools` baseline, **and**
+- `devflow-implement.yml`'s generated `implement` region — the `Resolve
+  allowed-tools` step's `TOOLS='…'` baseline, which `claude_args`'s
+  `--allowed-tools` consumes — **and**
 - `matcher-probe.yml`'s `IMPLEMENT` baseline
 
 in lockstep — so the probe's baseline can never drift from the tier it is probing —
@@ -799,9 +802,12 @@ cloud runs.
 ### Config-supplied helper grants and the repository rename (issue #928, deferred half)
 
 `prflow_implement.allowed_tools` is not a generated literal — the `config` job
-extracts it with `jq` and splices it verbatim onto `devflow-implement.yml`'s baked
-`--allowed-tools`. Two path shapes reach it, both **measured emissions** rather than
-design choices: cloud implement run **30183387509** (issue #802) recorded 43
+extracts it as `allowed_tools_extra` with `jq`, and `devflow-implement.yml`'s
+`Resolve allowed-tools` step appends it verbatim to the generated `implement`
+region (`${TOOLS}${EXTRA}`), so the one resolved string both `--allowed-tools` and
+the grounding block quote carries it. Two path shapes reach it, both **measured
+emissions** rather than design choices: cloud implement run **30183387509**
+(issue #802) recorded 43
 permission denials in which the engine invoked bundled helpers as
 `/home/runner/work/<repo>/<repo>/scripts/<helper>` (workspace-absolute) and as
 `scripts/<helper>` (repo-root-relative), because `.claude-plugin/marketplace.json`

--- a/scripts/render-grounding-block.sh
+++ b/scripts/render-grounding-block.sh
@@ -2,15 +2,20 @@
 # SPDX-FileCopyrightText: 2026 Daniel Radman
 # SPDX-License-Identifier: MIT
 # render-grounding-block.sh — print the `> [!IMPORTANT]` engine-ground-truth block
-# prepended to the review engine's prompt (issue #363).
+# prepended to a cloud engine's prompt (issue #363; the implement tier since #1170).
 #
-# TWO workflows run skills/review/SKILL.md and both must prepend this block:
-# devflow-runner.yml's `Compose review prompt` (the automated review path) and
-# devflow.yml's `Compose review grounding block` (the manual `/devflow:review`
-# comment path). The block carries the prompt-injection defense that tells the
-# engine a check name is data, never instruction — security-sensitive prose that
-# must never drift between the two callers. It therefore lives here, once, rather
-# than as hand-copied heredocs in two YAML files (CLAUDE.md's coupled-mirror rule).
+# THREE cloud prompt-composition sites call this renderer and prepend its output:
+#   - devflow-runner.yml's `Compose review prompt` (the automated review path)
+#   - devflow.yml's `Compose review grounding block` (the manual `/devflow:review`
+#     comment path)
+#   - devflow-implement.yml's `Compose implement grounding block`, which reaches
+#     this renderer through scripts/compose-implement-prompt.sh in `MODE=implement`
+#     (issue #1170)
+# The first two compose the prompt for skills/review/SKILL.md; the third composes
+# the implement engine's. The block carries the prompt-injection defense that tells
+# the engine a check name is data, never instruction — security-sensitive prose that
+# must never drift between the callers. It therefore lives here, once, rather than
+# as hand-copied heredocs at each call site (CLAUDE.md's coupled-mirror rule).
 #
 # Reads from the environment:
 #   HEAD_SHA       the reviewed commit; renders as `unknown` when empty.


### PR DESCRIPTION
Follow-up to the review of PR #1178 (merged as `5c87315e`, issue #1170). Two Minor findings, both behavior-inert prose.

## 1. Stale caller count in `scripts/render-grounding-block.sh`

The file header claimed **TWO** workflows call the renderer, "hand-copied heredocs in two YAML files". PR #1178 added a third caller. Measured caller set (`git grep -n 'render-grounding-block' -- .github scripts` on `origin/main`):

| Caller | Step | Mode |
| --- | --- | --- |
| `.github/workflows/devflow-runner.yml` | `Compose review prompt` (automated review path) | `review` (default) |
| `.github/workflows/devflow.yml` | `Compose review grounding block` (manual review-command comment path) | `review` (default) |
| `.github/workflows/devflow-implement.yml` | `Compose implement grounding block` -> `scripts/compose-implement-prompt.sh` | `MODE=implement` |

The header now enumerates all three and names the indirection through `compose-implement-prompt.sh`. The summary line also no longer says the block is prepended only to *the review engine's* prompt — it now names both engines.

This is the one part of that file that misstated exactly what #1178 changed. Comment-only: `shellcheck --severity=warning -e SC1091 scripts/render-grounding-block.sh` is clean and the rendered `MODE=implement` block is byte-unchanged.

## 2. Stale "baked `--allowed-tools`" prose in `docs/cloud-allowlist.md`

Verified against `.github/workflows/devflow-implement.yml` rather than the reported line numbers. #1170 hoisted the generated `implement` region out of the inline `claude_args` literal into a `Resolve allowed-tools` step; `claude_args` now consumes `${{ steps.tools.outputs.tools }}`, and the `Compose implement grounding block` step consumes the same output, which is why the block cannot drift from the resolved string. `lib/generate-capability-profiles.py`'s `REGIONS` table confirms the `implement` region is an `assign`-kind `TOOLS` region, the same shape as `command`/`runner-review`.

Four present-tense sites still called that literal "baked". The two the review named, plus two more of the same class found by sweeping `grep -n 'baked' docs/cloud-allowlist.md` (disclosed rather than left to contradict the sentences I was fixing):

- **§ "Implement-profile head guard + inline-engine surface (issue #484)"** — the one the review named; it sat directly above the freshly-edited paragraph describing the hoisted `TOOLS='…'` step, so the section contradicted itself.
- **§ "Implement-tier bundled-helper grant flow (issue #555)"** — the one the review named as likewise current-but-stale; the regeneration target is the `Resolve allowed-tools` step's `TOOLS='…'` baseline.
- **§ "Grants are per-HEAD across the whole pipeline"** (label call sites) — same class, "baked literal" -> "generated `implement` literal".
- **§ "Config-supplied helper grants and the repository rename (issue #928)"** — same class; corrected to describe the real path (`config` job emits `allowed_tools_extra`, the `Resolve allowed-tools` step appends it as `${TOOLS}${EXTRA}`).

## Deliberately left alone

- **`docs/cloud-allowlist.md`'s § "Implement-tier repo-internal test grants (issue #789)"** (two `baked` mentions) — that section opens *"Superseded by issue #1078 (this describes the #789-era state) … The paragraphs below are the #789 record, kept for provenance."* Per this repo's issue-#656 convention a past-time snapshot is an intentional frozen record; machine-refreshing it would falsify the record. This is the site the review judged defensible to leave.
- **`docs/install.md`'s superseded-spelling snapshots** — same reason, and out of scope by the same ruling.
- **The baked *marketplace* baseline literal** (`§ issue #1049`) — a different literal, still baked (`devflow-implement.yml` composes `plugin_marketplaces` from a baked baseline). Verified current, unchanged.
- **A golden byte-identity pin for `MODE=review` at the heredoc seams — DEFERRED.** It would need `lib/test/run.sh`, which three other PRs are contending for right now. Noting it here rather than shipping a conflicting edit.

## Changeset: none

Per `.prflow/prompt-extensions/implement.md` a changeset is for "changes that **reach consumer repos as an update** — a fix, feature, or breaking change to the engine surface"; this PR's only `scripts/` touch is a source comment with zero executable-behavior change, and `docs/cloud-allowlist.md` is a dev-only doc, so it is internal-only by that rule's own words and a CHANGELOG entry would be noise.

## Verification

- `shellcheck --severity=warning -e SC1091 scripts/render-grounding-block.sh` — clean.
- Renderer smoke-tested in `MODE=implement`; output unchanged.
- No `path:line` references introduced (repo convention).
- No new wording-only / prose-presence pins added; `lib/test/run.sh` untouched.
- Full suite not run locally (contended file, and CI is the aggregate gate) — the required `lib + python tests` check is the gate here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
