### PR TITLE
docs(#1061): scope the pin-retirement arms to the existence-pin census

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -264,11 +264,23 @@ wins**. Only arm 2 authorizes a *pin-only* removal; arm 1 permits removal solely
 alongside a copy deletion, and arms 0 and 3 retain outright — so an unanswered
 question always retains:
 
+**Which corpus these arms govern (issue #1061).** They range over the **existence-pin
+census** and nothing else — the sites `lib/test/pin-corpus-classifier.py`'s
+`extract_existence_sites` yields, which are the calls to its `EXISTENCE_HELPERS` names
+plus the presence-suffixed module wrappers `source_existence_helpers` admits. A pin of
+any other shape — a count-family helper (`pin_count`, `devflow_module_pin_count`) or a
+raw `grep -qF` presence check — is not a member and never has been, so **no arm below
+decides it, arm 0's *retain* included**. Its disposition is the separate rule under
+*Disposing of a pin outside the existence census*, after the arms.
+
 0. **No row** — the census is a **frozen snapshot**, not a live index, so a pin added
    since its `# revision:` line has none. This is the normal state between refreshes,
    and it means the census *cannot answer*, **never** that the answer is "no".
-   Either regenerate the census (below) and re-read, or **retain the pin**. Do not
-   hand-count: the deciding number excludes the census's own
+   Either regenerate the census (below) and re-read, or **retain the pin**. This arm
+   is about a row that is *absent* — obtainable, just not taken yet — and never about
+   one that is **unobtainable** because the pin is not in this corpus at all; that is
+   the case the scoping paragraph above routes elsewhere. Do not hand-count: the
+   deciding number excludes the census's own
    `# counted-file-exclusions` set (`lib/test/`, `.prflow/learnings/`,
    `.prflow/logs/`, `.changeset/`, `CHANGELOG.md`), so a `git grep` over-counts.
 1. **`counted_occurrences >= 2`** — remove the pin only in the same change that
@@ -303,6 +315,45 @@ question always retains:
 Adjudications are *read* from the inventory but *changed* in
 `lib/test/pin-corpus-adjudications.tsv` (the delta-gated table), then regenerated;
 never hand-edit the generated inventory.
+
+**Disposing of a pin outside the existence census (issue #1061).** Such a pin is
+**outside the ledger's domain**, and each ledger disposition is structurally
+unavailable to it rather than merely unused:
+
+- **No census row is obtainable.** `extract_existence_sites` yields a site only for a
+  helper in the existence set, and `source_existence_helpers` deliberately declines to
+  admit count-family wrappers — a recorded decision its own docstring states. So such a
+  literal has no site at any revision and therefore no adjudication key at all. Its row
+  is not missing; it cannot be produced.
+- **No row may be added by hand.** `pin-corpus-classifier.py` requires the adjudication
+  table's key set to be exactly closed over the sites it extracts and fails generation
+  on any key it cannot match, and
+  `test_current_worktree_adjudications_close_the_classifier_corpus` in
+  `lib/test/test_red_on_removal_retirement_manifest.py` enforces that against the
+  working tree. **Do not add rows for non-existence literals** — that closure stays as
+  it is.
+- **A `# structural-pin-ok:` declaration does not rescue one whose literal resolves
+  into prose.** The routing ladder weighs prose resolution *before* the bare
+  declaration pass, and helper identity buys no exemption (issue #925), so a
+  declaration clears a prose-resolving literal only in company with a `boundary` ledger
+  row — the row the point above says cannot be minted.
+
+The disposition is therefore taken **directly under the parent prose-pin policy**
+(`CLAUDE.md`'s *Recorded decision* bullet for issues #843/#876), on that policy's own
+question: does any tool or consumer read the pinned content? If one does — and the
+routing ladder's step 1 will usually have said so already — the pin is **retained**
+under the `# structural-pin-ok:` rule above, and nothing here authorizes removing it.
+If none does, the target is agent-executed prose, retirement owes no replacement
+coverage, and the pin is retired on that basis with **its disposition and the evidence
+for it recorded in prose** — the issue or pull request that retires it — never as a
+ledger row. That record carries the consumer search establishing no reader (run over
+the consumer surface the lint's own `machine_consumer_evidence` reads, so it is the
+same question the gate asks) and names what stops being asserted afterwards; the
+compensating control is the review pass that reads the prose, which narrows the gap
+and does not close it. Issue #1007's two literals are the worked case: both were
+count-helper or raw-`grep -qF` pins, and PR #1067 retired them under exactly this rule,
+with the per-literal consumer search and the accepted trade-off recorded on the issue
+instead of in the table.
 
 **Worked cases — the `#291` boundaries, which split across two arms.** Two of the
 three `#291` sites (`291(AC1)` and the `291(AC4)` severity-calibrated-eval pin) carry


### PR DESCRIPTION
Closes #1061.

Implements the maintainer ruling recorded on the issue: **option one** — a pin outside the existence-pin census is outside the ledger's domain, and is disposed of directly under the #843/#876 parent prose-pin policy, recorded in prose with evidence rather than as a ledger row. Options two (widen the corpus) and three (retain by default) are rejected and are not implemented here.

## What changed

`CONTRIBUTING.md` only, in the pin-retirement section:

1. **Scoping paragraph, immediately above the ordered arms** — *"Which corpus these arms govern (issue #1061)"*. States that the arms range over the existence-pin census and nothing else (the sites `extract_existence_sites` yields: `EXISTENCE_HELPERS` calls plus the presence-suffixed module wrappers `source_existence_helpers` admits), that a count-family (`pin_count`, `devflow_module_pin_count`) or raw `grep -qF` pin is not a member, and that **no arm decides such a pin — arm 0's *retain* included**. This is the load-bearing half: it removes the mis-signal named in the issue's *User Impact*.
2. **A clause in arm 0** separating an *absent* row (obtainable, not yet taken) from an **unobtainable** one, and routing the latter to the new rule.
3. **New rule after the arms** — *"Disposing of a pin outside the existence census (issue #1061)"*. Names the three structurally-unavailable ledger dispositions, then states the disposition that is available: decide under #843/#876's own question (does any tool or consumer read the content?); retain under `# structural-pin-ok:` if one does; otherwise retire and record the disposition plus its consumer-search evidence in prose — the issue or PR that retires it — never as a ledger row. #1007 / PR #1067 is cited as the worked case.

The canonical statement of the scoping and of the non-census disposition now lives in `CONTRIBUTING.md`'s pin-retirement section — the same place `CLAUDE.md` already points to for "the canonical ordered arms". No second copy was added.

## Premises verified against the tree before writing

The issue's central claim is a closed loop. Each limb was confirmed here, not taken on trust:

- **The gate weighs prose resolution before the bare declaration pass.** In `lib/test/pin-corpus-lint.py`'s routing ladder, the `_literal_prose_resolution` branch is evaluated ahead of the unconditional `if declared: continue`, and inside it a declaration passes the site only in company with `ledger_records_boundary(...)`. A `# structural-pin-ok:` declaration alone therefore never rescues a prose-resolving literal. The `_helper_family` short-circuit that once exempted count helpers is gone (issue #925, stated in the code's own comment and in `_literal_prose_resolution`'s docstring), so a count-spelled prose pin reaches the same finding.
- **`extract_existence_sites` yields no site for those pin shapes.** It filters to `existence_helpers`, which is `EXISTENCE_HELPERS` (`assert_pin_unique`, `assert_pin_red_on_removal`, `devflow_module_pin_unique`, `devflow_module_pin_present`) plus the presence-suffixed wrappers; `source_existence_helpers`' docstring explicitly refuses count-family wrappers, naming them as a decision. Empirically: the census's helper column contains only those four names plus `_raf_pin_unique`, and zero `pin_count` / `devflow_module_pin_count` rows, while `lib/test/run.sh` alone carries 125 `pin_count` call sites. Raw `grep -qF` checks are not helper calls at all.
- **The adjudication table's key set is exactly closed.** `pin-corpus-classifier.py` computes `set(adjudications) - known_keys` and raises `unknown adjudication keys` on any residue; `test_current_worktree_adjudications_close_the_classifier_corpus` (`lib/test/test_red_on_removal_retirement_manifest.py`) runs the classifier against the live working tree and asserts rc 0. Adding a row for a non-existence literal fails it.

All three hold, so the mechanism documented is the one that exists. No adjudication rows are added and the closure is untouched.

## Verification

Focused module, direct leading token — `harness-python-guards`, which owns issue #798 (the retirement arms) and drives the pin-corpus classifier, the #810 authoring gate, and the red-on-removal / residual retirement manifests:

```
lib/test/run-module.sh harness-python-guards
...
  PASS  #798 pin-corpus classifier remains maintainer-run (no run.sh invocation)
#810 pin-corpus wording-only authoring gate
  test_pin_corpus_lint.py: executed 207 test(s) across 4 concurrent worker(s) (207 enumerated)
  PASS  #810 pin-corpus authoring gate: focused Python tests pass
#810 red-on-removal retirement manifest
  PASS  #810 red-on-removal retirement manifest: focused Python tests pass
#810 residual pin-retirement manifests
  PASS  #810 residual pin-retirement manifests: focused Python tests pass
...
Module harness-python-guards: 43 passed, 0 failed
```

The `CONTRIBUTING.md` gates in `lib/test/run.sh` are unmodularized, so they were checked directly instead of by a full-suite run: the `_WSR_RETIRED_LITS` retired-convention sweep (all nine spans count 0 in `CONTRIBUTING.md`) and the `#719` `pin_count 'focused path'` assertion (0). No `.py` or `.sh` file was touched, so `ruff` and `shellcheck` have nothing new to read. CI is the aggregate gate.

## No changeset

`CONTRIBUTING.md` is not on the engine surface (`skills/`, `agents/`, `lib/`, `scripts/`, workflows, config schema), so no `.changeset/*.md` entry is required.

## No new pin

This is a policy-documentation change with no executable surface. Per #375/#666/#810 no wording-only or prose-presence pin was added to assert the new prose exists, and #843/#876 states that this absence is the decision rather than a gap to paper over.

## Residual for the maintainer

`CLAUDE.md`'s *Recorded decision* bullet for #843/#876 says "Each pin's answer is a per-pin adjudication read from `.prflow/logs/pin-corpus-inventory.tsv`", a universal over "each pin" that carries a trace of the same mis-signal for a pin the census cannot key. It was left alone deliberately: `CLAUDE.md` edits route through `/claude-md-management:revise-claude-md`, its retirement-arms Convention bullet is already scoped by its own opening words ("an existence-only pin") and defers to `CONTRIBUTING.md` as canonical, and adding the new fact there would make a second copy of it. Flagging rather than editing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
