### PR TITLE
test: harden the #1196 guard assertions (PR #1201 review follow-up)

### DIFF
--- a/lib/test/run.sh
+++ b/lib/test/run.sh
@@ -41456,8 +41456,22 @@ fi
 assert_eq "#1196 mutation: reserved stem with an extension (nul.md)" "rc=1" "$(e1196_rc skills/nul.md)"
 assert_eq "#1196 mutation: bare reserved stem (nul)" "rc=1" "$(e1196_rc skills/nul)"
 assert_eq "#1196 mutation: reserved stem in a NON-final component (nul/x.md)" "rc=1" "$(e1196_rc skills/nul/x.md)"
-assert_eq "#1196 mutation: reserved stem with a trailing space (nul )" "rc=1" "$(e1196_rc 'skills/nul ')"
-assert_eq "#1196 mutation: reserved name followed by : (nul:ads)" "rc=1" "$(e1196_rc skills/nul:ads)"
+# These two cases each have a violating input that a SECOND, independent rule also catches,
+# so an exit-code comparand passes them for the wrong reason (the PR #1201 review's finding
+# 1): `:` is independently a member of _FORBIDDEN_CHARS, and a trailing space is independently
+# caught by the trailing-space arm — so `nul:ads` and `nul ` both stay rc=1 with the
+# reserved-name rule's terminator handling (its `:` terminator and its trailing-space skip)
+# deleted outright. Measured before this change: with both deleted, the whole block was green.
+# The discriminating comparand is the REASON the guard reports, which names the rule that
+# actually fired. Under that deletion it becomes forbidden-character(':') / trailing-space
+# instead of reserved-device-name(NUL), so these two go RED where the exit code could not.
+# `rc=1|` is matched too, so each still subsumes the exit-code check it replaces.
+E1196_TSP="$(e1196_run 'skills/nul ')"
+assert_eq "#1196 mutation: reserved stem with a trailing space (nul ) fires the RESERVED-NAME rule" "yes" \
+  "$(case "$E1196_TSP" in "rc=1|"*"'nul ' reserved-device-name(NUL)"*) echo yes ;; *) echo "no: $E1196_TSP" ;; esac)"
+E1196_ADS="$(e1196_run skills/nul:ads)"
+assert_eq "#1196 mutation: reserved name followed by : (nul:ads) fires the RESERVED-NAME rule" "yes" \
+  "$(case "$E1196_ADS" in "rc=1|"*"'nul:ads' reserved-device-name(NUL)"*) echo yes ;; *) echo "no: $E1196_ADS" ;; esac)"
 # A `:` in a NON-reserved component reaches the forbidden-character arm (nul:ads above is caught
 # by the reserved-device branch first), so this is the case that goes RED if `:` were dropped
 # from _FORBIDDEN_CHARS — and it is the DOS-drive-prefix protection the guard subsumes via `:`.
@@ -41479,6 +41493,16 @@ assert_eq "#1196 negative controls are not flagged" "rc=0" \
 # COM/LPT asymmetry (AC7), demonstrated in BOTH directions: com0 not flagged, lpt0 flagged.
 assert_eq "#1196 asymmetry: com0.md is NOT flagged" "rc=0" "$(e1196_rc skills/com0.md)"
 assert_eq "#1196 asymmetry: lpt0.md IS flagged" "rc=1" "$(e1196_rc skills/lpt0.md)"
+# ...plus the POSITIVE half of the COM range (the PR #1201 review's finding 2). com0 being
+# clean pins only where the range STARTS: a regression that emptied _RESERVED_STEMS of every
+# COM member would leave BOTH assertions above passing, since neither reads a reserved COM.
+# The comparand is the guard's own violation TALLY over all nine, not the exit code — rc=1
+# over a nine-path list is satisfied by a single surviving member, so one hit could carry the
+# whole set; `9 violation(s)` cannot be satisfied by fewer than nine.
+E1196_COM="$(e1196_run skills/com1.md skills/com2.md skills/com3.md skills/com4.md skills/com5.md \
+                       skills/com6.md skills/com7.md skills/com8.md skills/com9.md)"
+assert_eq "#1196 asymmetry: every one of COM1-COM9 IS flagged" "yes" \
+  "$(case "$E1196_COM" in *"audited 9 tracked path(s), 9 violation(s)"*) echo yes ;; *) echo "no: $E1196_COM" ;; esac)"
 
 # ── Path-quoting regression (PR #1201 review finding 1) ──────────────────────
 # `core.quotePath` defaults to TRUE, under which git emits a non-ASCII path in C-QUOTED form:
@@ -41535,7 +41559,15 @@ assert_eq "#1196 the non-ASCII sandbox run audited its one tracked path" "yes" \
 # non-zero "enumeration unusable", never a clean pass — "audited nothing" ≠ "found nothing".
 E1196_EMPTY="$(probe_tmp '#1196 empty population')" || E1196_EMPTY=""
 case "$E1196_EMPTY" in
-  ""|/dev/null) : ;;
+  # probe_tmp has already recorded its own allocation FAIL, so this host is not silently
+  # green — but the NAMED check below would still vanish from the registered-check
+  # population here, and the #456 rule is that the population stays STABLE across
+  # environments: a host that cannot allocate scratch must report the same check name a
+  # host that can does. Emit it through the sole sanctioned skip emitter (the same way the
+  # historical block above handles its unreachable-commit host), rather than dropping it.
+  ""|/dev/null)
+     skip "#1196 an empty population fails closed (not a clean pass)" host-capability \
+       "probe_tmp allocated no usable scratch file for the empty --files-from list" ;;
   *) : > "$E1196_EMPTY"
      E1196_EOUT="$(python3 "$E1196_LINT" --root "$LIB/.." --files-from "$E1196_EMPTY" 2>&1)"; E1196_ERC=$?
      rm -f "$E1196_EMPTY"


### PR DESCRIPTION
Follow-up to **PR #1201** (merged as `d11a77b4`), addressing the three Suggestion-level findings its review raised. All three are in the `#1196` Windows-uncheckoutable tracked-path block in `lib/test/run.sh`; the guard itself (`lib/test/lint-windows-uncheckoutable-path.py`) is **unchanged**.

The diff is confined to `lib/test/`, so it is internal-only and carries no changeset.

---

## Finding 1 — two mutation fixtures passed for the wrong reason

`nul:ads` and `nul ` were asserted by exit code alone, but each violating input is caught by a **second, independent rule**: `:` is independently a member of `_FORBIDDEN_CHARS`, and a trailing space is independently caught by the `trailing-space` arm. So both stayed `rc=1` even with the reserved-name rule's `:` terminator and trailing-space skip deleted outright.

**Fix.** Both assertions now compare the **reason** the guard reports — `reserved-device-name(NUL)`, which names the rule that actually fired — instead of the exit code. Each pattern still matches the `rc=1|` prefix, so it subsumes the exit-code check it replaces rather than trading one guarantee for another.

### RED-first evidence

The block was driven in isolation against the real guard and against scratch mutations of it (the guard was restored via `git checkout --` between every run; nothing was committed in a mutated state).

| Guard state | Before this PR | After this PR |
|---|---|---|
| unmutated | 24 passed, 0 failed | 25 passed, 0 failed |
| `:` terminator **and** trailing-space skip both deleted | **24 passed, 0 failed** — the finding | **23 passed, 2 failed** |
| only the `:` terminator deleted | — | 24 passed, **1 failed** (`nul:ads`) |
| only the trailing-space skip deleted | — | 24 passed, **1 failed** (`nul `) |

The top-right/top-left cells are the point: with the reserved-name rule's terminator handling deleted *entirely*, the pre-existing assertions stayed fully green. Each half is now independently discriminating.

The reason strings behind it:

```
real guard:  skills/nul:ads -> 'nul:ads' reserved-device-name(NUL)
             skills/nul     -> 'nul '    reserved-device-name(NUL)
mutated:     skills/nul:ads -> 'nul:ads' forbidden-character(':')
             skills/nul     -> 'nul '    trailing-space
```

Isolation was **not** impossible — no fixture was faked.

## Finding 2 — no positive `COM1`–`COM9` assertion

The asymmetry block asserted `com0` is *not* flagged and `lpt0` *is*, which pins only where the range **starts**. A regression that emptied `_RESERVED_STEMS` of every COM member left both passing, since neither reads a reserved COM.

**Fix.** An assertion over all nine paths that compares the guard's own **violation tally** (`audited 9 tracked path(s), 9 violation(s)`) rather than the exit code — an `rc=1` over a nine-path list is satisfied by a single surviving member, so one hit could carry the whole set.

RED-first: emptying the COM range fails **only** the new assertion (24 passed, 1 failed) while `com0`/`lpt0` both still pass — exactly the blind spot the reviewer predicted. A *partial* regression (`COM1`–`COM5` only) also fails it, reporting `audited 9 tracked path(s), 5 violation(s)`.

The guard's implementation was re-verified against git's rule: `_RESERVED_STEMS` builds `com1`–`com9` (git tests `c < '1' || c > '9'`, so `COM0` is not reserved) and `lpt0`–`lpt9` (git tests `isdigit()`, so `LPT0` is). The asymmetry is modelled correctly.

## Finding 3 — a dropped check in the empty-population block

The AC8 empty-population block's `""|/dev/null` probe-unavailable arm was `: ;` — it silently dropped its named check, unlike the sibling historical block which skips both of its checks by name.

**Fix.** The arm now routes through the sanctioned `skip <name> <kind> <reason>` helper as `host-capability`, so the `#456` registered-check population stays stable across environments. `probe_tmp` already records its own allocation FAIL, so the host was never silently green — but the *named* check vanished, which is the population-stability defect.

Verified by forcing every `mktemp` in the block to fail:

- **before:** skip log empty — the check name appears nowhere
- **after:** `host-capability<TAB>#1196 an empty population fails closed (not a clean pass)<TAB>probe_tmp allocated no usable scratch file for the empty --files-from list`

---

## Verification

`#1196` is registered `"owner": "unmodularized"` in `coverage-map.json`, so it has no `run-module.sh` id. It was driven through a scratch harness that sources the real `module-harness.sh`, the real `skip()`/`assert_eq()` lifted verbatim from `run.sh`, and the `#1196` block extracted from `run.sh` itself — so the assertions under test are the shipped ones, not a paraphrase.

- focused `#1196` block: **25 passed, 0 failed, 0 skipped** (was 24; +1 for the COM range)
- `shellcheck --severity=warning -e SC1091 --extended-analysis=false lib/test/run.sh` — clean (ShellCheck 0.11.0)
- `lib/test/coverage_map_guard.py` — rc 0
- `lib/test/pin-corpus-lint.py mutation-routing-worktree` — `MUTATION-ROUTING-STATIC-SCAN-COMPLETED`, rc 0
- `lib/test/lint-tree-enumeration.py` — 112/112 audited, clean
- no `.py` touched, so no `ruff` surface in this diff
- no module floor moves (`unmodularized` owner; no `#1196` assertions live in any `lib/test/modules/*.sh`)

The full suite was deliberately **not** run here — a live suite run was in progress in a sibling worktree — so CI (`lib + python tests`) is the aggregate gate for this PR.

No reserved, non-ASCII, or exotic filename was ever planted on disk: every fixture is a synthetic path string fed through the guard's `--files-from` interface, which is the incident-avoidance rule issue #1196 exists to enforce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
