### PR TITLE
fix(agents): scope review-agent mutation checks to the narrowest covering target

### DIFF
--- a/.changeset/d1-review-agent-mutation-scope.md
+++ b/.changeset/d1-review-agent-mutation-scope.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+---
+
+### Changed
+
+- The five `pr-review-toolkit` review agents (`code-reviewer`, `comment-analyzer`, `pr-test-analyzer`, `silent-failure-hunter`, `type-design-analyzer`) now scope their mutation/half-revert verification to the narrowest test target covering the guard under test, instead of launching the project's whole test suite. All five are dispatched on every review roster pass and again on every shadow pass, and each could previously launch a full suite per finding from inside a subagent where the orchestrator never saw the cost. Mutation evidence needs only one assertion to go RED, so a whole-suite run proved nothing extra. The block stays read-only and advisory and keeps its `mktemp` temporary-copy discipline unchanged.

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -24,7 +24,7 @@ Three representative scenarios:
 
 ## Working-tree policy (read-only, advisory)
 
-You are advisory only: never modify working-tree source files, the index, HEAD, or branch state. Your job is to report findings, not to apply them. If verifying a finding would benefit from a mutation or half-revert check (delete a pinned line, flip a condition, then run the suite to confirm a guard goes RED), perform any mutation or half-revert verification on a temporary copy made with `mktemp`, never in place. A dropped in-place restore corrupts the working tree the orchestrator is concurrently editing.
+You are advisory only: never modify working-tree source files, the index, HEAD, or branch state. Your job is to report findings, not to apply them. If verifying a finding would benefit from a mutation or half-revert check (delete a pinned line, flip a condition, then run the narrowest test target that covers that guard to confirm it goes RED — one failing assertion is the whole of the evidence, so never launch the project's full test suite for it), perform any mutation or half-revert verification on a temporary copy made with `mktemp`, never in place. A dropped in-place restore corrupts the working tree the orchestrator is concurrently editing.
 
 ## Command-shape discipline (cloud runs)
 

--- a/agents/comment-analyzer.md
+++ b/agents/comment-analyzer.md
@@ -90,7 +90,7 @@ Remember: You are the guardian against technical debt from poor documentation. B
 
 ## Working-tree policy (read-only, advisory)
 
-You are advisory only: never modify working-tree source files, the index, HEAD, or branch state. Your job is to report findings, not to apply them. If verifying a finding would benefit from a mutation or half-revert check (delete a pinned line, flip a condition, then run the suite to confirm a guard goes RED), perform any mutation or half-revert verification on a temporary copy made with `mktemp`, never in place. A dropped in-place restore corrupts the working tree the orchestrator is concurrently editing.
+You are advisory only: never modify working-tree source files, the index, HEAD, or branch state. Your job is to report findings, not to apply them. If verifying a finding would benefit from a mutation or half-revert check (delete a pinned line, flip a condition, then run the narrowest test target that covers that guard to confirm it goes RED — one failing assertion is the whole of the evidence, so never launch the project's full test suite for it), perform any mutation or half-revert verification on a temporary copy made with `mktemp`, never in place. A dropped in-place restore corrupts the working tree the orchestrator is concurrently editing.
 
 ## Command-shape discipline (cloud runs)
 

--- a/agents/pr-test-analyzer.md
+++ b/agents/pr-test-analyzer.md
@@ -24,7 +24,7 @@ Three representative scenarios:
 
 ## Working-tree policy (read-only, advisory)
 
-You are advisory only: never modify working-tree source files, the index, HEAD, or branch state. Your job is to report findings, not to apply them. If verifying a finding would benefit from a mutation or half-revert check (delete a pinned line, flip a condition, then run the suite to confirm a guard goes RED), perform any mutation or half-revert verification on a temporary copy made with `mktemp`, never in place. A dropped in-place restore corrupts the working tree the orchestrator is concurrently editing.
+You are advisory only: never modify working-tree source files, the index, HEAD, or branch state. Your job is to report findings, not to apply them. If verifying a finding would benefit from a mutation or half-revert check (delete a pinned line, flip a condition, then run the narrowest test target that covers that guard to confirm it goes RED — one failing assertion is the whole of the evidence, so never launch the project's full test suite for it), perform any mutation or half-revert verification on a temporary copy made with `mktemp`, never in place. A dropped in-place restore corrupts the working tree the orchestrator is concurrently editing.
 
 ## Command-shape discipline (cloud runs)
 

--- a/agents/silent-failure-hunter.md
+++ b/agents/silent-failure-hunter.md
@@ -33,7 +33,7 @@ You operate under these non-negotiable rules:
 
 ## Working-tree policy (read-only, advisory)
 
-You are advisory only: never modify working-tree source files, the index, HEAD, or branch state. Your job is to report findings, not to apply them. If verifying a finding would benefit from a mutation or half-revert check (delete a pinned line, flip a condition, then run the suite to confirm a guard goes RED), perform any mutation or half-revert verification on a temporary copy made with `mktemp`, never in place. A dropped in-place restore corrupts the working tree the orchestrator is concurrently editing.
+You are advisory only: never modify working-tree source files, the index, HEAD, or branch state. Your job is to report findings, not to apply them. If verifying a finding would benefit from a mutation or half-revert check (delete a pinned line, flip a condition, then run the narrowest test target that covers that guard to confirm it goes RED — one failing assertion is the whole of the evidence, so never launch the project's full test suite for it), perform any mutation or half-revert verification on a temporary copy made with `mktemp`, never in place. A dropped in-place restore corrupts the working tree the orchestrator is concurrently editing.
 
 ## Command-shape discipline (cloud runs)
 

--- a/agents/type-design-analyzer.md
+++ b/agents/type-design-analyzer.md
@@ -23,7 +23,7 @@ Two representative scenarios:
 
 ## Working-tree policy (read-only, advisory)
 
-You are advisory only: never modify working-tree source files, the index, HEAD, or branch state. Your job is to report findings, not to apply them. If verifying a finding would benefit from a mutation or half-revert check (delete a pinned line, flip a condition, then run the suite to confirm a guard goes RED), perform any mutation or half-revert verification on a temporary copy made with `mktemp`, never in place. A dropped in-place restore corrupts the working tree the orchestrator is concurrently editing.
+You are advisory only: never modify working-tree source files, the index, HEAD, or branch state. Your job is to report findings, not to apply them. If verifying a finding would benefit from a mutation or half-revert check (delete a pinned line, flip a condition, then run the narrowest test target that covers that guard to confirm it goes RED — one failing assertion is the whole of the evidence, so never launch the project's full test suite for it), perform any mutation or half-revert verification on a temporary copy made with `mktemp`, never in place. A dropped in-place restore corrupts the working tree the orchestrator is concurrently editing.
 
 ## Command-shape discipline (cloud runs)
 


### PR DESCRIPTION
## What this changes

The five `pr-review-toolkit` review agents — `code-reviewer`, `comment-analyzer`, `pr-test-analyzer`, `silent-failure-hunter`, `type-design-analyzer` — each carry a **byte-identical** `## Working-tree policy (read-only, advisory)` block. That block licensed a **whole-suite run** as the way to confirm a mutation/half-revert check goes RED:

> …(delete a pinned line, flip a condition, then run **the suite** to confirm a guard goes RED)…

It now names the narrowest covering target instead:

> …(delete a pinned line, flip a condition, then run **the narrowest test target that covers that guard** to confirm it goes RED — one failing assertion is the whole of the evidence, so never launch the project's full test suite for it)…

## The multiplier being removed

This is a per-agent × per-finding multiplier, and it compounds where nobody can see it:

- All five agents are dispatched on **every** Phase 3 reviewer roster pass, **and again on every shadow pass**.
- Each was licensed to launch a whole suite **per finding**.
- The launches happen **inside a subagent**, so the orchestrator never observes the cost and never attributes it.
- The cloud coordinator is roughly 10.5 minutes per launch.

**Mutation evidence needs exactly one assertion to go RED.** A whole-suite run proves nothing the narrowest covering target does not already prove — it is strictly wasted wall-clock. Scoping the instruction removes the multiplier without weakening the evidence standard.

## What is deliberately unchanged

- The block stays **read-only and advisory**.
- The `mktemp` temporary-copy discipline is unchanged — verification still never touches the real working tree.
- No change to what the agents review, their tools, their frontmatter, or their dispatch gates. This is a scope change to one verification instruction only.
- Wording stays **generic** ("the narrowest test target that covers that guard", "the project's full test suite") rather than naming PRFlow-internal paths, because these vendored bodies ship verbatim into consumer repos.

## Byte-identity of the five blocks — confirmed

The five paragraphs were byte-identical before the edit and remain byte-identical after it:

```
$ grep -h 'You are advisory only' \
    agents/code-reviewer.md agents/comment-analyzer.md agents/pr-test-analyzer.md \
    agents/silent-failure-hunter.md agents/type-design-analyzer.md | sort -u | wc -l
       1
```

One distinct line across all five files. All five were changed in this single commit.

## Provenance

`CLAUDE.md` records these five as vendored from Anthropic's `pr-review-toolkit` under Apache-2.0. Each file's header comment already reads *"This file has been MODIFIED by PRFlow"* and points at `LICENSES/pr-review-toolkit-LICENSE` — the repo already modifies these bodies freely under a modification-disclosing header, and this whole `Working-tree policy` block is itself a PRFlow addition (it is pinned by issue #192). Every license/attribution header is preserved untouched.

## Pins reconciled

**None needed — no pin was invalidated.** The two `lib/test/run.sh` `#192` pins that assert over these exact five files were checked before editing and both literals survive verbatim:

| Pin | Literal | Status |
|---|---|---|
| `#192 agent-mandate: primary write-prohibition` | `modify working-tree source files, the index, HEAD, or branch state` | preserved verbatim, unique in each of the five |
| `#192 agent-mandate: never-mutate/mktemp-copy mandate` | ``on a temporary copy made with `mktemp`, never in place`` | preserved verbatim, unique in each of the five |

Nothing pins the replaced clause (`run the suite to confirm a guard goes RED`), no assertion counts these five copies byte-for-byte, and `agents/**` carries no entry in `scripts/devflow-cloud-writer-contract.json` or `lib/test/modules/coverage-map.json`. The sibling `skills/requesting-code-review/code-reviewer.md` — which bars mutation runs outright and has its own separate pins — is untouched.

## Verification

`agents/**` has no covering focused module (`coverage-map.json` maps `lib/` and `scripts/` only, and no module under `lib/test/modules/` carries the `#192` pins — they are `run.sh`-resident), so per the tier ladder the `monolith` shard was run rather than the full coordinator:

```
$ lib/test/run-shard.sh monolith
8468 passed, 0 failed
shard-tally extract [monolith]: 8468 passed, 0 failed, 0 skipped (rc=0)

$ git ls-files '*.py' | xargs -r ruff check
All checks passed!
```

Zero failures, **zero skips**.

## Changeset

`agents/**` is engine surface, so this carries `.changeset/d1-review-agent-mutation-scope.md` with `bump: patch`. `.claude-plugin/plugin.json` and `CHANGELOG.md` are untouched.

---

Writing-skills evidence: skill-loaded=yes (a context-isolated Agent-tool subagent invoked `superpowers:writing-skills` before opening any target file and read its full guidance); guidance-applied=yes (the edit was checked against "Match the Form to the Failure" — the baseline is a wrong-shaped-action failure, so the replacement is a positive recipe naming the correct target with the whole-suite escape hatch closed inline, rather than a bare prohibition); pressure-scenario=no (the replacement string was fixed verbatim by the brief and further constrained by two suite pins, so no wording latitude remained for a baseline/GREEN subagent cycle to discriminate); micro-tests=no (same reason — no competing wording variants to sample and no no-guidance control for a single mandated string).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
