### PR TITLE
security: narrow the PRFlow trigger authorization surface

### DIFF
--- a/.prflow/config.json
+++ b/.prflow/config.json
@@ -4,8 +4,8 @@
   "claude_model": "claude-opus-4-8",
   "prflow_version": "main",
   "prflow": {
-    "allowed_bots": "claude,dependabot,prflow-implementer",
-    "allowed_users": "*",
+    "allowed_bots": "claude,prflow-implementer",
+    "allowed_users": "The01Geek",
     "workpad_marker": "<!-- prflow:workpad -->",
     "effort": "low",
     "allowed_tools": [


### PR DESCRIPTION
Two authorization tightenings in this repository's own `.prflow/config.json`. Both keys feed `scripts/authorize-actor.sh`, the shared gate every AGENT-mode PRFlow workflow calls before starting a billable run.

## 1. Remove `dependabot` from `prflow.allowed_bots`

### The bot-bypass mechanism

`authorize_actor()` grants an `ALLOWED_BOTS` member authorization **before and instead of** the collaborator permission lookup. The bot loop runs first and sets the flag:

```bash
for b in "${bots[@]}"; do
  ...
  if [ -n "$bt" ] && { [ "$bt" = "$actor" ] || [ "$bt" = "$actor_bare" ]; }; then
    authorized=true
  fi
done

# User path: must match allowed_users AND hold write/admin/maintain.
if [ "$authorized" != "true" ] && [ -n "$actor" ] && [ -n "$repo" ]; then
```

The entire `admin|write|maintain` collaborator lookup sits behind `[ "$authorized" != "true" ]`, so a listed bot short-circuits it completely — the permission API is never called. Membership in `allowed_bots` is therefore a *total* bypass of the permission requirement, not an additional path through it. The matcher also strips a trailing `[bot]` suffix (`actor_bare`), so the bare slug matches the `<slug>[bot]` actor.

`dependabot` has no reason to post a PRFlow trigger comment, so it was a bypass path carrying no compensating benefit.

### Confirmed nothing depends on it

- No `.github/dependabot.yml` exists — Dependabot is not enabled on this repository at all.
- The only other `dependabot` occurrences in the tree are an **exclusion**, not a dependency: `github.actor != 'dependabot[bot]'` in `ci.yml`'s `auto_review_trigger` job (and its mirror in `docs/workflow-triggers.md`), which deliberately keeps Dependabot from triggering an auto-review. Removing the grant moves in the same direction.
- The remaining hits are self-contained test fixtures (`lib/test/run.sh`'s #682 block, `lib/test/modules/installer-wiring.sh`) that build their own config JSON, plus the shipped schema default and `config.example.json`. None reads this repository's live `.prflow/config.json`.

`claude` and `prflow-implementer` are retained — both are load-bearing (the implementer App posts trigger and stall-backstop comments; the Claude app identity triggers).

## 2. Pin `prflow.allowed_users` from `"*"` to `The01Geek`

### The wildcard exposure

`"*"` authorizes **any** collaborator holding write/admin/maintain. That is adequate for a solo repository, but it widens silently the moment a collaborator is added — a new collaborator gains the ability to start billable agent runs with no config change and no review. Pinning the owner login makes any future widening an explicit, reviewable edit.

### Verified matching semantics

`_actor_in_allowed_users()`:

```bash
local la="${actor,,}"
IFS=',' read -ra entries <<< "$list"
for entry in "${entries[@]}"; do
  e="${entry#"${entry%%[![:space:]]*}"}"
  e="${e%"${e##*[![:space:]]}"}"
  e="${e,,}"
  [ "$e" = "*" ] && return 0
  [ -n "$e" ] && [ "$e" = "$la" ] && return 0
done
```

- **Comma-separated list**, each entry whitespace-trimmed via parameter expansion.
- **Case-insensitive** exact compare — both sides lowercased (`${actor,,}` / `${e,,}`), so the stored casing of `The01Geek` is immaterial.
- **`*` anywhere in the list** is the wildcard; it has no other special handling.
- A **single-login value is an ordinary supported shape** — one entry, exact match. It is exercised in `lib/test/modules/review-trigger-helpers.sh` (`ALLOWED_USERS="$COLLAB,other"` authorizes; a list omitting the actor denies with `deny_reason` citing the allowlist).
- Empty/unset still defaults to `*` (`[ -z "$allowed_users" ] && allowed_users="*"`), so this is a deliberate narrowing of an otherwise-open default.

### The owner is not locked out

`The01Geek` is the repository owner (`The01Geek/prflow`) and holds admin, so both conjuncts hold: the allowlist match succeeds (case-insensitively), and the `repos/{owner}/{repo}/collaborators/{actor}/permission` lookup returns `admin`, which is in the `admin|write|maintain` accept set.

### The bot path is untouched

Bots are matched by the separate `ALLOWED_BOTS` loop and, as shown above, never reach `_actor_in_allowed_users()` at all — the function's own header comment says so, and the module asserts it directly (`auth: allowed bot bypasses allowed_users → authorized`, with `ALLOWED_USERS="nobody"`). So the App-authored trigger comments — the CI-green auto-review request, the implement and review stall backstops — keep working.

`allowed_bots` also stays non-empty, so the fail-loud `::error::` guard in each workflow's `config` job (`[ "$ENABLED" = "true" ] && [ -z "$ALLOWED_BOTS" ]`) is unaffected.

## Trigger-time inertness — do not expect this PR's own runs to reflect it

Both keys are resolved by the **`config` job at trigger time from the default branch**: `devflow.yml` and `devflow-implement.yml` each run a bare `actions/checkout@v6` under the `issue_comment` trigger and extract `.prflow.allowed_bots` / `.prflow.allowed_users // "*"` from that tree. So this change is **in-PR-inert and post-merge-only** — any run triggered on this pull request still resolves the pre-merge values (`claude,dependabot,prflow-implementer` and `*`). Nothing here can be observed in this PR's own runs; it takes effect on the first trigger after merge.

## Scope, pins, and the consumer default

- Only the two values changed; nothing else in the file.
- `.prflow/config.json` is tracked (force-added past the `/.prflow/*` ignore rule), so the edit staged normally and is in the commit.
- **No pins invalidated.** Every test touching these keys drives `authorize-actor.sh` or the config readers with its own fixture JSON; nothing asserts this repository's live `allowed_bots` or `allowed_users` values. (The two tests that *do* read the live config assert unrelated things — `Bash(cd:*)`'s absence from `prflow_implement.allowed_tools` and the `code-reviewer` agent-override pin.)
- **No changeset.** The changeset criterion covers changes that reach consumer repos as an update — the engine surface and the config *schema*. `.prflow/config.json` is this repository's own settings, and neither `config.example.json` nor `config.schema.json` is touched.
- **`config.example.json` deliberately unchanged** — see the note below.

### Recommendation on `.prflow/config.example.json`

Left unchanged in this PR, with a split recommendation:

- **`allowed_bots: "claude,dependabot"` — worth revisiting separately, but not here.** Shipping `dependabot` as a consumer default hands the same permission-lookup bypass to every fresh install, and unlike this repository a consumer *may* actually run Dependabot. But it is defensible as a starting value, and changing it is not a one-value edit: the same literal is the `default` in `config.schema.json` and is quoted verbatim in `docs/workflow-triggers.md`'s App-slug guidance, so all three must move together — a coupled change that belongs in its own reviewed PR, with a changeset (the schema *is* engine surface).
- **`allowed_users: "*"` — should stay `"*"` for consumers.** A consumer's owner login is unknowable to us, and any pinned placeholder would lock the installing repository out of its own automation on day one. The wildcard is the only value that is correct for an arbitrary installer, and it is already documented in the schema as narrowable. This repository's pin is a per-repository decision, not a defaulting one.

## Verification

`lib/test/run-module.sh review-trigger-helpers` — **782 passed, 0 failed, 0 skipped**, including the `authorize-actor.sh (allowed_users filter)` block. The full suite and the parallel coordinator were deliberately not run: another measurement was in flight on the same host, and CI is the aggregate gate here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
