### PR TITLE
docs: transcribe already-produced matcher-probe verdicts (run 30956039324)

### DIFF
--- a/docs/cloud-allowlist.md
+++ b/docs/cloud-allowlist.md
@@ -1166,11 +1166,12 @@ is a maintainer decision, not this page's.
 | `30956039324` (job `92149438739`) | **FIRED** | **REASON-ABSENT** | n/a — dropped post-#937 |
 
 **This is the 8th consecutive identical `FIRED` / `REASON-ABSENT` pair.** The six prior
-replications, all on same-repo `pull_request` runs and all returning the same pair, are
-runs `30658648601`, `30657675722`, `30652958122`, `30577692232`, `30472371076`, and
-`30421703361`. The two oldest render the breadcrumb path as `.devflow/tmp/…` rather than
-`.prflow/tmp/…` — a pre-#1002 rename spelling of the same marker, not a different
-measurement.
+replications — each re-read from its own job log, each triggered by `event=pull_request`,
+each concluding `success`, and each returning the same pair — are, newest first:
+`30658648601`, `30657675722`, `30652958122`, `30577692232`, `30472371076`, `30421703361`.
+The **three oldest** (`30577692232`, `30472371076`, `30421703361`) render the breadcrumb
+path as `.devflow/tmp/…` rather than `.prflow/tmp/…` — a pre-#1002 rename spelling of the
+same marker, not a different measurement.
 
 **Scope caveat — the `REASON-ABSENT` cell does not mean reason delivery is broken, and
 the row misleads without this.** The probe's own hook emits

--- a/docs/cloud-allowlist.md
+++ b/docs/cloud-allowlist.md
@@ -324,10 +324,12 @@ is filled from this**: the four-way question (`BOTH_HOPS` / `ORCHESTRATOR_ONLY` 
 `NEITHER_HOP`) remains open, and `ORCHESTRATOR_ONLY` in particular must not be inferred
 from a silent hop one.
 
-What this changes is the remedy. The observation suggests the probe needs a **design
-fix** before it can yield a verdict — hop one's report is not reaching the execution
-file the helper reads — so a blind re-dispatch would most likely return `INCONCLUSIVE`
-again. Diagnosing and repairing the probe's hop-one reporting path (a `matcher-probe.yml`
+What this changes is the remedy. The probe most likely needs a **design fix** before it
+can yield a verdict, so a blind re-run would probably return `INCONCLUSIVE` again. What
+is established is only that hop one produced **no reading at all** in the execution file
+the helper reads; *why* — the hop's command never ran, ran and emitted nothing, or ran
+and its output never reached that file — is itself unestablished and is the first thing
+to determine. Diagnosing and repairing the hop-one reporting path (a `matcher-probe.yml`
 change) is the actual next step, not another run.
 
 Until a verdict exists, the claim that a consumer's committed base-ref

--- a/docs/cloud-allowlist.md
+++ b/docs/cloud-allowlist.md
@@ -162,15 +162,17 @@ The portable source anchor `"${CLAUDE_SKILL_DIR:-…}"/../../scripts/<helper>` (
 
   `Bash(echo:*)` was present in that run's resolved allowlist — **the head was granted and the command was still denied.** The distinguishing feature is the unexpanded `${VAR:-default}` expansion in the **argument**. That run recorded 21 denials in total and still completed, so the denial is individually invisible, not individually fatal.
 
-  **Scope of the argument-position denial — three measurement rows now exist (issue #1152), verdict DISPATCHED-PENDING.** Whether the matcher refuses all unexpanded parameter expansions in argument position, only the defaulted `${VAR:-default}` form, or only this variable, was previously **unestablished** — `matcher-probe.yml` carried no argument-position corpus row. Issue #1152 adopted issue #1124's orphaned rows and added them to the new **`command-probe`** job (rows 8–10), which measures the same `command` tier the denial was recorded on:
+  **Scope of the argument-position denial — MEASURED, run `30956039324` (issue #1152).** Whether the matcher refuses all unexpanded parameter expansions in argument position, only the defaulted `${VAR:-default}` form, or only this variable, was **unestablished** until this run — `matcher-probe.yml` had carried no argument-position corpus row. Issue #1152 adopted issue #1124's orphaned rows and added them to the **`command-probe`** job (rows 8–10), which measures the same `command` tier the denial was recorded on. The verdicts below are from that job (job `92149438683`) of run [`30956039324`](https://github.com/The01Geek/prflow/actions/runs/30956039324), head `85e57ac1c6dcf732a861230f82182191977c6e41`, ref `issue-1152-command-profile-shape-lint`:
 
   | # | Argument-position shape | Verdict |
   |---|-------------------------|---------|
-  | 8 | defaulted anchor expansion `echo "${CLAUDE_SKILL_DIR:-…}" …` (reproduces run `30695072336`) | **dispatched-pending** |
-  | 9 | bare anchor expansion `echo "${CLAUDE_SKILL_DIR}" …` | **dispatched-pending** |
-  | 10 | bare expansion of a **non-anchor** variable `echo "${GITHUB_ACTIONS}" …` (control — distinguishes "this variable" from "this expansion form") | **dispatched-pending** |
+  | 8 | defaulted anchor expansion `echo "${CLAUDE_SKILL_DIR:-…}" …` (reproduces run `30695072336`) | **DENIED** |
+  | 9 | bare anchor expansion `echo "${CLAUDE_SKILL_DIR}" …` | **DENIED** |
+  | 10 | bare expansion of a **non-anchor** variable `echo "${GITHUB_ACTIONS}" …` (control — distinguishes "this variable" from "this expansion form") | **DENIED** |
 
-  The rows and their generated baseline ship with this change; the verdicts land on a later `workflow_dispatch` of `matcher-probe.yml`. **A verdict is never written from inference** — matcher semantics are provable only in a real probe run. Read against each other once dispatched: if 9 is DENIED and 10 PERMITTED, the denial is specific to `CLAUDE_SKILL_DIR`; if both are denied, argument-position bare expansion is refused generally; if 8 is denied but 9 permitted, only the defaulted form is refused. Until then this remains out of scope for the leading-token remedy (issue #1124 / PR #1272), whose conditional call form addresses only the leading-token position.
+  **Reading, per the cross-reading this table was built to decide: argument-position bare parameter expansion is refused GENERALLY, not specifically for `CLAUDE_SKILL_DIR`.** Row 10's control expands a non-anchor variable (`GITHUB_ACTIONS`) under the same granted `echo` head and was denied too, which is the pre-declared "both denied" arm; row 8 shows the defaulted form is refused on the same terms. The question is now **established and recorded** rather than open. State it no wider than the evidence: this is **one measurement, on the `command` tier, at one `claude-code-action` version** — it establishes nothing for the review or implement tiers, and it is not a platform contract. **A verdict is never written from inference** — matcher semantics are provable only in a real probe run; re-probe after any `claude-code-action` upgrade.
+
+  The practical consequence is unchanged in direction but now evidenced: the leading-token remedy (issue #1124 / PR #1272) addresses only the leading-token position, and an author must additionally keep the unexpanded anchor out of **argument** position on this tier — a granted head does not rescue it.
 
 **Anchor invocation call-site census (issue #1124 AC2).** Re-derived at the issue's HEAD (index-sourced per issue #711): **118** anchor leading-token helper invocations across **34** `skills/*` files. Disposition:
 
@@ -287,7 +289,7 @@ a command prefix (a leading `VAR=value` is a denied matcher shape), and the new
 than an agent command — so `lib/review-profile.tokens` is byte-identical and
 `lib/generate-capability-profiles.py --check` stays green.
 
-### Step-level `env:` propagation — PENDING a maintainer-dispatched run (issue #874)
+### Step-level `env:` propagation — still PENDING, but not on a dispatch (issue #874)
 
 `.github/workflows/matcher-probe.yml` carries an **`env-propagation-probe`** job that
 measures whether a step-level `env:` entry on a `claude-code-action` step is visible
@@ -306,16 +308,35 @@ each hop read through its own Bash calls, and derives a four-way verdict
 `DISPATCHED_TASK_ONLY` inversion) with `scripts/env-propagation-probe-verdict.py`,
 whose five verdict arms and four degraded arms `lib/test/run.sh` drives.
 
-**This measurement is PENDING.** The implementing run added the job and the
-documentation entry and deliberately did **not** dispatch the probe, so no verdict is
-recorded here yet. Until one is, the claim that a consumer's committed base-ref
+**This measurement is PENDING — but a dispatch is not what it is waiting for.** The
+framing this entry carried ("PENDING a maintainer-dispatched run") was wrong on its
+premise: `matcher-probe.yml` also triggers on a same-repo `pull_request` filtered to its
+own path, so the job has in fact been running on every PR that touches that workflow.
+
+**A run has now been observed and it did not produce a verdict.** In run
+[`30956039324`](https://github.com/The01Geek/prflow/actions/runs/30956039324), job
+`env-propagation-probe` (`92149438747`), head
+`85e57ac1c6dcf732a861230f82182191977c6e41`, 2026-08-04, the job returned
+**`INCONCLUSIVE`** with `hop1_reported=False, hop2_reported=True` — one hop reported
+nothing at all, which `scripts/env-propagation-probe-verdict.py` deliberately routes to
+*unestablished* rather than to a negative. Per "Unknown is not zero", **no verdict cell
+is filled from this**: the four-way question (`BOTH_HOPS` / `ORCHESTRATOR_ONLY` /
+`NEITHER_HOP`) remains open, and `ORCHESTRATOR_ONLY` in particular must not be inferred
+from a silent hop one.
+
+What this changes is the remedy. The observation suggests the probe needs a **design
+fix** before it can yield a verdict — hop one's report is not reaching the execution
+file the helper reads — so a blind re-dispatch would most likely return `INCONCLUSIVE`
+again. Diagnosing and repairing the probe's hop-one reporting path (a `matcher-probe.yml`
+change) is the actual next step, not another run.
+
+Until a verdict exists, the claim that a consumer's committed base-ref
 extension keeps working is an **expectation, not a guarantee**. The failure direction
 is safe either way — an unpropagated variable makes the loader resolve the repo-root
 path, find the workflow's truncated file, and print nothing — so a propagation failure
 costs the feature, never the boundary; the loader's resolved-root breadcrumb, surfaced
 at hop two through the `EXTENSION-STATUS: … resolved-root=…` field, is what makes such
-a failure observable rather than silent. Dispatch the job from the Actions tab and
-record the run id and verdict here.
+a failure observable rather than silent.
 
 The probe job's **helper-invocation-form rows** exercise a vendored helper as the
 leading token in five path/grant forms (the review job uses `config-get.sh` as that
@@ -352,7 +373,7 @@ on no profile, so the run is not an acceptance criterion of the change that adde
 this note). Until then, a refusal of the dispatched vendored-literal command is
 handled by the Phase-3 fail-closed refusal path, never assumed impossible.
 
-### Dispatched-subagent `Write` into `.prflow/tmp/**` — review tier — PENDING the first PR-triggered run (issue #858)
+### Dispatched-subagent `Write` into `.prflow/tmp/**` — review tier — MEASURED PERMITTED (issue #858)
 
 `.github/workflows/matcher-probe.yml` carries a **`subagent-write-review-probe`** job
 that measures whether a **dispatched subagent's** `Write` into `.prflow/tmp/**`
@@ -407,37 +428,49 @@ and a genuine `Write` denial still reports `DENIED` **provided a dispatch is als
 in the file** — that conjunct is what the verdict requires, and with no recorded dispatch
 there is no dispatchee to attribute the denial to, so such a list reports `unestablished`.
 
-**This measurement is PENDING.** The implementing run added the job and this entry and
-deliberately did **not** dispatch the probe (its only pre-merge trigger is a same-repo
-`pull_request` scoped to the workflow's own path — so pushing this change to the
-implementing PR *does* fire it — and `gh workflow run` is granted on no profile). Record
-the verdict here from the **final pre-merge head commit** (a later push re-fires the
-workflow and invalidates a recorded head — the `paths:` filter does NOT narrow this: on a
-`pull_request` event GitHub evaluates `paths:` against the three-dot base…head diff, i.e.
-the files changed in the whole PR, and this PR changes `matcher-probe.yml`, so every
-subsequent push re-fires both paid probe jobs — including the commit that records this very
-verdict), naming the **ref** (the implementing branch —
-the job does not exist on the default branch until this merges), the **run id**, the
-**job id**, the **head commit**, and the **resolved `--allowed-tools` literal verbatim**
-alongside `--permission-mode acceptEdits`, model `claude-haiku-4-5-20251001`, and
-`--effort low`. A `PERMITTED` cites, by their two ids, the
-`tool_use`/`parent_tool_use_id` pair tying the `Write` to the job's dispatch, so a reader
-can re-verify the chain against the execution file; a `DENIED`'s attribution rests on the no-orchestrator-write prompt
-(the `permission_denials` per-entry shape is not yet recorded), and the run's **observed
-denial-entry shape** is recorded alongside — the read that upgrades the denial side from
-by-construction to measured. Commit the job's machine output beside
-`docs/execution-file-shape.observed.txt`, as that record establishes.
+**This measurement is RECORDED.** The section's own prose already named the trigger that
+produced it — *"its only pre-merge trigger is a same-repo `pull_request` scoped to the
+workflow's own path — so pushing this change to the implementing PR **does** fire it"* —
+but the resulting run was never read back, so the row sat at `pending` while the evidence
+existed. It is transcribed here from run
+[`30956039324`](https://github.com/The01Geek/prflow/actions/runs/30956039324). No
+`workflow_dispatch` was involved.
+
+The recording requirements this section set for itself are met as follows. **Ref**,
+**run id**, **job id** and **head commit** are in the table below.
+`--permission-mode acceptEdits`, model `claude-haiku-4-5-20251001` and `--effort low`
+are as specified. The **resolved `--allowed-tools` literal, verbatim**, is committed at
+[`docs/subagent-write-probe.observed.md`](subagent-write-probe.observed.md) rather than
+inlined here: the two literals are ~1.9 KB and ~7.2 KB and would bury the surrounding
+prose, and that sidecar is exactly the *"commit the job's machine output beside
+`docs/execution-file-shape.observed.txt`"* artifact this section calls for — it carries
+each job's complete emitted step summary unedited, literal included, under the same
+expiring-evidence rationale that file states. Nothing required is omitted; it is
+relocated to the artifact and pointed at from here. The **`tool_use` /
+`parent_tool_use_id` pair** a `PERMITTED` must cite is
+`toolu_01SbG9oxWxp5PTNS3bbymzD3` → `toolu_01Cd3LViMMbQw2surtkyDFGL` (review tier), so a
+reader can re-verify the chain. The run recorded **zero** `permission_denials` entries,
+so this run contributes no reading of the **observed denial-entry shape** — that read,
+which would upgrade the *denial* side from by-construction to measured, remains
+outstanding and is not discharged by a `PERMITTED`.
+
+The helper's own supporting facts, all `yes` on this run: `dispatch_outcome=recorded`,
+`recorded_at_all=yes`, `chain_attributable=yes`, `control_before=yes`,
+`control_after=yes`, `write_outcome=recorded`, `write_chain_ok=yes`, and
+`side_effect_state=corroborated` — the on-disk `.prflow/tmp/subwrite-review.txt` carried
+the probe's payload marker.
 
 This verdict is version-dependent and establishes nothing for a differently-defined
-subagent type or a later `claude-code-action` version: **re-probe** after any upgrade.
+subagent type or a later `claude-code-action` version: **re-probe** after any upgrade
+(measured against `claude-code-action@v1` with Claude Code 2.1.221).
 **Scope caveat, carried in the emitted record itself:** the run uses
-`--permission-mode acceptEdits`, so a `PERMITTED` answers *"did the dispatched subagent's
-`Write` land under that permission mode?"* — it does not isolate the allowlist from the
-permission mode as the sole reason the write was allowed.
+`--permission-mode acceptEdits`, so this `PERMITTED` answers *"did the dispatched
+subagent's `Write` land under that permission mode?"* — it does **not** isolate the
+allowlist from the permission mode as the sole reason the write was allowed.
 
 | Tier | Verdict | Run id | Job id | Head commit | Ref |
 | --- | --- | --- | --- | --- | --- |
-| review | _pending first PR-triggered run_ | — | — | — | — |
+| review | **PERMITTED** | `30956039324` | `92149631372` | `85e57ac1c6dcf732a861230f82182191977c6e41` | `issue-1152-command-profile-shape-lint` |
 
 ---
 
@@ -588,7 +621,7 @@ direct leading token so the *same* command works on the local and cloud tiers. H
 the probe come back DENIED, the cloud tier would have kept the full-suite default
 and those tiers would have stayed local-only.
 
-### Dispatched-subagent `Write` into `.prflow/tmp/**` — implement tier — PENDING the first PR-triggered run (issue #858)
+### Dispatched-subagent `Write` into `.prflow/tmp/**` — implement tier — MEASURED PERMITTED (issue #858)
 
 `matcher-probe.yml` also carries a **`subagent-write-implement-probe`** job that measures
 the same dispatched-subagent `Write` fact on the **implement** tier — because a shape
@@ -604,13 +637,22 @@ Note the two tiers' row numberings are independent — both contain rows numbere
 so the verdict record names its tier as data, and the helper carries a machine-consumed
 `tier` field for the same reason.
 
-**This measurement is PENDING**, on the same terms as the review-tier entry above: added
-but not dispatched, recorded from the final pre-merge head, version-dependent, re-probe
-after any `claude-code-action` upgrade.
+**This measurement is RECORDED**, on the same terms as the review-tier entry above and
+from the same run: fired by the same-repo `pull_request` trigger, never dispatched,
+version-dependent, re-probe after any `claude-code-action` upgrade. The `tool_use` /
+`parent_tool_use_id` pair for this tier is `toolu_01NmqhQw56kRuoGSXdr3e1Ph` →
+`toolu_01CAkuq4wZ4x9M82HazPicfF`; `write_chain_ok=yes` and
+`side_effect_state=corroborated` against `.prflow/tmp/subwrite-implement.txt`, with
+**zero** `permission_denials` entries (so, as above, the denial-entry-shape read stays
+outstanding). The resolved implement `--allowed-tools` literal is committed verbatim in
+[`docs/subagent-write-probe.observed.md`](subagent-write-probe.observed.md) alongside the
+review one. The same `acceptEdits` scope caveat applies: the run carries
+`--permission-mode acceptEdits`, so the `PERMITTED` does not isolate the allowlist as the
+sole reason the write was allowed.
 
 | Tier | Verdict | Run id | Job id | Head commit | Ref |
 | --- | --- | --- | --- | --- | --- |
-| implement | _pending first PR-triggered run_ | — | — | — | — |
+| implement | **PERMITTED** | `30956039324` | `92149629323` | `85e57ac1c6dcf732a861230f82182191977c6e41` | `issue-1152-command-profile-shape-lint` |
 
 ---
 
@@ -643,26 +685,67 @@ Issue #1152 closes both gaps:
   `probe-review` / `probe-implement` baselines are, so it can never drift from the deployed
   allowlist.
 
-**This measurement is DISPATCHED-PENDING** — the rows and their generated baseline ship
-with issue #1152; the verdicts land on a later `workflow_dispatch` (a verdict is never
-written from inference). Version-dependent: re-probe after any `claude-code-action`
-upgrade.
+**This measurement is RECORDED** — run
+[`30956039324`](https://github.com/The01Geek/prflow/actions/runs/30956039324), job
+`command-probe` (`92149438683`), head `85e57ac1c6dcf732a861230f82182191977c6e41`, ref
+`issue-1152-command-profile-shape-lint`, 2026-08-04. No `workflow_dispatch` was needed:
+`matcher-probe.yml` also triggers on a same-repo `pull_request` filtered to its own path,
+so the PR that added these rows fired the job itself. The verdicts below are the job's
+deterministic step summary, computed from the execution file's `permission_denials`
+(DENIED) and recorded `tool_use` inputs (PERMITTED) — the model's prose is never the
+measurement. Version-dependent: re-probe after any `claude-code-action` upgrade
+(measured against `claude-code-action@v1` with Claude Code 2.1.221).
 
 | # | Shape | Verdict |
 |---|-------|---------|
-| 1 | granted vendored-literal helper path as a leading token (`config-get.sh`) | dispatched-pending |
-| 2 | resolved (expanded) skill-dir-anchored helper path as a leading token | dispatched-pending |
-| 3 | `>` redirect from a granted head into `.prflow/tmp/**` | dispatched-pending |
-| 4 | `.prflow/tmp/**` file authored with the **Write** tool | dispatched-pending |
-| 5 | `if VAR=$(granted-helper …)` command-substitution condition | dispatched-pending |
-| 6 | `;`-joined multi-statement sequence | dispatched-pending |
-| 7 | plainly granted single command (positive control) | dispatched-pending |
-| 8 | argument-position defaulted anchor expansion `${VAR:-default}` (reproduces run `30695072336`) | dispatched-pending |
-| 9 | argument-position bare anchor expansion `${VAR}` | dispatched-pending |
-| 10 | argument-position bare expansion of a non-anchor variable (control) | dispatched-pending |
+| 1 | granted vendored-literal helper path as a leading token (`config-get.sh`) | **PERMITTED** |
+| 2 | resolved (expanded) skill-dir-anchored helper path as a leading token | **DENIED** |
+| 3 | `>` redirect from a granted head into `.prflow/tmp/**` | **PERMITTED** |
+| 4 | `.prflow/tmp/**` file authored with the **Write** tool | **PERMITTED** |
+| 5 | `if VAR=$(granted-helper …)` command-substitution condition | **PERMITTED** |
+| 6 | `;`-joined multi-statement sequence | **PERMITTED** |
+| 7 | plainly granted single command (positive control) | **PERMITTED** |
+| 8 | argument-position defaulted anchor expansion `${VAR:-default}` (reproduces run `30695072336`) | **DENIED** |
+| 9 | argument-position bare anchor expansion `${VAR}` | **DENIED** |
+| 10 | argument-position bare expansion of a non-anchor variable (control) | **DENIED** |
+
+Each row also carries a per-row evidence triple, reproduced here verbatim from the job's
+own emitted summary (machine output, not a paraphrase) so a reader can tell a genuine
+refusal from a shape that was never attempted in the form the row names:
+
+```
+| 1 | granted vendored-literal helper path as a leading token (config-get.sh) | **PERMITTED** | denial=no; tool_use=yes; shape=ok |
+| 2 | resolved (expanded) skill-dir-anchored helper path as a leading token | **DENIED** | denial=yes; tool_use=yes; shape=ok |
+| 3 | `>` redirect from a granted head into `.prflow/tmp/**` | **PERMITTED** | denial=no; tool_use=yes; shape=ok |
+| 4 | `.prflow/tmp/**` file authored with the Write tool | **PERMITTED** | denial=no; tool_use=yes; shape=ok |
+| 5 | `if VAR=$(granted-helper …)` command-substitution condition | **PERMITTED** | denial=no; tool_use=yes; shape=ok |
+| 6 | `;`-joined multi-statement sequence | **PERMITTED** | denial=no; tool_use=yes; shape=ok |
+| 7 | plainly granted single command (positive control) | **PERMITTED** | denial=no; tool_use=yes; shape=n/a |
+| 8 | argument-position defaulted anchor expansion `${VAR:-default}` | **DENIED** | denial=yes; tool_use=yes; shape=ok |
+| 9 | argument-position bare anchor expansion `${VAR}` | **DENIED** | denial=yes; tool_use=yes; shape=ok |
+| 10 | argument-position bare expansion of a non-anchor variable (control) | **DENIED** | denial=yes; tool_use=yes; shape=ok |
+```
+
+Row 7 is the positive control and it passed, so the four refusals are refusals of their
+own shapes and not a dead session. Every row recorded `tool_use=yes` and `shape=ok`, so
+none is the `REFORMULATED` case the job warns about — each intended shape was actually
+attempted.
+
+**Row 2 is the substantive new finding, and it bears on the #1124/#1256 conditional-call
+remedy.** The *resolved* traversal form
+`.prflow/vendor/prflow/skills/<skill>/../../scripts/<helper>` — what the portable
+`"${CLAUDE_SKILL_DIR:-…}"/../../scripts/<helper>` anchor expands to at runtime on this
+tier — is **DENIED as a leading token**, while row 1's plain vendored literal
+`.prflow/vendor/prflow/scripts/<helper>` is **PERMITTED**. So the matcher does not
+normalize `../..` traversal back onto the granted literal. That is direct support for the
+remedy's shape: a cloud-reachable call site emits the **granted vendored literal
+directly** and keeps the anchor only as the fallback arm; rewriting the anchor into an
+expanded traversal would not have worked. (One measurement, `command` tier, one action
+version — see the caveat above.)
 
 Rows 8–10 are the argument-position rows adopted from issue #1124's closure; their
-cross-reading is described in *The `${CLAUDE_SKILL_DIR:-…}` anchor* subsection above.
+cross-reading is applied in *The `${CLAUDE_SKILL_DIR:-…}` anchor* subsection above, which
+is the canonical home for that reading.
 
 ---
 
@@ -1061,21 +1144,49 @@ establish, by observation, whether a `PreToolUse` hook fires under `claude-code-
 (`FIRED`/`NOT-FIRED`) and whether its `permissionDecisionReason` reaches the engine
 transcript (`REASON-DELIVERED`/`REASON-ABSENT`).
 
-Filling the table below is **#919's** job, not this section's, and that issue — not
-this page — holds the current record. Two things a reader should take from it rather
-than from the row's placeholder. First, the arm is **not** awaiting a dispatch to
-produce a first result: #919 records it as having already returned the same verdict
-pair on repeated same-repo `pull_request` runs, together with the scope note that keeps
-the pair from misleading (the probe's own hook emits `permissionDecision: "allow"`, for
-which `permissionDecisionReason` is specified to be ignored, so the guard's `deny`-path
-reason delivery remains unmeasured). Second, #919 has **dropped** the once-planned
-per-arm review-run denial count against the run-30138268273 baseline as no longer
-achievable — no live tier can produce a review run carrying the guard — retaining that
-baseline run id only as historical reference. The row is left as found until #919 lands.
+**The arm was never awaiting a dispatch, and the results were already there.**
+`matcher-probe.yml` triggers on `workflow_dispatch` **and** on a same-repo
+`pull_request` filtered to its own path, so every PR touching that workflow has fired
+the job — the results simply had not been read back. The row below is transcribed from
+run [`30956039324`](https://github.com/The01Geek/prflow/actions/runs/30956039324), job
+`pretooluse-probe` (`92149438739`), head `85e57ac1c6dcf732a861230f82182191977c6e41`,
+ref `issue-1152-command-profile-shape-lint`, 2026-08-04.
+
+The fourth column stays `n/a` by **#919's own record**: the once-planned per-arm
+review-run denial count against the run-`30138268273` baseline was **dropped** as no
+longer achievable — no live tier can produce a review run carrying the guard (the
+guard's registration rode on `devflow-runner.yml`, whose sole caller `devflow-review.yml`
+was deleted by PR #937 / issue #936) — and that baseline run id is retained as historical
+reference only. Issue #919 remains open: its AC1 still asks for an explicit
+`gh workflow run` dispatch that this evidence shows to be unnecessary, and amending that
+is a maintainer decision, not this page's.
 
 | Probe run id | Firing verdict | Reason-delivery verdict | Per-arm denial counts (review run) |
 | --- | --- | --- | --- |
-| _(pending post-merge dispatch)_ | — | — | — |
+| `30956039324` (job `92149438739`) | **FIRED** | **REASON-ABSENT** | n/a — dropped post-#937 |
+
+**This is the 8th consecutive identical `FIRED` / `REASON-ABSENT` pair.** The six prior
+replications, all on same-repo `pull_request` runs and all returning the same pair, are
+runs `30658648601`, `30657675722`, `30652958122`, `30577692232`, `30472371076`, and
+`30421703361`. The two oldest render the breadcrumb path as `.devflow/tmp/…` rather than
+`.prflow/tmp/…` — a pre-#1002 rename spelling of the same marker, not a different
+measurement.
+
+**Scope caveat — the `REASON-ABSENT` cell does not mean reason delivery is broken, and
+the row misleads without this.** The probe's own hook emits
+`permissionDecision: "allow"`, and per the Claude Code hooks decision-control table
+`permissionDecisionReason` is shown to Claude on `deny`, shown to the user on `ask`, and
+**ignored on `allow` and `defer`**. `REASON-ABSENT` is therefore the *specified*
+behavior for the decision this probe emits. `scripts/pretooluse-shape-guard.py` emits
+only `deny` and `defer`, so **the guard's own `deny`-path reason delivery and its
+`defer` fall-through semantics remain unmeasured**, and the probe arm as currently
+written cannot measure them — it would need a hook emitting `deny`.
+
+**Secondary caveat:** the observation helper searches the **execution file**, which is a
+proxy for the transcript rather than a capture of the model's own input; an absent
+string there is evidence about the execution file's contents, not a direct reading of
+what the model saw. Measured against `claude-code-action@v1` with the CLI version the
+run reports (Claude Code 2.1.221) — **re-probe after any upgrade.**
 
 ## Denial-population audit — the 2026-08-02 implement runs (issue #1135)
 

--- a/docs/cloud-allowlist.md
+++ b/docs/cloud-allowlist.md
@@ -438,6 +438,19 @@ existed. It is transcribed here from run
 [`30956039324`](https://github.com/The01Geek/prflow/actions/runs/30956039324). No
 `workflow_dispatch` was involved.
 
+**The trigger mechanism, kept here in full because misreading it is what left this row
+and several others stale.** `matcher-probe.yml` fires on
+`workflow_dispatch` **and** on a same-repo `pull_request` filtered to its own path, and
+**the `paths:` filter does not narrow that to the pushed commit**: on a `pull_request`
+event GitHub evaluates `paths:` against the three-dot base…head diff — the files changed
+in the *whole PR* — so once a PR touches `matcher-probe.yml` at all, **every subsequent
+push re-fires all 12 paid probe jobs**, including the commit that records a verdict. Two
+consequences. A recorded head goes stale the moment another push lands, so a verdict is
+transcribed from a specific run id and head rather than from "the PR". And a PR that
+edits that workflow is expensive by construction — which is why a docs-only change
+recording already-produced verdicts costs nothing and a re-dispatch costs a full probe
+sweep.
+
 The recording requirements this section set for itself are met as follows. **Ref**,
 **run id**, **job id** and **head commit** are in the table below.
 `--permission-mode acceptEdits`, model `claude-haiku-4-5-20251001` and `--effort low`

--- a/docs/subagent-write-probe.observed.md
+++ b/docs/subagent-write-probe.observed.md
@@ -1,0 +1,122 @@
+<!-- Dispatched-subagent Write probe — OBSERVED ARTIFACT (committed evidence) -->
+
+# Dispatched-subagent `Write` probe — observed artifact (issue #858)
+
+Machine-produced output of `scripts/subagent-write-probe-verdict.py`, copied verbatim
+from the two `matcher-probe.yml` job step summaries of run `30956039324`
+(`anthropics/claude-code-action@v1`, Claude Code 2.1.221, 2026-08-04). This provenance
+header is the ONLY addition; everything below each `## Dispatched-subagent Write probe`
+heading is the helper's own emitted summary, unedited — including the resolved
+`--allowed-tools` literal each job actually ran under.
+
+Committed deliberately, on the same reasoning as `docs/execution-file-shape.observed.txt`:
+GitHub logs and artifacts expire (~90 days), after which the verdict rows in
+`docs/cloud-allowlist.md` would become unfalsifiable — a claim with no surviving evidence.
+This file is that evidence. It is redaction-safe by construction: the helper emits no
+secret values, and the `--allowed-tools` literal is a generated region already committed
+in the tree.
+
+This is a DATED OBSERVATION OF ONE ACTION VERSION AND ONE SUBAGENT DEFINITION (the
+built-in `general-purpose` type), not a platform contract. The run carries
+`--permission-mode acceptEdits`, so a `PERMITTED` answers "did the dispatched subagent's
+`Write` land under that permission mode?" — it does not isolate the allowlist from the
+permission mode as the sole reason the write was allowed. Re-probe after any
+`claude-code-action` / CLI upgrade and refresh this file and the doc rows together.
+
+Run:       https://github.com/The01Geek/prflow/actions/runs/30956039324
+Ref:       issue-1152-command-profile-shape-lint
+Head:      85e57ac1c6dcf732a861230f82182191977c6e41
+Job (review tier):    92149631372
+Job (implement tier): 92149629323
+
+---
+
+## Dispatched-subagent Write probe — review tier (issue #858)
+
+**Verdict: `PERMITTED`**
+
+a subagent Write tool_use targeting subwrite-review.txt was recorded, its parent chains to a dispatch recorded in this file (tool_use id 'toolu_01SbG9oxWxp5PTNS3bbymzD3' -> parent_tool_use_id 'toolu_01Cd3LViMMbQw2surtkyDFGL'), and the on-disk side-effect file carries the probe's payload marker.
+
+Deterministic verdict from the execution file's recorded `tool_use` inputs, their `parent_tool_use_id`, and `permission_denials`, corroborated by the on-disk side-effect file this run actually stat'ed: `.prflow/tmp/subwrite-review.txt`. The model's prose is never the measurement.
+
+> [!IMPORTANT]
+> This verdict is a dated observation of one `claude-code-action` version and one subagent definition (the built-in general-purpose type dispatched by the probe's own prompt under the tier's generated baseline at the recorded commit) — not a platform contract, and it establishes nothing for a differently-defined subagent type or a later claude-code-action version. SCOPE: the run carries `--permission-mode acceptEdits`, so a `PERMITTED` answers "did the dispatched subagent's Write land under that permission mode?" — it does not isolate the allowlist from the permission mode as the sole reason the write was allowed. Re-probe (dispatch matcher-probe.yml, or push to a same-repo PR touching it) after a claude-code-action / CLI upgrade before trusting it.
+
+| Field | Value |
+|-------|-------|
+| tier | `review` |
+| verdict | **PERMITTED** |
+| dispatch_outcome | recorded |
+| recorded_at_all | yes |
+| chain_attributable | yes |
+| control_before | yes |
+| control_after | yes |
+| write_outcome | recorded |
+| write_chain_ok | yes |
+| side_effect_state | corroborated |
+
+**permission_mode:** `acceptEdits`
+
+**model:** `claude-haiku-4-5-20251001`
+
+**effort:** `low`
+
+**ref:** `issue-1152-command-profile-shape-lint`
+
+**head_commit:** `85e57ac1c6dcf732a861230f82182191977c6e41`
+
+**Resolved `--allowed-tools` literal (the measured condition, verbatim):**
+
+```
+Read,Glob,Grep,LS,Skill,Agent,TodoWrite,WebFetch,WebSearch,Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git ls-files:*),Bash(git rev-parse:*),Bash(git merge-base:*),Bash(git blame:*),Bash(git branch:*),Bash(git cat-file:*),Bash(git hash-object:*),Bash(git checkout:*),Bash(mkdir:*),Bash(tee:*),Bash(mktemp:*),Bash(cmp:*),Bash(rm -f:*),Bash(*/load-prompt-extension.sh:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(gh pr list:*),Bash(gh pr checks:*),Bash(gh issue view:*),Bash(gh issue comment:*),Bash(gh issue list:*),Bash(gh search:*),Bash(gh repo view:*),Bash(gh run view:*),Bash(gh run list:*),Bash(gh api:*),Bash(jq:*),Bash(.prflow/vendor/prflow/scripts/run-jq.sh:*),Bash(grep:*),Bash(rg:*),Bash(find:*),Bash(wc:*),Bash(sort:*),Bash(uniq:*),Bash(cut:*),Bash(tr:*),Bash(xargs:*),Bash(awk:*),Bash(sed:*),Bash(diff:*),Bash(comm:*),Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(ls:*),Bash(tree:*),Bash(file:*),Bash(stat:*),Bash(date:*),Bash(pwd:*),Bash(realpath:*),Bash(dirname:*),Bash(basename:*),Bash(which:*),Bash(type:*),Bash(env:*),Bash(echo:*),Bash(printf:*),Bash(test:*),Bash(.prflow/vendor/prflow/scripts/match-deferrals.py:*),Bash(.prflow/vendor/prflow/scripts/match-lint-adjudications.py:*),Bash(.prflow/vendor/prflow/scripts/normalize-verdicts.py:*),Bash(.prflow/vendor/prflow/scripts/dismiss-stale-rejections.sh:*),Bash(.prflow/vendor/prflow/scripts/post-review-verdict.sh:*),Bash(.prflow/vendor/prflow/scripts/workpad.py:*),Bash(.prflow/vendor/prflow/scripts/seed-review-progress.sh:*),Bash(.prflow/vendor/prflow/scripts/config-get.sh:*),Bash(.prflow/vendor/prflow/scripts/load-prompt-extension.sh:*),Bash(.prflow/vendor/prflow/scripts/resolve-review-overrides.py:*),Bash(.prflow/vendor/prflow/scripts/stale-prose-lint.py:*),Bash(.prflow/vendor/prflow/lib/efficiency-trace.sh:*),Write(.prflow/tmp/**),Bash(cd:*),Write(/tmp/**),Bash(scripts/*.sh:*),Task,Agent
+```
+
+### Observed `permission_denials` entries (0)
+
+_No permission_denials entries found in the execution file._
+
+---
+
+## Dispatched-subagent Write probe — implement tier (issue #858)
+
+**Verdict: `PERMITTED`**
+
+a subagent Write tool_use targeting subwrite-implement.txt was recorded, its parent chains to a dispatch recorded in this file (tool_use id 'toolu_01NmqhQw56kRuoGSXdr3e1Ph' -> parent_tool_use_id 'toolu_01CAkuq4wZ4x9M82HazPicfF'), and the on-disk side-effect file carries the probe's payload marker.
+
+Deterministic verdict from the execution file's recorded `tool_use` inputs, their `parent_tool_use_id`, and `permission_denials`, corroborated by the on-disk side-effect file this run actually stat'ed: `.prflow/tmp/subwrite-implement.txt`. The model's prose is never the measurement.
+
+> [!IMPORTANT]
+> This verdict is a dated observation of one `claude-code-action` version and one subagent definition (the built-in general-purpose type dispatched by the probe's own prompt under the tier's generated baseline at the recorded commit) — not a platform contract, and it establishes nothing for a differently-defined subagent type or a later claude-code-action version. SCOPE: the run carries `--permission-mode acceptEdits`, so a `PERMITTED` answers "did the dispatched subagent's Write land under that permission mode?" — it does not isolate the allowlist from the permission mode as the sole reason the write was allowed. Re-probe (dispatch matcher-probe.yml, or push to a same-repo PR touching it) after a claude-code-action / CLI upgrade before trusting it.
+
+| Field | Value |
+|-------|-------|
+| tier | `implement` |
+| verdict | **PERMITTED** |
+| dispatch_outcome | recorded |
+| recorded_at_all | yes |
+| chain_attributable | yes |
+| control_before | yes |
+| control_after | yes |
+| write_outcome | recorded |
+| write_chain_ok | yes |
+| side_effect_state | corroborated |
+
+**permission_mode:** `acceptEdits`
+
+**model:** `claude-haiku-4-5-20251001`
+
+**effort:** `low`
+
+**ref:** `issue-1152-command-profile-shape-lint`
+
+**head_commit:** `85e57ac1c6dcf732a861230f82182191977c6e41`
+
+**Resolved `--allowed-tools` literal (the measured condition, verbatim):**
+
+```
+Read,Write,Edit,Glob,Grep,LS,Skill,Agent,TodoWrite,EnterPlanMode,ExitPlanMode,WebFetch,WebSearch,Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git pull:*),Bash(git fetch:*),Bash(git ls-remote:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git hash-object:*),Bash(git checkout:*),Bash(git branch:*),Bash(git stash:*),Bash(git rm:*),Bash(git mv:*),Bash(git restore:*),Bash(git revert:*),Bash(git blame:*),Bash(git ls-files:*),Bash(git rev-parse:*),Bash(git merge-base:*),Bash(git merge:*),Bash(gh pr create:*),Bash(gh pr edit:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr ready:*),Bash(gh pr list:*),Bash(gh pr checks:*),Bash(gh pr status:*),Bash(gh pr reopen:*),Bash(gh issue view:*),Bash(gh issue comment:*),Bash(gh issue list:*),Bash(gh issue edit:*),Bash(gh issue create:*),Bash(gh issue reopen:*),Bash(gh issue status:*),Bash(gh search:*),Bash(gh label list:*),Bash(gh repo view:*),Bash(gh run view:*),Bash(gh run list:*),Bash(gh workflow view:*),Bash(gh workflow list:*),Bash(gh api:*),Bash(jq:*),Bash(.prflow/vendor/prflow/scripts/run-jq.sh:*),Bash(.prflow/vendor/prflow/scripts/config-get.sh:*),Bash(.prflow/vendor/prflow/scripts/workpad.py:*),Bash(.prflow/vendor/prflow/scripts/seed-review-progress.sh:*),Bash(.prflow/vendor/prflow/scripts/verification-flight.py:*),Bash(.prflow/vendor/prflow/scripts/reception-record.py:*),Bash(.prflow/vendor/prflow/scripts/checkout-fingerprint.py:*),Bash(.prflow/vendor/prflow/scripts/check-completion-evidence.py:*),Bash(.prflow/vendor/prflow/scripts/parse-acs.py:*),Bash(.prflow/vendor/prflow/scripts/check-verified-premises.py:*),Bash(.prflow/vendor/prflow/scripts/preflight.py:*),Bash(.prflow/vendor/prflow/scripts/branch-for-issue.py:*),Bash(.prflow/vendor/prflow/scripts/update-branch-checkpoint.sh:*),Bash(.prflow/vendor/prflow/scripts/phase2-durability-checkpoint.sh:*),Bash(.prflow/vendor/prflow/scripts/file-deferrals.py:*),Bash(.prflow/vendor/prflow/scripts/discover-deferral-manifests.py:*),Bash(.prflow/vendor/prflow/scripts/match-deferrals.py:*),Bash(.prflow/vendor/prflow/scripts/resolve-review-overrides.py:*),Bash(.prflow/vendor/prflow/scripts/apply-labels.sh:*),Bash(.prflow/vendor/prflow/scripts/ensure-label.sh:*),Bash(.prflow/vendor/prflow/scripts/apply-pr-triggerer.sh:*),Bash(.prflow/vendor/prflow/scripts/apply-issue-dependencies.py:*),Bash(.prflow/vendor/prflow/scripts/resolve-existing-pr.sh:*),Bash(.prflow/vendor/prflow/lib/efficiency-trace.sh:*),Bash(.prflow/vendor/prflow/scripts/stale-prose-lint.py:*),Bash(.prflow/vendor/prflow/scripts/dismiss-stale-rejections.sh:*),Bash(.prflow/vendor/prflow/scripts/post-review-verdict.sh:*),Bash(.prflow/vendor/prflow/scripts/loop-verdict-marker.py:*),Bash(.prflow/vendor/prflow/scripts/match-lint-adjudications.py:*),Bash(.prflow/vendor/prflow/scripts/normalize-verdicts.py:*),Bash(.prflow/vendor/prflow/scripts/load-prompt-extension.sh:*),Bash(.prflow/vendor/prflow/scripts/react-to-trigger.sh:*),Bash(.prflow/vendor/prflow/scripts/extract-doc-needed-paths.sh:*),Bash(pip install:*),Bash(pip:*),Bash(python:*),Bash(python3:*),Bash(python -m:*),Bash(python3 -m:*),Bash(ruff:*),Bash(ruff check:*),Bash(ruff format:*),Bash(pytest:*),Bash(mypy:*),Bash(grep:*),Bash(rg:*),Bash(find:*),Bash(wc:*),Bash(sort:*),Bash(uniq:*),Bash(cut:*),Bash(tr:*),Bash(xargs:*),Bash(awk:*),Bash(sed:*),Bash(diff:*),Bash(cmp:*),Bash(comm:*),Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(less:*),Bash(ls:*),Bash(tree:*),Bash(file:*),Bash(stat:*),Bash(date:*),Bash(pwd:*),Bash(realpath:*),Bash(dirname:*),Bash(basename:*),Bash(which:*),Bash(type:*),Bash(env:*),Bash(echo:*),Bash(printf:*),Bash(test:*),Bash(touch:*),Bash(mkdir:*),Bash(rmdir:*),Bash(rm:*),Bash(mv:*),Bash(cp:*),Bash(tee:*),Bash(lib/test/run.sh:*),Bash(lib/test/run-parallel.sh:*),Bash(lib/test/run-module.sh:*),Bash(lib/test/run-shard.sh:*),Bash(lib/test/shard-tally.py:*),Bash(lib/test/test_python_scripts.py:*),Bash(lib/test/test_workflow_flight_recorder.py:*),Bash(lib/test/test_workflow_analyzer.py:*),Bash(lib/test/test_verification_baseline.py:*),Bash(lib/test/test_create_issue_context_eval.py:*),Bash(lib/test/coverage_map_guard.py:*),Bash(lib/preflight.sh:*),Bash(shellcheck:*),Bash(chmod:*),Bash(git ls-remote:*),Bash(git check-ignore:*),Bash(lib/efficiency-trace.sh:*),Bash(/home/runner/work/prflow/prflow/lib/efficiency-trace.sh:*),Bash(scripts/apply-labels.sh:*),Bash(/home/runner/work/prflow/prflow/scripts/apply-labels.sh:*),Bash(scripts/apply-pr-triggerer.sh:*),Bash(/home/runner/work/prflow/prflow/scripts/apply-pr-triggerer.sh:*),Bash(scripts/branch-for-issue.py:*),Bash(/home/runner/work/prflow/prflow/scripts/branch-for-issue.py:*),Bash(scripts/check-completion-evidence.py:*),Bash(/home/runner/work/prflow/prflow/scripts/check-completion-evidence.py:*),Bash(scripts/config-get.sh:*),Bash(/home/runner/work/prflow/prflow/scripts/config-get.sh:*),Bash(scripts/discover-deferral-manifests.py:*),Bash(/home/runner/work/prflow/prflow/scripts/discover-deferral-manifests.py:*),Bash(scripts/dismiss-stale-rejections.sh:*),Bash(/home/runner/work/prflow/prflow/scripts/dismiss-stale-rejections.sh:*),Bash(scripts/ensure-label.sh:*),Bash(/home/runner/work/prflow/prflow/scripts/ensure-label.sh:*),Bash(scripts/apply-issue-dependencies.py:*),Bash(/home/runner/work/prflow/prflow/scripts/apply-issue-dependencies.py:*),Bash(scripts/extract-doc-needed-paths.sh:*),Bash(/home/runner/work/prflow/prflow/scripts/extract-doc-needed-paths.sh:*),Bash(scripts/file-deferrals.py:*),Bash(/home/runner/work/prflow/prflow/scripts/file-deferrals.py:*),Bash(scripts/load-prompt-extension.sh:*),Bash(/home/runner/work/prflow/prflow/scripts/load-prompt-extension.sh:*),Bash(scripts/match-deferrals.py:*),Bash(/home/runner/work/prflow/prflow/scripts/match-deferrals.py:*),Bash(scripts/match-lint-adjudications.py:*),Bash(/home/runner/work/prflow/prflow/scripts/match-lint-adjudications.py:*),Bash(scripts/normalize-verdicts.py:*),Bash(/home/runner/work/prflow/prflow/scripts/normalize-verdicts.py:*),Bash(scripts/parse-acs.py:*),Bash(/home/runner/work/prflow/prflow/scripts/parse-acs.py:*),Bash(scripts/preflight.py:*),Bash(/home/runner/work/prflow/prflow/scripts/preflight.py:*),Bash(scripts/react-to-trigger.sh:*),Bash(/home/runner/work/prflow/prflow/scripts/react-to-trigger.sh:*),Bash(scripts/reception-record.py:*),Bash(/home/runner/work/prflow/prflow/scripts/reception-record.py:*),Bash(scripts/resolve-existing-pr.sh:*),Bash(/home/runner/work/prflow/prflow/scripts/resolve-existing-pr.sh:*),Bash(scripts/resolve-review-overrides.py:*),Bash(/home/runner/work/prflow/prflow/scripts/resolve-review-overrides.py:*),Bash(scripts/run-jq.sh:*),Bash(/home/runner/work/prflow/prflow/scripts/run-jq.sh:*),Bash(scripts/stale-prose-lint.py:*),Bash(/home/runner/work/prflow/prflow/scripts/stale-prose-lint.py:*),Bash(scripts/update-branch-checkpoint.sh:*),Bash(/home/runner/work/prflow/prflow/scripts/update-branch-checkpoint.sh:*),Bash(scripts/verification-flight.py:*),Bash(/home/runner/work/prflow/prflow/scripts/verification-flight.py:*),Bash(scripts/workpad.py:*),Bash(/home/runner/work/prflow/prflow/scripts/workpad.py:*),Bash(mktemp:*),Bash(bash:*),Task,Agent
+```
+
+### Observed `permission_denials` entries (0)
+
+_No permission_denials entries found in the execution file._

--- a/lib/test/run.sh
+++ b/lib/test/run.sh
@@ -46777,7 +46777,18 @@ assert_eq "#908: describe-denial-count.sh is byte-unmodified by this issue (AC6)
 # now: every placeholder entry still declares itself PENDING. Legitimate additions
 # elsewhere on the page pass; silently promoting a placeholder to a measurement
 # goes RED, which is the regression the original pin existed to catch.
-assert_eq "#908: docs/cloud-allowlist.md's placeholder probe-evidence entries still declare themselves PENDING (AC8)" "3" \
+#
+# The expected count is data, not an invariant: it drops as placeholders are legitimately
+# promoted by a cited measurement, and the promotion reconciles this literal in the SAME
+# commit (the coupled-invariant discipline). It went 3 -> 1 when the two issue-858
+# dispatched-subagent Write entries (review and implement tiers) were filled from run
+# 30956039324 with run/job/head/ref recorded on the page and the jobs' verbatim machine
+# output committed at docs/subagent-write-probe.observed.md — a cited promotion, which is
+# exactly what this pin asks for and the opposite of the silent one it forbids. The
+# remaining entry is the issue-874 env: propagation probe, which stays PENDING because the
+# observed run returned INCONCLUSIVE (hop1_reported=False) — an unestablished measurement,
+# not a verdict, so its cell is deliberately still unfilled.
+assert_eq "#908: docs/cloud-allowlist.md's placeholder probe-evidence entries still declare themselves PENDING (AC8)" "1" \
   "$(grep -c '^\*\*This measurement is PENDING' "$LIB/../docs/cloud-allowlist.md")"
 # ────────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## What this is

**Docs-only.** It transcribes matcher-probe verdicts that **already existed** and had never been read back. No new probe run was dispatched and none was needed.

## The blind spot

`.github/workflows/matcher-probe.yml` triggers on `workflow_dispatch` **and** on a same-repo `pull_request` filtered to `paths: ['.github/workflows/matcher-probe.yml']`. So any same-repo PR editing that workflow automatically fires all 12 probe jobs. That was not appreciated, so six places in `docs/cloud-allowlist.md` claimed a measurement was "pending a dispatch" while the measurement sat unread in a completed run.

The irony is on record: the issue-#858 section's own prose already said *"its only pre-merge trigger is a same-repo `pull_request` scoped to the workflow's own path — so pushing this change to the implementing PR **does** fire it"*. It fired. Nobody looked.

## Evidence and attributability

Run [**30956039324**](https://github.com/The01Geek/prflow/actions/runs/30956039324) — 2026-08-04 22:20 UTC, branch `issue-1152-command-profile-shape-lint`, head `85e57ac1c6dcf732a861230f82182191977c6e41`. All 12 jobs concluded `success`.

That sha is **byte-identical to `origin/main`** for every file the verdicts depend on, which is what makes them attributable to `main` without a new dispatch. Verified empty for each of:

- `.github/workflows/matcher-probe.yml`
- `docs/cloud-allowlist.md`
- `scripts/subagent-write-probe-verdict.py`
- `scripts/env-propagation-probe-verdict.py`
- `scripts/describe-pretooluse-probe.sh`
- `lib/capability-profiles.json`, `lib/generate-capability-profiles.py` (the generated `--allowed-tools` baselines)

Every verdict below was read independently from the job logs (`gh api repos/{owner}/{repo}/actions/jobs/<id>/logs`, deterministic step summary), not taken on trust.

## What is now recorded

### Command-tier probe table (issue #1152) — job `92149438683`

All ten verdicts, plus each row's evidence triple reproduced verbatim from the job's own summary: **1, 3, 4, 5, 6, 7 PERMITTED; 2, 8, 9, 10 DENIED.** Row 7 is the positive control and passed, so the four refusals are real refusals and not a dead session; every row reported `tool_use=yes; shape=ok`, so none is the `REFORMULATED` case.

**Row 2 is a substantive new finding, not just a filled cell.** The *resolved/expanded* traversal form `.prflow/vendor/prflow/skills/<skill>/../../scripts/<helper>` is **DENIED** as a leading token, while the plain vendored literal `.prflow/vendor/prflow/scripts/<helper>` (row 1) is **PERMITTED**. The matcher does not normalize `../..` traversal back onto the granted literal. That is direct support for the **#1124/#1256 conditional-call remedy's shape** — emit the vendored literal *directly*, not a traversal — and it is stated where a reader of that remedy will see it.

### The `${CLAUDE_SKILL_DIR:-…}` anchor, argument position (issue #1124/#1152)

Rows 8, 9 and 10 all came back **DENIED**, so the section's *own pre-declared* cross-reading applies: **argument-position bare parameter expansion is refused generally, not specifically for `CLAUDE_SKILL_DIR`.** Row 10's control is the non-anchor `GITHUB_ACTIONS` under the same granted `echo` head, and it was denied too. The "unestablished" framing becomes established-and-recorded — scoped explicitly to one measurement, on the command tier, at one action version.

### PreToolUse probe evidence, Part 1 (issue #919) — job `92149438739`

**FIRED** / **REASON-ABSENT** — the **8th consecutive identical pair**. The six prior replications are listed and were each re-read from their own job log rather than taken on trust: all six are `event=pull_request`, all `success`, all returning the same pair. The fourth column stays `n/a — dropped post-#937` per #919's own dropped-AC record.

**One correction to the brief I was given:** it is the **three** oldest runs (`30577692232`, `30472371076`, `30421703361`) that render the breadcrumb as `.devflow/tmp/…`, not the two oldest — `30577692232` was mis-attributed to the post-rename spelling. Corrected in the second commit. No verdict changes; the pair is identical across all seven runs.

**The mandatory scope caveat is in.** The probe hook emits `permissionDecision: "allow"`, and per the Claude Code hooks decision-control table `permissionDecisionReason` is shown to Claude on `deny`, to the user on `ask`, and **ignored on `allow` and `defer`**. So `REASON-ABSENT` is the *specified* behavior for the decision emitted — **not** evidence that reason delivery is broken. `scripts/pretooluse-shape-guard.py` emits only `deny` and `defer`, so the guard's own deny-path reason delivery and its defer fall-through **remain unmeasured**, and this arm as written cannot measure them. Secondary caveat also recorded: the helper searches the *execution file*, a proxy for the transcript rather than a capture of the model's input.

### Dispatched-subagent `Write` into `.prflow/tmp/**` (issue #858), both tiers

**PERMITTED** on both — jobs `92149631372` (review) and `92149629323` (implement); `write_chain_ok=yes`, `side_effect_state=corroborated`, **zero** `permission_denials`.

Those sections state their own recording contract, and it is stricter than a bare verdict. All of it is honored: **ref**, **run id**, **job id**, **head commit**, `--permission-mode acceptEdits`, model `claude-haiku-4-5-20251001`, `--effort low`, and the `tool_use` -> `parent_tool_use_id` pair for each tier (`toolu_01SbG9oxWxp5PTNS3bbymzD3` -> `toolu_01Cd3LViMMbQw2surtkyDFGL` review; `toolu_01NmqhQw56kRuoGSXdr3e1Ph` -> `toolu_01CAkuq4wZ4x9M82HazPicfF` implement).

**On the verbatim `--allowed-tools` literals — flagged explicitly rather than silently omitted.** The two literals are ~1.9 KB and ~7.2 KB. Inlining them would bury the surrounding prose, so they are committed in full at **`docs/subagent-write-probe.observed.md`** and pointed at from both sections. That is not a workaround: it *is* the *"commit the job's machine output beside `docs/execution-file-shape.observed.txt`"* artifact those sections call for. The file carries each job's complete emitted step summary unedited (literal included), under a provenance header modeled on `execution-file-shape.observed.txt` and the same expiring-evidence rationale (GitHub logs expire ~90 days; without this the rows become unfalsifiable). **If a reviewer prefers the literals inline, say so and I will inline them** — nothing is omitted either way.

The `acceptEdits` scope caveat both jobs emit is carried across: a `PERMITTED` answers *"did the dispatched subagent's Write land under that permission mode?"* and does **not** isolate the allowlist as the sole reason. Also recorded: with zero denial entries, this run contributes **no** reading of the observed denial-entry shape, so that read stays outstanding — a `PERMITTED` does not discharge it.

## What is deliberately NOT recorded as a verdict

### Step-level `env:` propagation (issue #874) — job `92149438747`

The job returned **`INCONCLUSIVE`**, with `hop1_reported=False, hop2_reported=True`. `scripts/env-propagation-probe-verdict.py` deliberately routes that to *unestablished* rather than to a negative. Per **"Unknown is not zero"** the verdict cell stays **unfilled**; only the observation (run id, job id, hop detail) is recorded, and `ORCHESTRATOR_ONLY` in particular must not be inferred from a silent hop one.

What does change is the section's framing: **"PENDING a maintainer-dispatched run" was wrong on its premise** — a dispatch is not what it is waiting for.

**The probe appears to need a design fix before it can yield a verdict.** Hop one's report is not reaching the execution file the helper reads, so a blind re-dispatch would most likely return `INCONCLUSIVE` again. Diagnosing that means editing `matcher-probe.yml`, which is out of bounds for this PR (see below) — flagging it, not attempting it.

## Coupled reconciliation (the one non-docs edit)

`lib/test/run.sh`'s #908 AC8 pin counts the page's self-declared `PENDING` entries and goes **3 -> 1**.

That pin exists to catch a **silent** promotion of a placeholder into a measurement it never made — "Unknown is not zero" applied to probe evidence. These promotions are the opposite of silent: each cites run id, job id, head commit and ref, and two of them ship the verbatim machine output. Reconciling the literal in the **same commit** is exactly what the coupled-invariant discipline requires; leaving it would ship CI-red. The comment above the assertion now records why the count moved and that it is data, not an invariant. The remaining entry is #874's, which is honestly still pending.

## Deliberate non-actions

- **No `.github/workflows/` edits.** A PR touching `matcher-probe.yml` fires 12 paid Claude sessions per push. Keeping this docs-only is the entire cost argument for doing it now.
- **No `CLAUDE.md` edit.** Per its own convention those route through the claude-md-management revise skill. I don't think one is warranted here; if a maintainer wants the "matcher-probe auto-fires on same-repo PRs touching it" fact in project memory, that is the channel.
- **No changeset.** `CLAUDE.md` scopes changesets to the engine surface (`skills/`, `agents/`, `lib/`, `scripts/`, workflows, config schema); internal-only changes (tests, CI, dev-only docs) add none. This PR is `docs/` plus one test-file count reconciliation — no engine surface, so no changeset is missing.
- **No issue-body edits, no closing keywords.** #919, #858 and #874 stay open and untouched. **#919's AC1 needs a maintainer amendment** — it mandates an explicit `gh workflow run` dispatch that this evidence shows to be provably unnecessary — and that call is not mine. #874 needs the probe design fix above before it can close. Referenced descriptively throughout.

## Verification

Focused, per the tiered-runner convention — `docs/cloud-allowlist.md` has no module owner in `lib/test/modules/coverage-map.json` (the #805/#858/#874/#908/#1152 blocks are all `unmodularized`, i.e. monolith-shard), so the covering assertions were driven directly:

| Check | Result |
| --- | --- |
| `#434` stale-prose self-scan over this branch's diff | exit 0 |
| `#908` AC8 pin value (`grep -c` on the page) | `1` — matches the reconciled literal |
| `#805` arm-to-`REMEDIATION` mirror, all three arms **and** both row-scoping negative controls | pass |
| `lib/test/run-module.sh capability-profiles` | 68 passed, 0 failed |
| `lib/test/run-module.sh regenerate-artifacts` | 380 passed, 0 failed |
| `lib/test/cloud_writer_contract.py verify` | manifest matches closure |
| `shellcheck --severity=warning -e SC1091 --extended-analysis=false lib/test/run.sh` (0.11.0) | clean |
| `lint-tree-enumeration` / `lint-shipped-pruned-path` / `lint-gh-api-repo-path` / `lint-carveout-guard` / `lint-anchor-fallback-arm` / `lint-skills-glob-guard` | all clean |

The `#434` scan caught one real conflict on the way: rendering the evidence triples as a fourth table column made `denial=no` read as a deny-absolute, which with the backticked `` `>` `` in row 3 tripped R4 against the same file's `PERMITTED`. Fixed properly rather than suppressed — the rendered table keeps the page's existing three-column shape and the triples now sit in a fenced verbatim block as the machine output they are.

No local full-suite aggregate was attempted (slow and hang-prone in this environment); **CI `lib + python tests` is the aggregate signal.**
