### PR TITLE
fix: give the denial floor a skeleton arm so denials survive a costless run

### DIFF
--- a/.changeset/denial-record-skeleton-arm.md
+++ b/.changeset/denial-record-skeleton-arm.md
@@ -1,0 +1,33 @@
+---
+bump: patch
+type: Fixed
+---
+
+- **A permission-denial record is no longer discarded when the run produced no usable
+  cost figures.** Denial forensics ride the per-run efficiency record as its
+  `permission_denials` key, and `apply_denial_floor` could only ever *merge* onto a host
+  record — so a run that died before yielding cost figures lost its fully-built denial
+  record entirely. `scripts/prepare-harness-floor.sh` refuses to stage an all-null
+  `harness_cost`, which empties the cost handoff, which returns `apply_harness_floor`
+  before its own skeleton arm, so no host record existed to merge onto and the denial
+  record was dropped with only an expiring job-log warning — precisely the stall / crash /
+  execution-ceiling class where denial forensics matter most. The denial floor now has a
+  skeleton arm mirroring the cost floor's (same run-id targeting, same overwrite guard,
+  same minimal `synthesized: true, source: null` shape), so the record is written rather
+  than declined. An unjoinable denial record still beats a vanished one. This **closes the
+  all-null-cost drop path**; it is not an unconditional guarantee — the mirrored skeleton
+  inherits the cost skeleton's two gates, and each remains a named, breadcrumbed drop
+  path: a `pr-description` or unclassified command class, and an unresolvable PR number
+  (the record has no slug to be keyed by). How often either is reached is unestablished.
+- **The PR number is now resolved even when the cost is inert.**
+  `scripts/prepare-harness-floor.sh` short-circuited its PR resolution on every
+  cost-inert branch, back when `DEVFLOW_EXECUTION_PR` was the cost floor's operand alone.
+  It has a second consumer now, and the two operands fail independently — so the
+  short-circuit made the denial skeleton unreachable on exactly the path it exists for.
+  The cost side is unchanged: `apply_harness_floor` still returns at its first guard on an
+  empty cost, so no all-null `harness_cost` and no cost skeleton is ever staged.
+- **`efficiency_telemetry_enabled` now documents that it also gates denial forensics.**
+  Its schema description and the `docs/efficiency-trace.md` config table mentioned only
+  trace rendering and record writes, so a consumer disabling it for cost had nothing
+  warning them that they were also giving up the durable record of what the harness
+  refused.

--- a/.prflow/config.schema.json
+++ b/.prflow/config.schema.json
@@ -250,7 +250,7 @@
         },
         "efficiency_telemetry_enabled": {
           "type": "boolean",
-          "description": "When true, /prflow:review-and-fix derives a per-subagent effectiveness trace at Loop Exit, prints it to chat, and persists one per-run record to .prflow/logs/efficiency/. When false, the loop neither renders the trace nor writes any file under .prflow/logs/. Derivation is best-effort: a failure never aborts the fix loop.",
+          "description": "When true, /prflow:review-and-fix derives a per-subagent effectiveness trace at Loop Exit, prints it to chat, and persists one per-run record to .prflow/logs/efficiency/. When false, the loop neither renders the trace nor writes any file under .prflow/logs/. Derivation is best-effort: a failure never aborts the fix loop. This key ALSO gates permission-denial forensics: the durable record of what the harness refused on a run (its count, denied tool names and scrubbed command text) is persisted as the permission_denials key on that same per-run record, so setting this to false to save telemetry cost silently gives up denial forensics too -- a run that ends with no verdict then leaves only an expiring job log.",
           "default": true
         },
         "efficiency_cut_candidate_min_dispatch": {

--- a/docs/efficiency-trace.md
+++ b/docs/efficiency-trace.md
@@ -295,7 +295,7 @@ Both live under `prflow_review_and_fix` in `.prflow/config.json`
 
 | Key | Type | Default | Effect |
 |---|---|---|---|
-| `efficiency_telemetry_enabled` | boolean | `true` | Master gate. When `false`, the loop renders no trace and persists no effectiveness record to the telemetry branch. |
+| `efficiency_telemetry_enabled` | boolean | `true` | Master gate. When `false`, the loop renders no trace and persists no effectiveness record to the telemetry branch — **and no permission-denial forensics**, which ride the same per-run record as its `permission_denials` key (`apply_denial_floor` is gated on this flag exactly as record derivation is). Disabling this for cost gives up denial forensics too. |
 | `efficiency_cut_candidate_min_dispatch` | integer | `3` | Minimum dispatch count before an all-null/noise agent is flagged as a cut candidate. Defined here so the config surface is stable; **consumed by the follow-up cross-run analyzer**, not by `/prflow:review-and-fix` itself (the record carries it forward). |
 
 The telemetry-store branch is configured separately, at the top level of `.prflow/config.json`:
@@ -824,6 +824,10 @@ so the floor is buildable on the cloud tier without the agent's cooperation.
   reader, resolves/verifies the run's PR via `gh` (`lib/resolve-gh.sh`), and emits the floor env
   values. Each non-happy branch (execution file absent, not-a-PR, lookup failed, `pr-description`
   class) leaves a specific `::warning::` so a skipped skeleton/inert floor is auditable in the step log.
+  An **inert cost does not suppress the PR resolution**: the two operands fail independently, and
+  `DEVFLOW_EXECUTION_PR` has a second consumer (the denial floor's skeleton arm below). The cost side
+  is unchanged either way — `apply_harness_floor` returns at its first guard on an empty
+  `DEVFLOW_EXECUTION_COST`, so no cost skeleton is written and no all-null `harness_cost` is staged.
 - *Writer (`--persist`, `apply_harness_floor`).* Gated exactly like record derivation
   (`efficiency_telemetry_enabled`). It attaches `harness_cost` to **exactly** the record whose run-id
   equals this run's `${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}` identity — via a **merge arm** (a

--- a/lib/efficiency-trace.sh
+++ b/lib/efficiency-trace.sh
@@ -1317,10 +1317,34 @@ apply_harness_floor() {
 # Consume DEVFLOW_DENIAL_RECORD (scripts/build-denial-record.sh's single-line JSON) and
 # land it as a distinct top-level `permission_denials` key on this run's efficiency
 # record. Mirrors apply_harness_floor exactly (same run-id identity targeting, same
-# three arms — staged record / already-persisted branch record / decline) so the two
-# floors behave identically; a denial record is NEVER a skeleton (unlike harness_cost:
-# a denial floor with no efficiency record for the run-id simply declines — the analysis
-# joins the cost record, and the count is restored from THIS key when a record exists).
+# four arms — staged record / already-persisted branch record / skeleton / decline) so
+# the two floors behave identically.
+#
+# WHY THE SKELETON ARM EXISTS (it replaced an unconditional decline). The decline it
+# replaced reasoned that "a denial record with no cost record to key it has no analysis
+# join". That reasoning is right about ANALYSIS and wrong about FORENSICS: the cross-run
+# cost analysis does want a cost record beside the count, but the denial record's primary
+# job is telling an operator, after the fact, what the harness refused on a run that
+# produced no verdict. An unjoinable denial record still beats a vanished one — and the
+# vanished case was reachable, on exactly the runs that need it most. A run that died
+# before yielding usable cost figures leaves scripts/prepare-harness-floor.sh's
+# _cost_has_figures refusing to stage an all-null harness_cost, which empties
+# DEVFLOW_EXECUTION_COST, which returns apply_harness_floor at its first guard — before
+# its own skeleton arm — so no host record exists for the fully-built denial record to
+# merge onto, and the record was discarded with only a job-log warning that expires.
+# That is the stall / crash / execution-ceiling class.
+#
+# WHAT THIS DOES AND DOES NOT CLOSE. It closes the all-null-cost drop path. It is NOT an
+# unconditional guarantee that every denial reaches durable storage: the skeleton is a
+# faithful mirror of apply_harness_floor's, so it inherits that skeleton's two gates, and
+# each remains a real drop path:
+#   (1) DEVFLOW_COMMAND_CLASS is `pr-description` or does not classify — no record is
+#       derived for those classes at all, so there is no keyed store to write into;
+#   (2) DEVFLOW_EXECUTION_PR is empty — the record is keyed `<slug>-<run-id>.json` and the
+#       slug is `pr-<N>`, so with no PR number there is no identity to file it under.
+# Both take a named breadcrumb rather than a silent drop. How often either is reached in
+# practice is UNESTABLISHED and cannot be established from this tree — do not read the
+# breadcrumbs' absence as evidence of zero.
 #
 # Add the denial record (add-if-absent) to an in-STAGING record file $1, via temp+mv.
 _denial_merge_staged() {
@@ -1393,10 +1417,55 @@ apply_denial_floor() {
     fi
     return 0
   done < <(devflow_telemetry_list_blobs "$root" "$ref" ".prflow/logs/efficiency/")
-  # Decline arm: no record for this run-id. Unlike harness_cost there is no skeleton —
-  # a denial record without a cost record to key it has no analysis join, so decline
-  # with a breadcrumb rather than fabricate a bare record.
-  echo "::warning::efficiency-trace.sh --persist: denial floor: no efficiency record for run-id ${ident} (staged or on-branch); the denial record is not attached this run (no skeleton is written for denials — the analysis joins the cost record)" >&2
+
+  # Skeleton arm: no efficiency record for this run-id anywhere (staged or on-branch).
+  # Mirrors apply_harness_floor's skeleton arm — same class gate, same empty-PR gate,
+  # same overwrite guard, same minimal `synthesized: true, source: null` shape — with
+  # `permission_denials` in place of `harness_cost`. See the block comment above this
+  # function for why a record that cannot join the cost analysis is still written, and
+  # for the two residual drop paths the two gates below leave open.
+  #
+  # Only record-DERIVING command classes get a skeleton: pr-description's healthy state
+  # is "no record", so a skeleton there would invent a store entry the analysis is built
+  # to not expect.
+  case "${DEVFLOW_COMMAND_CLASS:-}" in
+    review|review-and-fix|implement) ;;
+    pr-description)
+      echo "::warning::efficiency-trace.sh --persist: denial floor: no record by design for command class 'pr-description'; no denial skeleton written (residual drop path: the denial record is discarded this run)" >&2
+      return 0 ;;
+    *)
+      echo "::warning::efficiency-trace.sh --persist: denial floor: command class '${DEVFLOW_COMMAND_CLASS:-<unset>}' does not derive records; no denial skeleton written (residual drop path: the denial record is discarded this run)" >&2
+      return 0 ;;
+  esac
+  if [ -z "${DEVFLOW_EXECUTION_PR:-}" ]; then
+    echo "::warning::efficiency-trace.sh --persist: denial floor: no record for run-id ${ident} and DEVFLOW_EXECUTION_PR is empty, so the skeleton has no pr-<N> slug to be keyed by; denial skeleton skipped (residual drop path: the denial record is discarded this run)" >&2
+    return 0
+  fi
+  local slug="pr-${DEVFLOW_EXECUTION_PR}" generated_at skel
+  # Skeleton-overwrite guard, mirroring apply_harness_floor's: merge arm (b) reaches here
+  # by falling through a loop that iterates zero times BOTH when the branch genuinely holds
+  # no record for this run-id AND when list_blobs swallowed a git failure (it returns empty
+  # on a rev-parse/ls-tree error). Writing a contentless skeleton over a real, populated
+  # record under the same filename would destroy it, so re-check the blob explicitly and
+  # decline rather than rest on the empty-list signal.
+  if [ -n "$ref" ] && devflow_telemetry_blob_exists "$root" "$ref" ".prflow/logs/efficiency/${slug}-${ident}.json" 2>/dev/null; then
+    echo "::warning::efficiency-trace.sh --persist: denial floor: a record already exists on the telemetry branch at .prflow/logs/efficiency/${slug}-${ident}.json (merge-arm-b's branch listing may have failed silently); declining to overwrite it with a denial skeleton" >&2
+    return 0
+  fi
+  generated_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  mkdir -p "$eff_dir" 2>/dev/null || true
+  # Same distinguishing marks as the cost skeleton — source:null (no mode's derivation
+  # ran), synthesized:true, iterations:0 — so a reader tells a floor skeleton from a #381
+  # commit-reconstructed record; here the carried key is permission_denials, not harness_cost.
+  if skel="$("$DEVFLOW_JQ" -n --arg slug "$slug" --arg ga "$generated_at" --argjson dr "$dr" \
+        '{schema_version: 1, slug: $slug, generated_at: $ga, source: null,
+          synthesized: true, iterations: 0, per_iteration: [], telemetry: [],
+          permission_denials: $dr}' 2>/dev/null)" && printf '%s\n' "$skel" > "${eff_dir}/${slug}-${ident}.json"; then
+    echo "devflow: efficiency-trace.sh --persist: denial floor: no record for run-id ${ident}; wrote a minimal denial skeleton ${slug}-${ident}.json (source:null, synthesized:true) so the denial record is durable even without cost figures" >&2
+  else
+    echo "::warning::efficiency-trace.sh --persist: denial floor: could not write the denial skeleton for ${slug}-${ident}; no floor write" >&2
+    rm -f "${eff_dir}/${slug}-${ident}.json" 2>/dev/null
+  fi
   return 0
 }
 

--- a/lib/test/modules/efficiency-trace-telemetry.sh
+++ b/lib/test/modules/efficiency-trace-telemetry.sh
@@ -1608,6 +1608,21 @@ assert_eq "df-runid: GITHUB_RUN_ID unset → a specific breadcrumb (fail-closed,
   "$(printf '%s' "$DF_RU_ERR" | grep -qF 'GITHUB_RUN_ID is unset' && echo yes || echo no)"
 rm -rf "$DF_RU"
 
+# Gate off (mirrors the cost floor's A8): efficiency_telemetry_enabled gates denial
+# forensics too, not only cost. Every input the skeleton arm needs is present (operand,
+# PR, record-deriving class, run-id), so with the flag ON this run WOULD write
+# pr-42-646-1.json — the gate is the only thing standing between here and that write.
+DF_G="$(_hc_repo "df gate-off")"
+printf '{"prflow_review_and_fix":{"efficiency_telemetry_enabled":false}}' > "$DF_G/.prflow/off.json"
+DF_G_ERR="$( ( cd "$DF_G" && DEVFLOW_CONFIG_FILE="$DF_G/.prflow/off.json" GITHUB_RUN_ID=646 \
+    GITHUB_RUN_ATTEMPT=1 DEVFLOW_DENIAL_RECORD="$DF_REC" DEVFLOW_EXECUTION_PR=42 \
+    DEVFLOW_COMMAND_CLASS=review-and-fix bash "$LIB/efficiency-trace.sh" --persist ) 2>&1 1>/dev/null )"
+assert_eq "df-gate: telemetry disabled → no denial skeleton (nor any other record) is written" "" \
+  "$(git -C "$DF_G" ls-tree -r --name-only refs/heads/prflow-telemetry 2>/dev/null | grep '\.prflow/logs/efficiency/' || true)"
+assert_eq "df-gate: telemetry disabled → the denial floor's own 'disabled' breadcrumb" "yes" \
+  "$(printf '%s' "$DF_G_ERR" | grep -qF 'denial floor: efficiency telemetry is disabled' && echo yes || echo no)"
+rm -rf "$DF_G"
+
 # Env-absent inertness: with DEVFLOW_DENIAL_RECORD unset the floor is inert AND SILENT,
 # so every pre-#1064 agent-side --persist call site is byte-identical to before.
 DF_E="$(_hc_repo "df env-absent")"

--- a/lib/test/modules/efficiency-trace-telemetry.sh
+++ b/lib/test/modules/efficiency-trace-telemetry.sh
@@ -1440,9 +1440,8 @@ rm -rf "$HC_RU"
 # required it be unit-tested against the helper directly (no network, no branch push).
 # It declares that it mirrors apply_harness_floor exactly, so it is driven through the
 # same arms as the HC block above: staged (a), already-persisted read-back (b) with
-# byte-preservation, decline, re-run idempotency, malformed operand, run-id absent.
-# The ONE deliberate divergence from harness_cost is asserted too: a denial floor with
-# no efficiency record for the run-id DECLINES — it never writes a skeleton.
+# byte-preservation, skeleton (with its overwrite guard and both residual decline gates),
+# re-run idempotency, malformed operand, run-id absent.
 DF_REC='{"count":3,"tool_names":["Bash"],"commands_state":"present","commands":["cat x > /tmp/a"],"total":1,"truncated":false,"commands_field_enabled":true,"scrub":{"applied":true,"blocklist_incomplete":true,"shapes":"s"}}'
 
 # arm (a): a record staged THIS PASS under the run-id identity gains permission_denials,
@@ -1486,17 +1485,99 @@ assert_eq "df-merge(b): re-run emits the already-carries backstop breadcrumb" "y
   "$(printf '%s' "$DF_M_RERUN" | grep -qF 'already carries permission_denials' && echo yes || echo no)"
 rm -rf "$DF_M"
 
-# DECLINE arm — the deliberate divergence from harness_cost: no efficiency record exists
-# for this run-id, so the floor attaches nothing and writes NO skeleton (a denial record
-# with no cost record to key it has no analysis join). Fail-closed with a breadcrumb.
-DF_D="$(_hc_repo "df decline")"
-DF_D_ERR="$( ( cd "$DF_D" && GITHUB_RUN_ID=606 GITHUB_RUN_ATTEMPT=1 DEVFLOW_DENIAL_RECORD="$DF_REC" \
+# SKELETON arm — no efficiency record exists for this run-id (the all-null-cost drop path:
+# prepare-harness-floor refuses to stage an all-null harness_cost, so apply_harness_floor
+# returns before its own skeleton arm and there is no host record to merge onto). The denial
+# floor writes its own minimal record rather than discarding a fully-built denial record.
+DF_SK="$(_hc_repo "df skeleton")"
+DF_SK_ERR="$( ( cd "$DF_SK" && GITHUB_RUN_ID=606 GITHUB_RUN_ATTEMPT=1 DEVFLOW_DENIAL_RECORD="$DF_REC" \
+    DEVFLOW_EXECUTION_PR=42 DEVFLOW_COMMAND_CLASS=review-and-fix \
     bash "$LIB/efficiency-trace.sh" --persist ) 2>&1 1>/dev/null )"
-assert_eq "df-decline: no record for the run-id → NO skeleton is written (unlike harness_cost)" "" \
-  "$(git -C "$DF_D" ls-tree -r --name-only refs/heads/prflow-telemetry 2>/dev/null | grep '\.prflow/logs/efficiency/' || true)"
-assert_eq "df-decline: emits the no-skeleton decline breadcrumb naming the run-id" "yes" \
-  "$(printf '%s' "$DF_D_ERR" | grep -qF 'no efficiency record for run-id 606-1' && echo yes || echo no)"
-rm -rf "$DF_D"
+assert_eq "df-skeleton: no record + PR + record-deriving class → a pr-<N> denial skeleton is written" "yes" \
+  "$(_et_on_branch "$DF_SK" ".prflow/logs/efficiency/pr-42-606-1.json")"
+assert_eq "df-skeleton: skeleton shape — schema_version/slug/source/synthesized/iterations/per_iteration/telemetry" \
+  '[1,"pr-42",null,true,0,[],[]]' \
+  "$(_et_show "$DF_SK" ".prflow/logs/efficiency/pr-42-606-1.json" | jq -c '[.schema_version,.slug,.source,.synthesized,.iterations,.per_iteration,.telemetry]')"
+assert_eq "df-skeleton: the denial record is carried VERBATIM (no harness_cost fabricated beside it)" \
+  "$(printf '%s' "$DF_REC" | jq -S -c .)|null" \
+  "$(_et_show "$DF_SK" ".prflow/logs/efficiency/pr-42-606-1.json" | jq -S -c '.permission_denials')|$(_et_show "$DF_SK" ".prflow/logs/efficiency/pr-42-606-1.json" | jq -c '.harness_cost')"
+# The downstream consumer claim this arm rests on: build-experiment-records.py's
+# _efficiency_entry needs only a top-level string `slug`, so a denial-only record INGESTS —
+# cost None (no telemetry to sum), and permission_denials flowing through to _denials_from_eff,
+# which reads only `.count`. A record that broke ingestion would be worse than none.
+DF_SK_RS="$(_et_show "$DF_SK" ".prflow/logs/efficiency/pr-42-606-1.json" | python3 -c 'import importlib.util,sys,json
+s=importlib.util.spec_from_file_location("e",sys.argv[1]);m=importlib.util.module_from_spec(s);s.loader.exec_module(m)
+r=json.load(sys.stdin); e=m._efficiency_entry(r,"606-1")
+print(json.dumps([e is not None, e["cost"], e["telemetry_complete"], list(m._denials_from_eff([e]))]))' "$LIB/../scripts/build-experiment-records.py" 2>/dev/null)"
+assert_eq "df-skeleton: a denial-only skeleton ingests downstream and yields the count via _denials_from_eff" \
+  '[true, null, false, [3, "efficiency-record"]]' "$DF_SK_RS"
+assert_eq "df-skeleton: emits the named skeleton-written breadcrumb" "yes" \
+  "$(printf '%s' "$DF_SK_ERR" | grep -qF 'wrote a minimal denial skeleton pr-42-606-1.json' && echo yes || echo no)"
+# Re-running the backstop over the now-persisted skeleton is a tree-equality no-op (the
+# already-carries arm), so the skeleton cannot churn the branch on every retry.
+DF_SK_BC="$(_et_branch_count "$DF_SK")"
+DF_SK_RERUN="$( ( cd "$DF_SK" && GITHUB_RUN_ID=606 GITHUB_RUN_ATTEMPT=1 DEVFLOW_DENIAL_RECORD="$DF_REC" \
+    DEVFLOW_EXECUTION_PR=42 DEVFLOW_COMMAND_CLASS=review-and-fix \
+    bash "$LIB/efficiency-trace.sh" --persist ) 2>&1 1>/dev/null )"
+assert_eq "df-skeleton: re-run over the persisted skeleton is a tree-equality no-op" \
+  "$DF_SK_BC" "$(_et_branch_count "$DF_SK")"
+assert_eq "df-skeleton: re-run takes the already-carries arm, never a second skeleton write" "yes" \
+  "$(printf '%s' "$DF_SK_RERUN" | grep -qF 'already carries permission_denials' && echo yes || echo no)"
+rm -rf "$DF_SK"
+
+# Skeleton-overwrite guard (mirrors the cost floor's A6+ fixture): merge arm (b) falls
+# through a loop that iterates zero times BOTH when the branch holds no record for this
+# run-id AND when list_blobs swallowed a git failure. Force that ambiguity — patch the
+# copied telemetry-branch.sh so list_blobs returns empty while blob_exists still finds the
+# blob — and a REAL, populated record occupying the skeleton's own filename must survive.
+DF_OW_ROOT="$(git_sandbox "df skel-overwrite root")"
+mkdir -p "$DF_OW_ROOT/lib" "$DF_OW_ROOT/.claude-plugin"
+cp "$LIB"/*.sh "$LIB"/*.jq "$DF_OW_ROOT/lib/" 2>/dev/null
+cp "$LIB/../.claude-plugin/plugin.json" "$DF_OW_ROOT/.claude-plugin/" 2>/dev/null
+printf '\ndevflow_telemetry_list_blobs() { return 0; }\n' >> "$DF_OW_ROOT/lib/telemetry-branch.sh"
+DF_OW="$(_hc_repo "df skel-overwrite")"
+DF_OW_REC='{"schema_version":1,"slug":"pr-42","generated_at":"2026-01-01T00:00:00Z","source":"review-and-fix","iterations":7,"real_marker":true,"telemetry":[]}'
+DF_OW_IDX="$DF_OW/.git/dfowidx"
+DF_OW_SB="$(printf '%s' "$DF_OW_REC" | git -C "$DF_OW" hash-object -w --stdin)"
+GIT_INDEX_FILE="$DF_OW_IDX" git -C "$DF_OW" update-index --add --cacheinfo "100644,${DF_OW_SB},.prflow/logs/efficiency/pr-42-616-1.json"
+DF_OW_ST="$(GIT_INDEX_FILE="$DF_OW_IDX" git -C "$DF_OW" write-tree)"; rm -f "$DF_OW_IDX"
+DF_OW_SN="$(GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@e GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@e git -C "$DF_OW" commit-tree "$DF_OW_ST" -m seed-record)"
+git -C "$DF_OW" update-ref refs/heads/prflow-telemetry "$DF_OW_SN"
+DF_OW_ERR="$( ( cd "$DF_OW" && GITHUB_RUN_ID=616 GITHUB_RUN_ATTEMPT=1 DEVFLOW_DENIAL_RECORD="$DF_REC" \
+    DEVFLOW_EXECUTION_PR=42 DEVFLOW_COMMAND_CLASS=review-and-fix \
+    bash "$DF_OW_ROOT/lib/efficiency-trace.sh" --persist ) 2>&1 1>/dev/null )"
+assert_eq "df-skeleton: guard declines → the real branch record is NOT overwritten (iterations still 7, not the skeleton's 0)" "7" \
+  "$(git -C "$DF_OW" show "refs/heads/prflow-telemetry:.prflow/logs/efficiency/pr-42-616-1.json" 2>/dev/null | jq -c '.iterations')"
+assert_eq "df-skeleton: guard declines → the real record's marker survives (skeleton never written over it)" "true" \
+  "$(git -C "$DF_OW" show "refs/heads/prflow-telemetry:.prflow/logs/efficiency/pr-42-616-1.json" 2>/dev/null | jq -c '.real_marker')"
+assert_eq "df-skeleton: guard declines → the specific 'declining to overwrite it with a denial skeleton' breadcrumb" "yes" \
+  "$(printf '%s' "$DF_OW_ERR" | grep -qF 'declining to overwrite it with a denial skeleton' && echo yes || echo no)"
+rm -rf "$DF_OW" "$DF_OW_ROOT"
+
+# Residual drop path 1 — a class that derives no record (pr-description, and unclassified):
+# no skeleton, and a NAMED breadcrumb so the discard is auditable rather than silent.
+for _df_cls in pr-description ''; do
+  DF_C="$(_hc_repo "df class")"
+  DF_C_ERR="$( ( cd "$DF_C" && GITHUB_RUN_ID=626 GITHUB_RUN_ATTEMPT=1 DEVFLOW_DENIAL_RECORD="$DF_REC" \
+      DEVFLOW_EXECUTION_PR=42 DEVFLOW_COMMAND_CLASS="$_df_cls" \
+      bash "$LIB/efficiency-trace.sh" --persist ) 2>&1 1>/dev/null )"
+  assert_eq "df-residual(class='$_df_cls'): no denial skeleton is written" "" \
+    "$(git -C "$DF_C" ls-tree -r --name-only refs/heads/prflow-telemetry 2>/dev/null | grep '\.prflow/logs/efficiency/' || true)"
+  assert_eq "df-residual(class='$_df_cls'): the discard draws a named residual-drop-path breadcrumb" "yes" \
+    "$(printf '%s' "$DF_C_ERR" | grep -qF 'no denial skeleton written (residual drop path' && echo yes || echo no)"
+  rm -rf "$DF_C"
+done
+
+# Residual drop path 2 — DEVFLOW_EXECUTION_PR empty: the record is keyed `<slug>-<run-id>`,
+# so with no PR number there is no slug to file it under. No skeleton, named breadcrumb.
+DF_NP="$(_hc_repo "df no-pr")"
+DF_NP_ERR="$( ( cd "$DF_NP" && GITHUB_RUN_ID=636 GITHUB_RUN_ATTEMPT=1 DEVFLOW_DENIAL_RECORD="$DF_REC" \
+    DEVFLOW_COMMAND_CLASS=review-and-fix bash "$LIB/efficiency-trace.sh" --persist ) 2>&1 1>/dev/null )"
+assert_eq "df-residual(empty PR): no denial skeleton is written" "" \
+  "$(git -C "$DF_NP" ls-tree -r --name-only refs/heads/prflow-telemetry 2>/dev/null | grep '\.prflow/logs/efficiency/' || true)"
+assert_eq "df-residual(empty PR): the discard draws a named residual-drop-path breadcrumb" "yes" \
+  "$(printf '%s' "$DF_NP_ERR" | grep -qF 'DEVFLOW_EXECUTION_PR is empty' && echo yes || echo no)"
+rm -rf "$DF_NP"
 
 # Malformed operand: 'not json' fails the jq PARSE; '[1,2]' PARSES but is not an object.
 # Both must draw the not-a-JSON-object breadcrumb and leave the record without the key —
@@ -1659,22 +1740,37 @@ assert_eq "hc-glue(A7): happy path → cost JSON written to the out file" "1" \
 HC_G_EXP="$(DEVFLOW_GH="$HC_GD/gh" STUB_PRS=50 bash "$HC_GLUE" "$HC_GD/exec.json" "/devflow:review-and-fix 50" 999 "$HC_GD/c2.json" 2>/dev/null)"
 assert_eq "hc-glue(A7): an explicit-number command uses the target (50), not the context number (999)" "yes" \
   "$(printf '%s' "$HC_G_EXP" | grep -qF "DEVFLOW_EXECUTION_PR='50'" && echo yes || echo no)"
-# inert: execution file absent → named inert breadcrumb, empty PR, empty cost file.
-HC_G_INERT="$(DEVFLOW_GH="$HC_GD/gh" bash "$HC_GLUE" "$HC_GD/nope.json" "/devflow:review-and-fix" 50 "$HC_GD/c3.json" 2>"$HC_GD/inert.err")"
+# inert: execution file absent → named inert breadcrumb, empty cost file. The PR is still
+# resolved: an inert COST no longer short-circuits the PR resolution, because the PR is a
+# SHARED operand (the denial floor's skeleton arm keys its record by it) and the two fail
+# independently. The cost handoff staying EMPTY is what keeps the cost floor inert.
+HC_G_INERT="$(DEVFLOW_GH="$HC_GD/gh" STUB_PRS=50 bash "$HC_GLUE" "$HC_GD/nope.json" "/devflow:review-and-fix" 50 "$HC_GD/c3.json" 2>"$HC_GD/inert.err")"
 assert_eq "hc-glue(A7): inert (execution file absent) → the named inert breadcrumb" "yes" \
   "$(grep -qF 'harness cost floor inert this run: execution file absent' "$HC_GD/inert.err" && echo yes || echo no)"
-assert_eq "hc-glue(A7): inert → DEVFLOW_EXECUTION_PR empty" "yes" \
-  "$(printf '%s' "$HC_G_INERT" | grep -qF "DEVFLOW_EXECUTION_PR=''" && echo yes || echo no)"
+assert_eq "hc-glue(A7): inert (execution file absent) → the cost handoff stays empty" "no" \
+  "$([ -s "$HC_GD/c3.json" ] && echo yes || echo no)"
+assert_eq "hc-glue(A7): inert cost no longer suppresses the shared PR operand" "yes" \
+  "$(printf '%s' "$HC_G_INERT" | grep -qF "DEVFLOW_EXECUTION_PR='50'" && echo yes || echo no)"
 # Parsed-but-figureless: the reader prints a non-empty normalized object by contract, but
 # the glue must not turn its all-null payload into false cost coverage or a cost skeleton.
+# This is the drop path the denial skeleton closes, so it is the one that most needs the PR.
 printf '%s' '{"type":"result"}' > "$HC_GD/all-null.json"
 HC_G_NULL="$(DEVFLOW_GH="$HC_GD/gh" STUB_PRS=50 bash "$HC_GLUE" "$HC_GD/all-null.json" "/devflow:review-and-fix" 50 "$HC_GD/c-null.json" 2>"$HC_GD/null.err")"
-assert_eq "hc-glue(A7): all-null reader object leaves DEVFLOW_EXECUTION_PR empty" "yes" \
-  "$(printf '%s' "$HC_G_NULL" | grep -qF "DEVFLOW_EXECUTION_PR=''" && echo yes || echo no)"
+assert_eq "hc-glue(A7): all-null reader object still resolves DEVFLOW_EXECUTION_PR (the denial floor keys on it)" "yes" \
+  "$(printf '%s' "$HC_G_NULL" | grep -qF "DEVFLOW_EXECUTION_PR='50'" && echo yes || echo no)"
 assert_eq "hc-glue(A7): all-null reader object leaves the cost handoff empty" "no" \
   "$([ -s "$HC_GD/c-null.json" ] && echo yes || echo no)"
 assert_eq "hc-glue(A7): all-null reader object emits a named no-figures inert breadcrumb" "yes" \
   "$(grep -qF 'execution file carried no cost or usage figures' "$HC_GD/null.err" && echo yes || echo no)"
+# Negative control for that decoupling: a resolved PR beside an EMPTY cost must NOT make the
+# COST floor write anything (apply_harness_floor returns at its first guard), so the glue
+# change cannot leak an all-null harness_cost or a cost skeleton into the store.
+HC_G_NCTL="$(_hc_repo "hc glue no-cost-skeleton")"
+( cd "$HC_G_NCTL" && GITHUB_RUN_ID=717 GITHUB_RUN_ATTEMPT=1 DEVFLOW_EXECUTION_COST="" \
+    DEVFLOW_EXECUTION_PR=50 DEVFLOW_COMMAND_CLASS=review-and-fix bash "$LIB/efficiency-trace.sh" --persist ) >/dev/null 2>&1
+assert_eq "hc-glue(A7): a resolved PR with an EMPTY cost writes no cost skeleton (the floor stays inert)" "" \
+  "$(git -C "$HC_G_NCTL" ls-tree -r --name-only refs/heads/prflow-telemetry 2>/dev/null | grep '\.prflow/logs/efficiency/' || true)"
+rm -rf "$HC_G_NCTL"
 # not-a-PR / lookup-failed: candidate 999 is not in the PR set → empty PR + breadcrumb.
 HC_G_NAP="$(DEVFLOW_GH="$HC_GD/gh" STUB_PRS=50 bash "$HC_GLUE" "$HC_GD/exec.json" "/devflow:review-and-fix" 999 "$HC_GD/c4.json" 2>"$HC_GD/nap.err")"
 assert_eq "hc-glue(A7): candidate not a real PR → DEVFLOW_EXECUTION_PR empty" "yes" \
@@ -1707,8 +1803,10 @@ assert_eq "hc-glue(A7): implement lookup-failed → the specific 'could not reso
 # exists and is non-empty), so the branch is attributed to a parse failure, not an absent file.
 printf 'not json at all {{{' > "$HC_GD/garbage.json"
 HC_G_PF="$(DEVFLOW_GH="$HC_GD/gh" STUB_PRS=50 bash "$HC_GLUE" "$HC_GD/garbage.json" "/devflow:review-and-fix" 50 "$HC_GD/c8.json" 2>"$HC_GD/pf.err")"
-assert_eq "hc-glue(A7): reader parse-fail → DEVFLOW_EXECUTION_PR empty" "yes" \
-  "$(printf '%s' "$HC_G_PF" | grep -qF "DEVFLOW_EXECUTION_PR=''" && echo yes || echo no)"
+assert_eq "hc-glue(A7): reader parse-fail → the cost handoff stays empty (the cost floor is inert)" "no" \
+  "$([ -s "$HC_GD/c8.json" ] && echo yes || echo no)"
+assert_eq "hc-glue(A7): reader parse-fail → the shared PR operand is still resolved" "yes" \
+  "$(printf '%s' "$HC_G_PF" | grep -qF "DEVFLOW_EXECUTION_PR='50'" && echo yes || echo no)"
 assert_eq "hc-glue(A7): reader parse-fail → the 'could not be parsed for cost' breadcrumb (not the absent-file one)" "yes" \
   "$(grep -qF 'could not be parsed for cost' "$HC_GD/pf.err" && ! grep -qF 'execution file absent' "$HC_GD/pf.err" && echo yes || echo no)"
 # review class, EMPTY-NUM: no explicit number in the command AND an empty candidate →

--- a/lib/test/run.sh
+++ b/lib/test/run.sh
@@ -17593,7 +17593,7 @@ assert_eq "app-token: overview §15 routes the review agent's posts to DevFlow-R
 # The registry and this full-suite call share the same lower-bound contract;
 # test_module_runner.py parses this operand and rejects any coupling drift.
 if ! devflow_run_full_suite_module "$LIB/test/modules/efficiency-trace-telemetry.sh" \
-  "efficiency-trace-telemetry" 903; then
+  "efficiency-trace-telemetry" 920; then
   printf 'ERROR: efficiency-trace-telemetry boundary could not record its result\n'
   exit 1
 fi

--- a/lib/test/run.sh
+++ b/lib/test/run.sh
@@ -17593,7 +17593,7 @@ assert_eq "app-token: overview §15 routes the review agent's posts to DevFlow-R
 # The registry and this full-suite call share the same lower-bound contract;
 # test_module_runner.py parses this operand and rejects any coupling drift.
 if ! devflow_run_full_suite_module "$LIB/test/modules/efficiency-trace-telemetry.sh" \
-  "efficiency-trace-telemetry" 920; then
+  "efficiency-trace-telemetry" 922; then
   printf 'ERROR: efficiency-trace-telemetry boundary could not record its result\n'
   exit 1
 fi

--- a/scripts/devflow-cloud-writer-contract.json
+++ b/scripts/devflow-cloud-writer-contract.json
@@ -1,6 +1,6 @@
 {
   "files": {
-    "lib/efficiency-trace.sh": "6e9a05761926b84b9160a7755f53ce3cce658f260f74860176e56dab5bd1e7aa",
+    "lib/efficiency-trace.sh": "6d7beddf6f7433e0f3a34e9041e575121da9ef0d3b5f8f97ee50536808d6656d",
     "scripts/apply-issue-dependencies.py": "87724c993e84b3c45b2d1a703ba027f478bf70b7dd1bb498db5cccb4df29491b",
     "scripts/apply-labels.sh": "7ea8de21f888b038ab0d6a2324b197e6e865144caf51d8b7a765d06996ab3ad2",
     "scripts/branch-for-issue.py": "e44aa7e0d8e743c9ea6c0b650e39376b91cefb5ce7eaca22803f3f50f5a0f1a9",

--- a/scripts/prepare-harness-floor.sh
+++ b/scripts/prepare-harness-floor.sh
@@ -119,30 +119,43 @@ case "$CLASS" in
 esac
 
 # ── Run the reader over the execution file → cost JSON ───────────────────────
-# Named inert breadcrumb (AC7) for the absent/empty file — the id-rename hazard would
+# An inert COST does NOT short-circuit the PR resolution below. DEVFLOW_EXECUTION_PR
+# used to be the cost floor's operand alone, so each inert arm emitted an empty PR and
+# exited here. It has a SECOND consumer now — the permission-denial forensics floor's
+# skeleton arm in lib/efficiency-trace.sh, which keys its record `pr-<N>-<run-id>.json`
+# — and those two operands fail INDEPENDENTLY: a run that dies before writing cost
+# figures can still have produced denials worth persisting. Short-circuiting here made
+# the denial skeleton unreachable on exactly that path (empty COST *and* empty PR), so
+# the arms below record the cost as inert and fall through. The cost floor itself is
+# unaffected: apply_harness_floor returns at its first guard on an empty
+# DEVFLOW_EXECUTION_COST, so no cost skeleton is written and no all-null harness_cost is
+# staged — a non-empty PR beside an empty COST changes nothing on the cost side.
+# Each arm keeps its own distinct named breadcrumb (AC7): the id-rename hazard would
 # otherwise disarm the floor silently.
+COST=""
+COST_INERT=""
 if [ -z "$EXEC_FILE" ] || [ ! -f "$EXEC_FILE" ] || [ ! -s "$EXEC_FILE" ]; then
   echo "::warning::prepare-harness-floor: harness cost floor inert this run: execution file absent" >&2
-  [ -n "$COST_OUT" ] && : > "$COST_OUT" 2>/dev/null || true
-  _emit "" "$CLASS"
+  COST_INERT=1
+else
+  # Do NOT suppress the reader's stderr: its breadcrumb (OSError / empty / JSON-garbage —
+  # the exact reason COST comes back empty here) must reach the step log so the "see the
+  # reader's breadcrumb" message below points at a breadcrumb that actually appears. Only
+  # stdout is captured into COST; the reader's stderr flows to this step's log.
+  COST="$(python3 "$READER" "$EXEC_FILE" || true)"
+  if [ -z "$COST" ]; then
+    echo "::warning::prepare-harness-floor: harness cost floor inert this run: execution file could not be parsed for cost (see the reader's breadcrumb above)" >&2
+    COST_INERT=1
+  elif ! _cost_has_figures "$COST"; then
+    echo "::warning::prepare-harness-floor: harness cost floor inert this run: execution file carried no cost or usage figures; refusing to stage an all-null harness_cost" >&2
+    COST_INERT=1
+  fi
 fi
-# Do NOT suppress the reader's stderr: its breadcrumb (OSError / empty / JSON-garbage —
-# the exact reason COST comes back empty here) must reach the step log so the "see the
-# reader's breadcrumb" message below points at a breadcrumb that actually appears. Only
-# stdout is captured into COST; the reader's stderr flows to this step's log.
-COST="$(python3 "$READER" "$EXEC_FILE" || true)"
-if [ -z "$COST" ]; then
-  echo "::warning::prepare-harness-floor: harness cost floor inert this run: execution file could not be parsed for cost (see the reader's breadcrumb above)" >&2
+if [ -n "$COST_INERT" ]; then
+  # Empty the handoff so no caller reads a stale cost from a previous invocation.
   [ -n "$COST_OUT" ] && : > "$COST_OUT" 2>/dev/null || true
-  _emit "" "$CLASS"
-fi
-if ! _cost_has_figures "$COST"; then
-  echo "::warning::prepare-harness-floor: harness cost floor inert this run: execution file carried no cost or usage figures; refusing to stage an all-null harness_cost" >&2
-  [ -n "$COST_OUT" ] && : > "$COST_OUT" 2>/dev/null || true
-  _emit "" "$CLASS"
-fi
-# Cost is available — stage it for --persist.
-if [ -n "$COST_OUT" ]; then
+elif [ -n "$COST_OUT" ]; then
+  # Cost is available — stage it for --persist.
   printf '%s\n' "$COST" > "$COST_OUT" 2>/dev/null \
     || echo "::warning::prepare-harness-floor: could not write cost JSON to '$COST_OUT'; the merge/skeleton arms will be inert this run" >&2
 fi

--- a/scripts/workflow-flight-recorder-registry.json
+++ b/scripts/workflow-flight-recorder-registry.json
@@ -87,7 +87,7 @@
     },
     "efficiency-trace-telemetry": {
       "path": "lib/test/modules/efficiency-trace-telemetry.sh",
-      "minimum_assertions": 903,
+      "minimum_assertions": 920,
       "assertion_floor_policy": "exact",
       "description": "Focused efficiency-trace and telemetry-persistence coverage: the efficiency-trace.jq/.sh per-run derivation surface with its degradation and flag-off arms, --persist and --self-check (#80), the #475 harness-side cost floor, the #381 synthesis floor with its shadow-provenance pins, #532 base-ref freshness, #441 telemetry-branch persistence, the #469 push-operand fail-closed/fetch-before-exclusion/degraded-retention contract, the #489 cross-workflow telemetry artifact relay, and the #499 unavailable-telemetry normalization matrix that shares this module's _et_show durable-blob reader"
     },

--- a/scripts/workflow-flight-recorder-registry.json
+++ b/scripts/workflow-flight-recorder-registry.json
@@ -87,7 +87,7 @@
     },
     "efficiency-trace-telemetry": {
       "path": "lib/test/modules/efficiency-trace-telemetry.sh",
-      "minimum_assertions": 920,
+      "minimum_assertions": 922,
       "assertion_floor_policy": "exact",
       "description": "Focused efficiency-trace and telemetry-persistence coverage: the efficiency-trace.jq/.sh per-run derivation surface with its degradation and flag-off arms, --persist and --self-check (#80), the #475 harness-side cost floor, the #381 synthesis floor with its shadow-provenance pins, #532 base-ref freshness, #441 telemetry-branch persistence, the #469 push-operand fail-closed/fetch-before-exclusion/degraded-retention contract, the #489 cross-workflow telemetry artifact relay, and the #499 unavailable-telemetry normalization matrix that shares this module's _et_show durable-blob reader"
     },


### PR DESCRIPTION
## The problem

Permission denials on the cloud tiers are recorded durably by pushing a denial record to
the `prflow-telemetry` orphan branch, via `lib/efficiency-trace.sh --persist`. That works —
except the denial record is a **rider on the efficiency record**.

`apply_denial_floor` had three arms: merge onto a record staged this pass, merge onto one
already on the branch, or **decline** with a warning and write nothing. The decline arm was
reachable, and reachable on exactly the runs that need denial forensics most:

1. `scripts/prepare-harness-floor.sh`'s `_cost_has_figures` refuses to stage an all-null
   `harness_cost` when the execution file carried no cost or usage figures.
2. That empties `DEVFLOW_EXECUTION_COST`.
3. `apply_harness_floor` returns at its **first guard** on an empty cost — before its own
   skeleton arm — so no efficiency record for the run-id exists anywhere.
4. `apply_denial_floor` therefore found nothing to merge onto and declined.

Result: a run that produced denials but died before yielding usable cost figures had its
fully-built denial record discarded, leaving only a `::warning::` in a job log that expires.
That is the stall / crash / execution-ceiling class.

The denial record itself was still being built on that path: `scripts/build-denial-record.sh`
only declines when the execution file is *absent or empty*; a present-but-figureless file
yields a real record, and an unparseable one yields `count: "unavailable"`.

## The fix

`apply_denial_floor` gains a **skeleton arm mirroring `apply_harness_floor`'s** — same
run-id identity targeting, same class gate, same empty-PR gate, same skeleton-overwrite
guard, same minimal `{schema_version, slug, generated_at, source: null, synthesized: true,
iterations: 0, per_iteration: [], telemetry: []}` shape — carrying `permission_denials`
where the cost skeleton carries `harness_cost`. The `synthesized: true, source: null` marker
is the existing sanctioned precedent for this situation (verified against
`apply_harness_floor`'s own skeleton, issue #475 AC6).

The decline arm's rationale — a denial record without a cost record *"has no analysis join"*
— is **right about analysis and wrong about forensics**. The record's primary job is telling
an operator, after the fact, what the harness refused on a run that produced no verdict; an
unjoinable denial record still beats a vanished one. That reasoning now sits in a code
comment where the decline arm's comment was.

### Second change: the PR operand was coupled to the cost operand

Verifying the inherited gates surfaced a coupling that would have made the skeleton **inert
on the very path it targets**. `prepare-harness-floor.sh` short-circuited its PR resolution
on every cost-inert branch (`_emit "" "$CLASS"` — empty PR), from back when
`DEVFLOW_EXECUTION_PR` was the cost floor's operand alone. So on the all-null-cost path
*both* `DEVFLOW_EXECUTION_COST` **and** `DEVFLOW_EXECUTION_PR` were empty, and a faithfully
mirrored skeleton would have declined at its PR gate every time.

The operands fail independently — a run can die before writing cost figures and still have
produced denials worth persisting — so the cost-inert arms now record the cost as inert and
**fall through** to the PR resolution instead of exiting. The cost side is unchanged:
`apply_harness_floor` returns at its first guard on an empty cost, so no all-null
`harness_cost` and no cost skeleton is ever staged. That is asserted as an explicit negative
control, not just reasoned about.

## What this does and does not close

It **closes the all-null-cost drop path**. It is **not** an unconditional guarantee that
every denied permission request reaches durable storage. The mirrored skeleton inherits
`apply_harness_floor`'s two gates, and each remains a real drop path — both verified in the
source, both named in a code comment beside the arm, both taking a named breadcrumb rather
than a silent drop, and both driven by tests:

1. **`DEVFLOW_COMMAND_CLASS` is `pr-description` or does not classify.** Those classes derive
   no record at all, so there is no keyed store to write into.
2. **`DEVFLOW_EXECUTION_PR` is empty.** The record is keyed `<slug>-<run-id>.json` with slug
   `pr-<N>`; with no PR number there is no identity to file it under.

**How often the decline arm was actually reached is unestablished** and cannot be established
from this tree. No estimate is offered, and the absence of these breadcrumbs is not evidence
of zero.

## Downstream consumer claim — verified, holds

`scripts/build-experiment-records.py`'s `_efficiency_entry` requires only a top-level string
`slug`, so a denial-only record ingests cleanly: `_run_cost` reads `record["telemetry"]` and
returns `None` for an empty list, `_telemetry_complete` returns `False`, and
`permission_denials` flows through verbatim to `_denials_from_eff`, which reads only
`.count`. This is asserted by driving the real module functions over a real skeleton, not
by inspection — a record that broke ingestion would be worse than none.

## `efficiency_telemetry_enabled` also gates denial persistence

`apply_denial_floor` is gated on `prflow_review_and_fix.efficiency_telemetry_enabled` exactly
as record derivation is (verified in `lib/efficiency-trace.sh`). Its schema description and
the `docs/efficiency-trace.md` config table mentioned only trace rendering and
`.prflow/logs/efficiency/` writes, so a consumer disabling it for cost reasons had nothing in
the key's name or description warning them they were also giving up denial forensics. Both
now say so.

## Tests

All behavioral, in `lib/test/modules/efficiency-trace-telemetry.sh`'s existing `#1064 AC3/W1`
block (which already drove the merge/decline arms). The decline-arm assertions are replaced
by, and the glue assertions extended with:

- the skeleton is written for a record-deriving class with a PR, with the asserted record
  shape and the denial record carried verbatim (and no fabricated `harness_cost` beside it);
- that skeleton ingests downstream and yields its count through `_denials_from_eff`;
- re-running the backstop over the persisted skeleton is a tree-equality no-op;
- the overwrite guard declines when a real, populated record occupies the skeleton's own
  filename and `list_blobs` silently returned empty (the patched-lib fixture pattern the cost
  floor's own guard test uses);
- both residual gates: no skeleton written, named breadcrumb, for `pr-description`, for an
  unclassified class, and for an empty PR;
- the glue now resolves the PR on the absent-file, unparseable and figureless branches while
  the cost handoff stays empty, plus the negative control that a resolved PR with an empty
  cost writes no cost skeleton.

`lib/test/run-module.sh efficiency-trace-telemetry` → **920 passed, 0 failed** (post-commit).
`shellcheck --severity=warning -e SC1091` over the tracked non-`lib/test` shell surface and
`ruff check` over the tracked Python surface are both clean.
`scripts/devflow-cloud-writer-contract.json` regenerated in the same commit (it SHA-256-pins
`lib/efficiency-trace.sh`).

No issue exists for this work; the problem and its evidence are described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
