### PR TITLE
docs: name the guard's no-decision fall-through in the runner heartbeat comment

### DIFF
--- a/.changeset/runner-guard-heartbeat-comment-refresh.md
+++ b/.changeset/runner-guard-heartbeat-comment-refresh.md
@@ -11,4 +11,4 @@ type: Fixed
   the tool and end the process, and `allow` was never emitted. The clause now names the
   no-decision fall-through and records that `deny` is the guard's only decision token.
   Comment prose only — no executable content changed, and the four-outcome disambiguation the
-  block describes is unaffected.
+  block describes is unaffected. (#1323)

--- a/.changeset/runner-guard-heartbeat-comment-refresh.md
+++ b/.changeset/runner-guard-heartbeat-comment-refresh.md
@@ -1,0 +1,14 @@
+---
+bump: patch
+type: Fixed
+---
+
+- **Correct a stale clause in the runner's PreToolUse guard-heartbeat comment.** The comment
+  block above the guard-visibility step described the heartbeat as written "on every
+  invocation including a defer/allow", naming two `permissionDecision` tokens that
+  `scripts/pretooluse-shape-guard.py` no longer emits — its `defer` fall-through was replaced
+  with a true no-decision path (exit 0 with no stdout) after that token was measured to block
+  the tool and end the process, and `allow` was never emitted. The clause now names the
+  no-decision fall-through and records that `deny` is the guard's only decision token.
+  Comment prose only — no executable content changed, and the four-outcome disambiguation the
+  block describes is unaffected.

--- a/.github/workflows/devflow-runner.yml
+++ b/.github/workflows/devflow-runner.yml
@@ -2632,7 +2632,8 @@ jobs:
       # guard fires but denies nothing does not create that file, so its absence is
       # ambiguous between "guard did not fire" and "guard fired, zero denials" unless
       # disambiguated against the heartbeat, written from `_write_heartbeat` on every
-      # invocation including a defer/allow. This step distinguishes FOUR outcomes
+      # invocation including the no-decision fall-through (exit 0 with no stdout, the
+      # guard's only non-`deny` outcome). This step distinguishes FOUR outcomes
       # (issue #908 review — an earlier revision of this comment named only the first
       # two, which is what let the third go untested; the fourth arrived with the
       # confirmatory review's zero-byte finding):


### PR DESCRIPTION
## Problem

The long comment block above `devflow-runner.yml`'s `Surface PreToolUse guard firing + denial counts` step describes the guard's heartbeat as:

> written from `_write_heartbeat` on every invocation including a defer/allow

`scripts/pretooluse-shape-guard.py` emits **neither** of those tokens today:

- **`defer`** — PR #1311 replaced the guard's `defer` fall-through with a true no-decision path (exit 0 with no stdout), after **run 30967680822** (`defer-probe`, job 92185120496) measured that `defer` blocks the tool and ends the process — `DEFER-BLOCKED` / `STOP-REASON-DEFERRED`, transcript `tool_deferred`. What was written as a fail-*open* path was in fact fail-*closed*.
- **`allow`** — never emitted. Verified against `origin/main`: `_emit(_decision_object(...))` has exactly one call site and its literal is `"deny"`; every other path calls `_emit_no_decision()`, which deliberately writes nothing.

So `deny` is the only decision token the guard ever writes, and the clause named two outcomes that do not exist.

## Change

One clause reworded:

```diff
       # disambiguated against the heartbeat, written from `_write_heartbeat` on every
-      # invocation including a defer/allow. This step distinguishes FOUR outcomes
+      # invocation including the no-decision fall-through (exit 0 with no stdout, the
+      # guard's only non-`deny` outcome). This step distinguishes FOUR outcomes
```

**The block's argument is untouched.** The heartbeat genuinely is written on every invocation — `_run()` calls `_write_heartbeat(tmp)` before any classification, under the comment "Every invocation, including a fall-through — this is the never-fired signal." That is precisely what makes the four-outcome disambiguation below it work, and none of those four outcomes, their routing, or their rationale changed. Only the *naming* of the non-`deny` outcomes was stale.

Comment prose only — no executable content changed. The changeset says so explicitly so the assembled CHANGELOG entry does not overclaim.

## Verification

- `actionlint .github/workflows/devflow-runner.yml` — 3 pre-existing `shellcheck` info findings at lines 458 / 1202 / 1732, all far from the edit at 2634. Confirmed identical count against the `origin/main` copy of the file, so this change introduces none.
- `lib/test/test_python_scripts.py` (the `focused_test` that `lib/test/modules/coverage-map.json` names for `scripts/pretooluse-shape-guard.py`) — **3684 passed, 0 failed, 0 skipped.**
- Convention checks: no `lib/test/` pin covers the changed clause (`defer/allow` occurred exactly once in the whole tree — the line being fixed), so nothing needed reconciling and **no new pin was added** (new prose-presence pins are prohibited). The replacement text names neither the withheld review workflow (the `#936` surviving-references allowlist is untouched) nor any `.devflow` / `devflow_*` spelling (`scaffold-config.sh`'s freshness gate).

CI is the aggregate signal; no local full-suite aggregate was chased.

## Found but deliberately NOT fixed

A sweep of `.github/workflows/` turned up further prose that tonight's measurements have staled, all in `.github/workflows/matcher-probe.yml`. **Left untouched** — a wider sweep is a separate decision:

1. **Line 1832–1840** (the `defer-probe` job header) is the substantive one, and is now false in three places:
   - "`defer` is the token `scripts/pretooluse-shape-guard.py` emits on every fail-open path" — it no longer emits it on any path.
   - "that file's own header records the premise as an UNESTABLISHED assumption" — the guard's header now records it as *measured*, with the run id.
   - "repairing the guard is separate work in which `defer` is load-bearing at several sites" — that repair has landed (#1311); `defer` is load-bearing at no site.
2. **Line 34** — "whether `defer` falls through to the default permission flow" is framed as an open question the probe will settle. It has been settled.

The `defer-probe` job body itself is correct as-is: it deliberately emits a literal `defer` from its own throwaway hook to measure the harness, independently of what the guard emits, so its mechanics need no change even once the prose is refreshed.

Also noted for the record: `scripts/pretooluse-shape-guard.py`'s own module docstring is already accurate on all of this — it was updated with the fix.

No issue exists for this; filed directly.
