### PR TITLE
docs: add visual guides to public documentation

### DIFF
--- a/docs/external/docs/concepts/lifecycle.md
+++ b/docs/external/docs/concepts/lifecycle.md
@@ -7,6 +7,22 @@ description: "Follow an issue through implementation, review, documentation and 
 
 This page follows seven lifecycle stages from issue preparation through human merge. PRFlow performs the middle stages through four implementation phases. The final merge remains human-controlled.
 
+```mermaid
+flowchart TD
+    accTitle: Seven stages in the PRFlow lifecycle
+    accDescr: An issue starts a PRFlow run. PRFlow prepares a branch and workpad, implements and verifies the change, then opens a draft pull request. It reviews and routes findings and updates documentation. A person reviews and merges the finished pull request.
+    issue["1. Issue<br/>Define the change"] --> run["2. Run<br/>Load guidance and start or resume"]
+
+    subgraph prflow["PRFlow prepares the change"]
+        run --> branch["3. Branch and workpad<br/>Record progress and decisions"]
+        branch --> draft["4. Draft pull request<br/>Implement and verify, then open"]
+        draft --> review["5. Verification and review<br/>Route findings and apply authorized fixes"]
+        review --> docs["6. Documentation<br/>Explain the finished change"]
+    end
+
+    docs --> merge["7. Human merge<br/>Review, approve and merge"]
+```
+
 ## 1. Issue
 
 The GitHub issue is the change contract. PRFlow reads its description and acceptance criteria, checks declared dependencies and compares important claims with the repository before editing code.

--- a/docs/external/docs/concepts/review-system.md
+++ b/docs/external/docs/concepts/review-system.md
@@ -7,6 +7,8 @@ description: "Understand how PRFlow verifies claims, combines reviewers and fixe
 
 This page is for developers deciding how much confidence to place in a PRFlow review. The system combines mechanical evidence and independent review passes, but it does not prove that a change is perfect.
 
+![The prflow:review skill moves through setup and classification, a verification checklist, specialized reviewers and a verdict. The prflow:review-and-fix skill uses the same engine, applies justified corrections, verifies them and reviews the result again. A shadow pass checks an approval-side result before the loop exits.](/images/review-system-loop.svg)
+
 ## Four Review Phases
 
 ### Setup and Classification

--- a/docs/external/docs/concepts/workpads-and-resume.md
+++ b/docs/external/docs/concepts/workpads-and-resume.md
@@ -7,6 +7,8 @@ description: "Understand PRFlow's recorded progress and interruption boundaries.
 
 This page is for developers who need to understand what survives when an implementation run pauses, stops or is retriggered.
 
+![The prflow:implement skill resumes from two kinds of recovery evidence: the GitHub issue workpad and the remote branch. A Blocked workpad causes PRFlow to surface the recorded cause. If matching open work exists, PRFlow adopts it, inspects the current tree and repeats blocking checks.](/images/workpad-resume.svg)
+
 ## The Workpad
 
 An implementation run maintains exactly one dedicated progress comment on its GitHub issue. This workpad is the human-readable progress record for the run.

--- a/docs/external/docs/runs/cloud/index.md
+++ b/docs/external/docs/runs/cloud/index.md
@@ -7,6 +7,10 @@ description: "Run PRFlow from authorized GitHub comments through repository auto
 
 Cloud runs are for teams that want authorized collaborators to start PRFlow from GitHub. They run in GitHub Actions without an open local Claude Code session.
 
+Cloud commands pass through an authorization gate before the agent job starts. The gate uses narrow GitHub permissions. The agent job then receives model credentials and its configured repository permissions. Maintainer-controlled workflows and configuration define both jobs. The run writes its work to a branch, workpad, pull request or review; it does not merge the change.
+
+![A cloud command moves from a GitHub comment through an authorization gate with narrow GitHub permissions, then into an agent job with model credentials and configured repository permissions. The agent job produces a branch, workpad, pull request or review for a person to review and merge.](/images/cloud-run-trust-boundary.svg)
+
 Fresh installations support two public cloud commands:
 
 - `/prflow:implement` turns an issue into a pull request.

--- a/docs/external/docs/runs/index.md
+++ b/docs/external/docs/runs/index.md
@@ -7,6 +7,20 @@ description: "Choose local interactive execution or optional GitHub Actions auto
 
 This page is for teams choosing where PRFlow should execute. The lifecycle is similar in both modes, but the credentials, permission boundary and interaction model differ.
 
+```mermaid
+flowchart TD
+    accTitle: Choose between a local run and a cloud run
+    accDescr: Use a local run for interactive work in your current development session. Use a cloud run for unattended work only after the GitHub Actions workflow, runner, secrets, setup and permissions are ready.
+    start{"Do you want PRFlow to run<br/>in your current development session?"}
+    start -- "Yes" --> local["Use a local run<br/>Interactive and easiest to start"]
+    start -- "No" --> unattended{"Do you need authorized GitHub comments<br/>to start unattended work?"}
+    unattended -- "No" --> local
+    unattended -- "Yes" --> ready{"Are the workflow, runner, secrets,<br/>setup and permissions ready?"}
+    ready -- "Not yet" --> prepare["Start locally<br/>Then configure and test cloud runs"]
+    ready -- "Yes" --> cloud["Use a cloud run<br/>GitHub Actions executes the work"]
+    prepare --> cloud
+```
+
 | **Run Type** | **Execution Environment** | **Best For** |
 | --- | --- | --- |
 | [Local runs](/docs/runs/local/index) | Your Claude Code, GitHub Copilot CLI or Codex CLI session. | First use, interactive decisions and access to an existing development environment. |

--- a/docs/external/docs/workflows/index.md
+++ b/docs/external/docs/workflows/index.md
@@ -7,6 +7,10 @@ description: "Choose the PRFlow workflow that matches the outcome and edit autho
 
 This page helps you choose the smallest workflow with the needed edit authority.
 
+The diagram uses PRFlow skill names without a client-specific command prefix. The command examples below show how to invoke them in each supported client.
+
+![A map of PRFlow skills grouped by outcome. The core delivery skills are prflow:create-issue, prflow:implement, prflow:review and prflow:review-and-fix. Supporting skills are prflow:pr-description, prflow:docs and prflow:retrospective-weekly.](/images/workflow-skill-map.svg)
+
 ## Choose a Workflow
 
 | **Goal** | **Workflow** | **What It Can Change** | **Expected Result** |

--- a/docs/external/images/cloud-run-trust-boundary.svg
+++ b/docs/external/images/cloud-run-trust-boundary.svg
@@ -1,0 +1,67 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="720" viewBox="0 0 900 720" role="img" aria-labelledby="title" aria-describedby="description">
+  <title id="title">PRFlow cloud run trust boundary</title>
+  <desc id="description">A GitHub comment passes through an authorization gate that uses narrow GitHub permissions. The gate starts a maintainer-controlled agent job with model credentials and configured repository permissions. The agent job produces a branch, workpad, pull request or review. A person reviews and merges the work.</desc>
+
+  <defs>
+    <marker id="arrow" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto" markerUnits="strokeWidth">
+      <path d="M 0 0 L 12 6 L 0 12 z" fill="#635BFF"/>
+    </marker>
+  </defs>
+
+  <rect x="1" y="1" width="898" height="718" rx="28" fill="#FBFAFF" stroke="#E2DFFF" stroke-width="2"/>
+
+  <g font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
+    <text x="46" y="52" fill="#19172B" font-size="26" font-weight="600">How a cloud command becomes review-ready work</text>
+    <text x="46" y="83" fill="#5C5875" font-size="16">The authorization gate runs before the agent job.</text>
+    <text x="46" y="107" fill="#5C5875" font-size="16">Repository rules still govern what each job can access.</text>
+
+    <rect x="462" y="134" width="392" height="446" rx="24" fill="#F2F0FF" stroke="#7C73FF" stroke-width="2" stroke-dasharray="8 7"/>
+    <rect x="487" y="118" width="256" height="34" rx="17" fill="#635BFF"/>
+    <text x="615" y="141" fill="#FFFFFF" font-size="13" font-weight="600" text-anchor="middle" letter-spacing="0.5">TRUSTED EXECUTION BOUNDARY</text>
+
+    <line x1="408" y1="250" x2="500" y2="250" stroke="#635BFF" stroke-width="3" marker-end="url(#arrow)"/>
+    <line x1="680" y1="326" x2="680" y2="404" stroke="#635BFF" stroke-width="3" marker-end="url(#arrow)"/>
+    <line x1="502" y1="480" x2="410" y2="480" stroke="#635BFF" stroke-width="3" marker-end="url(#arrow)"/>
+
+    <g>
+      <rect x="48" y="176" width="360" height="150" rx="18" fill="#FFFFFF" stroke="#D8D4F4" stroke-width="2"/>
+      <circle cx="88" cy="218" r="20" fill="#EAE8FF"/>
+      <text x="88" y="225" fill="#4B45CC" font-size="19" font-weight="700" text-anchor="middle">1</text>
+      <text x="122" y="224" fill="#19172B" font-size="20" font-weight="600">GitHub comment</text>
+      <text x="76" y="270" fill="#5C5875" font-size="17">A collaborator requests implementation</text>
+      <text x="76" y="296" fill="#5C5875" font-size="17">or review.</text>
+    </g>
+
+    <g>
+      <rect x="500" y="176" width="324" height="150" rx="18" fill="#FFFFFF" stroke="#635BFF" stroke-width="2"/>
+      <circle cx="540" cy="218" r="20" fill="#EAE8FF"/>
+      <text x="540" y="225" fill="#4B45CC" font-size="19" font-weight="700" text-anchor="middle">2</text>
+      <text x="574" y="224" fill="#19172B" font-size="20" font-weight="600">Authorization gate</text>
+      <text x="528" y="270" fill="#5C5875" font-size="17">Checks the allowed list and</text>
+      <text x="528" y="296" fill="#5C5875" font-size="17">uses narrow GitHub permissions.</text>
+    </g>
+
+    <g>
+      <rect x="500" y="404" width="324" height="150" rx="18" fill="#FFFFFF" stroke="#635BFF" stroke-width="2"/>
+      <circle cx="540" cy="446" r="20" fill="#EAE8FF"/>
+      <text x="540" y="453" fill="#4B45CC" font-size="19" font-weight="700" text-anchor="middle">3</text>
+      <text x="574" y="452" fill="#19172B" font-size="20" font-weight="600">Agent job</text>
+      <text x="528" y="498" fill="#5C5875" font-size="17">Receives model credentials and</text>
+      <text x="528" y="524" fill="#5C5875" font-size="17">configured repository permissions.</text>
+    </g>
+
+    <g>
+      <rect x="48" y="404" width="360" height="150" rx="18" fill="#FFFFFF" stroke="#D8D4F4" stroke-width="2"/>
+      <circle cx="88" cy="446" r="20" fill="#EAE8FF"/>
+      <text x="88" y="453" fill="#4B45CC" font-size="19" font-weight="700" text-anchor="middle">4</text>
+      <text x="122" y="452" fill="#19172B" font-size="20" font-weight="600">Work product</text>
+      <text x="76" y="498" fill="#5C5875" font-size="17">Branch, workpad, pull request</text>
+      <text x="76" y="524" fill="#5C5875" font-size="17">or review.</text>
+    </g>
+
+    <line x1="228" y1="554" x2="228" y2="615" stroke="#A39EBE" stroke-width="2"/>
+    <circle cx="228" cy="615" r="5" fill="#635BFF"/>
+    <text x="228" y="652" fill="#19172B" font-size="18" font-weight="600" text-anchor="middle">Human review and merge</text>
+    <text x="228" y="678" fill="#5C5875" font-size="16" text-anchor="middle">Automation stops before merge.</text>
+  </g>
+</svg>

--- a/docs/external/images/review-system-loop.svg
+++ b/docs/external/images/review-system-loop.svg
@@ -1,0 +1,68 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="720" viewBox="0 0 900 720" role="img" aria-labelledby="title" aria-describedby="description">
+  <title id="title">PRFlow review engine and correction loop</title>
+  <desc id="description">The prflow review skill runs four phases: setup and classification, verification checklist, specialized reviewers and verdict. The prflow review-and-fix skill uses the same review engine, applies justified corrections, verifies them and runs the engine again. A shadow pass checks an approval-side result before the loop exits.</desc>
+
+  <defs>
+    <marker id="arrow" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto" markerUnits="strokeWidth">
+      <path d="M 0 0 L 12 6 L 0 12 z" fill="#635BFF"/>
+    </marker>
+  </defs>
+
+  <rect x="1" y="1" width="898" height="718" rx="28" fill="#FBFAFF" stroke="#E2DFFF" stroke-width="2"/>
+
+  <g font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
+    <text x="46" y="52" fill="#19172B" font-size="26" font-weight="600">How PRFlow reviews and corrects a change</text>
+    <text x="46" y="83" fill="#5C5875" font-size="16">The correction loop reuses the same four-phase review engine.</text>
+
+    <rect x="46" y="112" width="142" height="32" rx="16" fill="#635BFF"/>
+    <text x="117" y="134" fill="#FFFFFF" font-size="14" font-weight="700" text-anchor="middle">prflow:review</text>
+
+    <line x1="408" y1="224" x2="492" y2="224" stroke="#635BFF" stroke-width="3" marker-end="url(#arrow)"/>
+    <line x1="676" y1="296" x2="676" y2="368" stroke="#635BFF" stroke-width="3" marker-end="url(#arrow)"/>
+    <line x1="492" y1="440" x2="408" y2="440" stroke="#635BFF" stroke-width="3" marker-end="url(#arrow)"/>
+
+    <g>
+      <rect x="48" y="158" width="360" height="138" rx="18" fill="#FFFFFF" stroke="#D8D4F4" stroke-width="2"/>
+      <circle cx="88" cy="199" r="20" fill="#EAE8FF"/>
+      <text x="88" y="206" fill="#4B45CC" font-size="19" font-weight="700" text-anchor="middle">1</text>
+      <text x="122" y="205" fill="#19172B" font-size="20" font-weight="600">Setup and classification</text>
+      <text x="76" y="250" fill="#5C5875" font-size="16">Resolve the diff, base, issue criteria</text>
+      <text x="76" y="275" fill="#5C5875" font-size="16">and risk profile.</text>
+    </g>
+
+    <g>
+      <rect x="492" y="158" width="360" height="138" rx="18" fill="#FFFFFF" stroke="#D8D4F4" stroke-width="2"/>
+      <circle cx="532" cy="199" r="20" fill="#EAE8FF"/>
+      <text x="532" y="206" fill="#4B45CC" font-size="19" font-weight="700" text-anchor="middle">2</text>
+      <text x="566" y="205" fill="#19172B" font-size="20" font-weight="600">Verification checklist</text>
+      <text x="520" y="250" fill="#5C5875" font-size="16">Check change-specific claims against</text>
+      <text x="520" y="275" fill="#5C5875" font-size="16">mechanical or reviewer evidence.</text>
+    </g>
+
+    <g>
+      <rect x="492" y="368" width="360" height="138" rx="18" fill="#FFFFFF" stroke="#D8D4F4" stroke-width="2"/>
+      <circle cx="532" cy="409" r="20" fill="#EAE8FF"/>
+      <text x="532" y="416" fill="#4B45CC" font-size="19" font-weight="700" text-anchor="middle">3</text>
+      <text x="566" y="415" fill="#19172B" font-size="20" font-weight="600">Specialized reviewers</text>
+      <text x="520" y="460" fill="#5C5875" font-size="16">Review correctness, tests, comments,</text>
+      <text x="520" y="485" fill="#5C5875" font-size="16">silent failures and type design.</text>
+    </g>
+
+    <g>
+      <rect x="48" y="368" width="360" height="138" rx="18" fill="#FFFFFF" stroke="#70A38B" stroke-width="2"/>
+      <circle cx="88" cy="409" r="20" fill="#E8F5EF"/>
+      <text x="88" y="416" fill="#2F6B51" font-size="19" font-weight="700" text-anchor="middle">4</text>
+      <text x="122" y="415" fill="#19172B" font-size="20" font-weight="600">Verdict</text>
+      <text x="76" y="460" fill="#5C5875" font-size="16">Combine evidence, findings, coverage</text>
+      <text x="76" y="485" fill="#5C5875" font-size="16">and configured severity thresholds.</text>
+    </g>
+
+    <line x1="228" y1="506" x2="228" y2="558" stroke="#635BFF" stroke-width="3" marker-end="url(#arrow)"/>
+    <rect x="48" y="558" width="804" height="116" rx="20" fill="#F2F0FF" stroke="#635BFF" stroke-width="2"/>
+    <rect x="72" y="578" width="214" height="32" rx="16" fill="#635BFF"/>
+    <text x="179" y="600" fill="#FFFFFF" font-size="14" font-weight="700" text-anchor="middle">prflow:review-and-fix</text>
+    <text x="72" y="638" fill="#19172B" font-size="18" font-weight="600">Apply justified corrections → verify them → run the review engine again</text>
+    <text x="72" y="664" fill="#5C5875" font-size="15">A shadow pass checks an approval-side result before the loop exits.</text>
+    <text x="817" y="644" fill="#4B45CC" font-size="28" font-weight="700" text-anchor="middle">↺</text>
+  </g>
+</svg>

--- a/docs/external/images/workflow-skill-map.svg
+++ b/docs/external/images/workflow-skill-map.svg
@@ -1,0 +1,73 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="760" viewBox="0 0 900 760" role="img" aria-labelledby="title" aria-describedby="description">
+  <title id="title">Choose a PRFlow skill by outcome</title>
+  <desc id="description">Four core delivery skills create an issue, implement an issue, review changes or review and fix changes. Three supporting skills update a pull request description, maintain documentation or run the weekly retrospective.</desc>
+
+  <rect x="1" y="1" width="898" height="758" rx="28" fill="#FBFAFF" stroke="#E2DFFF" stroke-width="2"/>
+
+  <g font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
+    <text x="46" y="52" fill="#19172B" font-size="26" font-weight="600">Choose the skill that matches the outcome</text>
+    <text x="46" y="83" fill="#5C5875" font-size="16">Start with the smallest workflow that has the edit authority you need.</text>
+
+    <text x="48" y="130" fill="#5C5875" font-size="14" font-weight="700" letter-spacing="0.7">CORE DELIVERY SKILLS</text>
+
+    <g>
+      <rect x="48" y="150" width="385" height="142" rx="18" fill="#FFFFFF" stroke="#D8D4F4" stroke-width="2"/>
+      <rect x="72" y="174" width="190" height="31" rx="15" fill="#EAE8FF"/>
+      <text x="167" y="195" fill="#4B45CC" font-size="15" font-weight="700" text-anchor="middle">prflow:create-issue</text>
+      <text x="72" y="239" fill="#19172B" font-size="20" font-weight="600">Create an approved issue</text>
+      <text x="72" y="268" fill="#5C5875" font-size="16">Turns a rough request into a reviewed ticket.</text>
+    </g>
+
+    <g>
+      <rect x="467" y="150" width="385" height="142" rx="18" fill="#FFFFFF" stroke="#635BFF" stroke-width="2"/>
+      <rect x="491" y="174" width="166" height="31" rx="15" fill="#635BFF"/>
+      <text x="574" y="195" fill="#FFFFFF" font-size="15" font-weight="700" text-anchor="middle">prflow:implement</text>
+      <text x="491" y="239" fill="#19172B" font-size="20" font-weight="600">Complete an existing issue</text>
+      <text x="491" y="268" fill="#5C5875" font-size="16">Prepares a review-ready or draft pull request.</text>
+    </g>
+
+    <g>
+      <rect x="48" y="322" width="385" height="142" rx="18" fill="#FFFFFF" stroke="#70A38B" stroke-width="2"/>
+      <rect x="72" y="346" width="144" height="31" rx="15" fill="#E8F5EF"/>
+      <text x="144" y="367" fill="#2F6B51" font-size="15" font-weight="700" text-anchor="middle">prflow:review</text>
+      <text x="72" y="411" fill="#19172B" font-size="20" font-weight="600">Assess without tree edits</text>
+      <text x="72" y="440" fill="#5C5875" font-size="16">Returns findings and an APPROVE or REJECT verdict.</text>
+    </g>
+
+    <g>
+      <rect x="467" y="322" width="385" height="142" rx="18" fill="#FFFFFF" stroke="#635BFF" stroke-width="2"/>
+      <rect x="491" y="346" width="214" height="31" rx="15" fill="#EAE8FF"/>
+      <text x="598" y="367" fill="#4B45CC" font-size="15" font-weight="700" text-anchor="middle">prflow:review-and-fix</text>
+      <text x="491" y="411" fill="#19172B" font-size="20" font-weight="600">Assess and correct</text>
+      <text x="491" y="440" fill="#5C5875" font-size="16">Commits corrections only when you authorize edits.</text>
+    </g>
+
+    <text x="48" y="516" fill="#5C5875" font-size="14" font-weight="700" letter-spacing="0.7">SUPPORTING SKILLS</text>
+
+    <g>
+      <rect x="48" y="536" width="250" height="154" rx="18" fill="#FFFFFF" stroke="#D8D4F4" stroke-width="2"/>
+      <text x="72" y="572" fill="#4B45CC" font-size="15" font-weight="700">prflow:pr-description</text>
+      <text x="72" y="610" fill="#19172B" font-size="18" font-weight="600">Explain the change</text>
+      <text x="72" y="640" fill="#5C5875" font-size="15">Refreshes the pull request</text>
+      <text x="72" y="663" fill="#5C5875" font-size="15">description.</text>
+    </g>
+
+    <g>
+      <rect x="325" y="536" width="250" height="154" rx="18" fill="#FFFFFF" stroke="#D8D4F4" stroke-width="2"/>
+      <text x="349" y="572" fill="#4B45CC" font-size="15" font-weight="700">prflow:docs</text>
+      <text x="349" y="610" fill="#19172B" font-size="18" font-weight="600">Document the change</text>
+      <text x="349" y="640" fill="#5C5875" font-size="15">Runs the complete branch</text>
+      <text x="349" y="663" fill="#5C5875" font-size="15">documentation pass.</text>
+    </g>
+
+    <g>
+      <rect x="602" y="536" width="250" height="154" rx="18" fill="#FFFFFF" stroke="#D8D4F4" stroke-width="2"/>
+      <text x="626" y="572" fill="#4B45CC" font-size="15" font-weight="700">prflow:retrospective-weekly</text>
+      <text x="626" y="610" fill="#19172B" font-size="18" font-weight="600">Learn from merged work</text>
+      <text x="626" y="640" fill="#5C5875" font-size="15">Produces bounded proposals</text>
+      <text x="626" y="663" fill="#5C5875" font-size="15">for human triage.</text>
+    </g>
+
+    <text x="450" y="726" fill="#5C5875" font-size="15" text-anchor="middle">Skill names stay the same; invocation syntax varies by client.</text>
+  </g>
+</svg>

--- a/docs/external/images/workpad-resume.svg
+++ b/docs/external/images/workpad-resume.svg
@@ -1,0 +1,61 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="700" viewBox="0 0 900 700" role="img" aria-labelledby="title" aria-describedby="description">
+  <title id="title">How PRFlow resumes implementation work</title>
+  <desc id="description">PRFlow reads recovery evidence from the GitHub issue workpad and the remote branch. The prflow implement skill uses both sources. A Blocked workpad causes PRFlow to surface the recorded cause. If matching open work exists, PRFlow adopts it, inspects the current tree and repeats checks that can block the run.</desc>
+
+  <defs>
+    <marker id="arrow" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto" markerUnits="strokeWidth">
+      <path d="M 0 0 L 12 6 L 0 12 z" fill="#635BFF"/>
+    </marker>
+  </defs>
+
+  <rect x="1" y="1" width="898" height="698" rx="28" fill="#FBFAFF" stroke="#E2DFFF" stroke-width="2"/>
+
+  <g font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
+    <text x="46" y="52" fill="#19172B" font-size="26" font-weight="600">Resume uses two kinds of recovery evidence</text>
+    <text x="46" y="83" fill="#5C5875" font-size="16">The progress record and pushed code answer different questions.</text>
+
+    <g>
+      <rect x="48" y="132" width="360" height="194" rx="18" fill="#FFFFFF" stroke="#635BFF" stroke-width="2"/>
+      <rect x="72" y="156" width="192" height="32" rx="16" fill="#EAE8FF"/>
+      <text x="168" y="178" fill="#4B45CC" font-size="15" font-weight="700" text-anchor="middle">GitHub issue workpad</text>
+      <text x="72" y="226" fill="#19172B" font-size="19" font-weight="600">Human-readable progress</text>
+      <text x="72" y="259" fill="#5C5875" font-size="16">Status and feature branch</text>
+      <text x="72" y="284" fill="#5C5875" font-size="16">Plan and acceptance criteria</text>
+      <text x="72" y="309" fill="#5C5875" font-size="16">Blockers, deferrals and reflections</text>
+    </g>
+
+    <g>
+      <rect x="492" y="132" width="360" height="194" rx="18" fill="#FFFFFF" stroke="#635BFF" stroke-width="2"/>
+      <rect x="516" y="156" width="150" height="32" rx="16" fill="#EAE8FF"/>
+      <text x="591" y="178" fill="#4B45CC" font-size="15" font-weight="700" text-anchor="middle">Remote branch</text>
+      <text x="516" y="226" fill="#19172B" font-size="19" font-weight="600">Durable code checkpoints</text>
+      <text x="516" y="259" fill="#5C5875" font-size="16">Scoped commits</text>
+      <text x="516" y="284" fill="#5C5875" font-size="16">Verified pushes</text>
+      <text x="516" y="309" fill="#5C5875" font-size="16">Matching pull request head</text>
+    </g>
+
+    <line x1="228" y1="326" x2="355" y2="400" stroke="#635BFF" stroke-width="3" marker-end="url(#arrow)"/>
+    <line x1="672" y1="326" x2="545" y2="400" stroke="#635BFF" stroke-width="3" marker-end="url(#arrow)"/>
+
+    <rect x="260" y="396" width="380" height="104" rx="20" fill="#635BFF"/>
+    <text x="450" y="436" fill="#FFFFFF" font-size="16" font-weight="700" text-anchor="middle">prflow:implement</text>
+    <text x="450" y="470" fill="#FFFFFF" font-size="20" font-weight="600" text-anchor="middle">Read both before planning</text>
+
+    <line x1="365" y1="500" x2="235" y2="552" stroke="#635BFF" stroke-width="3" marker-end="url(#arrow)"/>
+    <line x1="535" y1="500" x2="665" y2="552" stroke="#635BFF" stroke-width="3" marker-end="url(#arrow)"/>
+
+    <g>
+      <rect x="48" y="550" width="360" height="108" rx="18" fill="#FFF8EC" stroke="#D49A3A" stroke-width="2"/>
+      <text x="72" y="588" fill="#7A4D00" font-size="19" font-weight="600">If the Workpad is Blocked</text>
+      <text x="72" y="620" fill="#5C5875" font-size="16">Surface the recorded cause and wait</text>
+      <text x="72" y="644" fill="#5C5875" font-size="16">for the required human action.</text>
+    </g>
+
+    <g>
+      <rect x="492" y="550" width="360" height="108" rx="18" fill="#F0F8F4" stroke="#70A38B" stroke-width="2"/>
+      <text x="516" y="588" fill="#2F6B51" font-size="19" font-weight="600">If matching open work exists</text>
+      <text x="516" y="620" fill="#5C5875" font-size="16">Adopt the branch or pull request, inspect</text>
+      <text x="516" y="644" fill="#5C5875" font-size="16">the tree and repeat blocking checks.</text>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
<!-- PR_BODY_START -->
## Summary
- Add six focused visual guides to make PRFlow's lifecycle, execution choices, trust boundary, public skills, review loop and resume behavior easier to understand.
- Use canonical `prflow:*` skill names, plain language and accessible Mermaid and SVG markup throughout.

## Changes
**Lifecycle and execution**: Add a seven-stage lifecycle diagram, a local-versus-cloud decision tree and a cloud authorization and agent-job trust-boundary visual.

**Review and recovery**: Show the four-phase review engine, the bounded `prflow:review-and-fix` loop and the separate roles of the Workpad and remote branch during resume.

**Workflow selection**: Add a scannable map from common outcomes to the corresponding public PRFlow skill names.

**Accessibility**: Give both Mermaid diagrams accessible titles and descriptions. Give each SVG intrinsic dimensions, descriptive alternative text and embedded title and description metadata.

## Test Plan
- [x] Run `env TMPDIR=/private/tmp bash lib/test/run.sh` — 17,264 passed, 0 failed.
- [x] Render all six visuals with the Mintlify local preview and inspect every changed page at a narrow documentation-column width.
- [x] Validate all four SVGs with `xmllint`, parse `docs.json` with `jq` and run `git diff --check`.
- [x] Confirm the protected migration guide is byte-identical and no design, spec, generated preview or Superpowers files are included.

## Visual Changes
Adds diagrams to The PRFlow Lifecycle, Runs, Cloud Runs, Workflows, The Review System and Workpads and Resume.

## Breaking Changes
None.

<!-- PR_BODY_END -->
