### PR TITLE
fix(lint-manifest): close two schema-side fail-opens and correct three stale claims

### DIFF
--- a/.changeset/lint-manifest-schema-fail-opens.md
+++ b/.changeset/lint-manifest-schema-fail-opens.md
@@ -13,5 +13,8 @@ type: Fixed
   `special_invocations[].path`) accepted `../../../etc/passwd`, `/etc/passwd`,
   `..`, and leading-dash tokens such as `-x` / `--exclude`, the last of which a
   ShellCheck/Ruff argv parses as an *option* rather than a path; they are now
-  required to be repo-relative and argv-safe. Both defects were latent — nothing
-  consumes the manifest yet. (#1276)
+  required to be repo-relative and argv-safe. An artifact's `member` — the name
+  an extractor pulls out of the archive and then invokes — is path-shaped too and
+  now takes that same guard: `.`, `..` and a leading-dash value such as `-rf` are
+  rejected where all three previously validated. Every one of these defects was
+  latent — nothing consumes the manifest yet. (#1276, #1484)

--- a/.changeset/lint-manifest-schema-fail-opens.md
+++ b/.changeset/lint-manifest-schema-fail-opens.md
@@ -1,0 +1,17 @@
+---
+bump: patch
+type: Fixed
+---
+
+- **Close two schema-side fail-opens in the lint-manifest validator
+  (`scripts/lint_manifest.py`).** A manifest that selects no files at all —
+  `include_globs: []`, or a present-but-empty `exclude_globs` / `exclusions` —
+  validated as `established`, so a consumer would enumerate zero files and report
+  a clean lint having linted nothing; the glob lists now enforce non-emptiness
+  like their `selectors` / `full_profiles` / `artifacts` siblings. Separately, the
+  path-shaped fields (`include_globs`, `exclude_globs`, `exclusions`,
+  `special_invocations[].path`) accepted `../../../etc/passwd`, `/etc/passwd`,
+  `..`, and leading-dash tokens such as `-x` / `--exclude`, the last of which a
+  ShellCheck/Ruff argv parses as an *option* rather than a path; they are now
+  required to be repo-relative and argv-safe. Both defects were latent — nothing
+  consumes the manifest yet. (#1276)

--- a/.gitignore
+++ b/.gitignore
@@ -45,10 +45,12 @@
 # Committed declarative lint manifest (issue #1276) — the versioned, declarative
 # description of the bounded lint toolchain (exact ShellCheck/Ruff versions, per
 # platform artifact digests, selectors, exclusions, special-invocation IDs,
-# timeout bounds, full-profile IDs). Re-included past the /.prflow/* rule so the
-# plugin ships it and a clean checkout / ordinary `git add -A` keeps it tracked.
-# (The paired .prflow/install-state.json marker is added with the installer that
-# publishes it — see the follow-up issue.)
+# timeout bounds, full-profile IDs). Re-included past the /.prflow/* rule so a
+# clean checkout / ordinary `git add -A` keeps it tracked. It is NOT shipped to
+# consumers: devflow_copy_slice copies an explicit three-file list from .prflow/
+# (config.example.json, config.schema.json, tool-presets.json), so a consumer
+# installs scripts/lint_manifest.py with no manifest for it to read. Whether the
+# manifest should ship is issue #1388's decision.
 !/.prflow/lint-manifest.json
 # DevFlow's own consumer prompt extensions (e.g. the dogfooded versioning rule in
 # implement.md). Tracked so a clean checkout — and CI — sees the re-homed policy.

--- a/lib/test/cloud_writer_contract.py
+++ b/lib/test/cloud_writer_contract.py
@@ -267,8 +267,10 @@ REQUIRED_HELPER_HEADS = {
         ".prflow/vendor/prflow/scripts/match-lint-adjudications.py",
         ".prflow/vendor/prflow/scripts/load-prompt-extension.sh",
         # The prompt-extension render wrapper (scripts/render-prompt-extension.sh,
-        # issue #1264), reached from every entry SKILL.md through the render-time
-        # `!`…`` placeholder that injects the consumer extension. Registered at the
+        # issue #1264). PRs #1471 and #1473 removed every render-time `!`…``
+        # placeholder, so no entry SKILL.md reaches it today; the grant is retained
+        # deliberately rather than narrowed, since removing it is a security-boundary
+        # change. Registered at the
         # issue-#1359 baseline bump: it first shipped in 2.31.13, and the baseline now
         # advances past that release, so the AC19 pairing-2 invariant (an N-1 workflow
         # paired with the current plugin still validates cleanly) is satisfied by the
@@ -300,10 +302,10 @@ REQUIRED_HELPER_HEADS = {
         ".prflow/vendor/prflow/scripts/dismiss-stale-rejections.sh",
         ".prflow/vendor/prflow/scripts/load-prompt-extension.sh",
         # The prompt-extension render wrapper (issue #1264), registered at the
-        # issue-#1359 baseline bump like its implement-profile sibling above — every
-        # entry SKILL.md the light-command listener dispatches injects it through the
-        # render-time placeholder. Its basename-wildcard companion grant is sanctioned
-        # per profile below.
+        # issue-#1359 baseline bump like its implement-profile sibling above. The
+        # render-time placeholders that reached it were removed by PRs #1471/#1473;
+        # the grant is retained deliberately. Its basename-wildcard companion grant
+        # is sanctioned per profile below.
         ".prflow/vendor/prflow/scripts/render-prompt-extension.sh",
         ".prflow/vendor/prflow/lib/efficiency-trace.sh",
     ],
@@ -316,9 +318,10 @@ REQUIRED_HELPER_HEADS = {
         ".prflow/vendor/prflow/scripts/config-get.sh",
         ".prflow/vendor/prflow/scripts/load-prompt-extension.sh",
         # The prompt-extension render wrapper (issue #1264), registered at the
-        # issue-#1359 baseline bump like its siblings above — the review engine's
-        # entry SKILL.md injects it through the render-time placeholder. Its
-        # basename-wildcard companion grant is sanctioned per profile below.
+        # issue-#1359 baseline bump like its siblings above. The render-time
+        # placeholder the review engine's entry SKILL.md used was removed by PRs
+        # #1471/#1473; the grant is retained deliberately. Its basename-wildcard
+        # companion grant is sanctioned per profile below.
         ".prflow/vendor/prflow/scripts/render-prompt-extension.sh",
         ".prflow/vendor/prflow/scripts/resolve-review-overrides.py",
         ".prflow/vendor/prflow/scripts/stale-prose-lint.py",

--- a/lib/test/test_python_scripts.py
+++ b/lib/test/test_python_scripts.py
@@ -27627,6 +27627,41 @@ assert_eq("#1276 M3 positive control: the shipped manifest still establishes",
           True,
           lint_manifest.load_manifest(SCRIPTS.parent / ".prflow" / "lint-manifest.json").established)
 
+# ── Issue #1484: an artifact `member` is path-shaped too — it is the name the
+#    extractor pulls out of the archive and then invokes — yet `_MEMBER_RE`'s
+#    character class admitted `.`, `..` and `-rf`, each of which established.
+# These are their OWN cases rather than members of the _LM_BAD_PATHS fan-out:
+# every `/`-bearing entry in that tuple is already rejected by `_MEMBER_RE`, so
+# reusing it would attribute the rejection to the wrong guard. Each assertion
+# therefore pins the FULL reason, so a different guard rejecting the same input
+# cannot masquerade as this one.
+def _lm_member(value):
+    """Set the ruff artifact's member and return (established, full reason)."""
+    obj = _lm_valid()
+    obj["tools"]["ruff"]["artifacts"][0]["member"] = value
+    r = lint_manifest.validate_manifest(obj)
+    return (r.established, r.reason)
+
+
+_LM_MEMBER_WHERE = "invalid-value: tool 'ruff' artifact #0 member"
+assert_eq("#1484 member '.' rejected as a directory entry",
+          (False, f"{_LM_MEMBER_WHERE} '.' names a directory entry, not an extractable file"),
+          _lm_member("."))
+assert_eq("#1484 member '..' rejected by the shared traversal arm",
+          (False, f"{_LM_MEMBER_WHERE} '..' escapes the repository via '..'"),
+          _lm_member(".."))
+assert_eq("#1484 dash-leading member rejected by the shared argv-safety arm",
+          (False, f"{_LM_MEMBER_WHERE} '-rf' starts with '-' "
+                  "(would be parsed as an option, not a path)"),
+          _lm_member("-rf"))
+# Positive controls: the three rejections above must not pass vacuously by
+# banning every member. The shipped manifest's own end-to-end `established`
+# assertions above cover the third control the criterion names.
+assert_eq("#1484 positive control: member 'shellcheck' still establishes",
+          (True, None), _lm_member("shellcheck"))
+assert_eq("#1484 positive control: member 'ruff.exe' still establishes",
+          (True, None), _lm_member("ruff.exe"))
+
 
 print()
 print(f"{PASS} passed, {FAIL} failed")

--- a/lib/test/test_python_scripts.py
+++ b/lib/test/test_python_scripts.py
@@ -27541,9 +27541,12 @@ assert_eq("#1276 H1 empty tool artifacts array rejected (non-empty guard is disc
 assert_eq("#1276 H1 empty include_globs rejected (a selector matching nothing lints nothing)",
           (False, "invalid-value"),
           _lm_mut(lambda o: o["selectors"][0].__setitem__("include_globs", [])))
-assert_eq("#1276 H1 EVERY selector with empty include_globs rejected (whole manifest lints nothing)",
+# selectors[0] deliberately stays VALID here: _validate_selectors returns on the
+# first non-established selector, so emptying every selector would only ever
+# exercise selectors[0]. Emptying the SECOND alone proves the guard runs per selector.
+assert_eq("#1276 H1 a LATER selector's empty include_globs is rejected too (guard runs per selector)",
           (False, "invalid-value"),
-          _lm_mut(lambda o: [s.__setitem__("include_globs", []) for s in o["selectors"]]))
+          _lm_mut(lambda o: o["selectors"][1].__setitem__("include_globs", [])))
 assert_eq("#1276 H1 present-but-empty exclude_globs rejected (declares nothing)",
           (False, "invalid-value"),
           _lm_mut(lambda o: o["selectors"][0].__setitem__("exclude_globs", [])))
@@ -27558,7 +27561,9 @@ assert_eq("#1276 H1 positive control: omitting exclusions and exclude_globs stil
 
 # ── Audit finding: the two isinstance(..., bool) guards are load-bearing because
 #    `True in {1}` is True and `1 <= True <= 3600` is True — without the bool
-#    exclusion a JSON `true` would validate as a version/timeout. ────────────────
+#    exclusion a JSON `true` would validate as a version/timeout. `true` is the
+#    only input that discriminates either guard, so no `false` timeout case is
+#    pinned: `1 <= False <= 3600` is already False, so it is rejected either way.
 assert_eq("#1276 boolean true schema_version rejected (True in {1} is True)",
           (False, "wrong-type"), _lm_mut(lambda o: o.__setitem__("schema_version", True)))
 assert_eq("#1276 boolean false schema_version rejected",
@@ -27571,7 +27576,9 @@ assert_eq("#1276 boolean true timeout_seconds rejected (1 <= True <= 3600 is Tru
 #    leading-dash entry spliced into a shellcheck/ruff argv is parsed as an OPTION
 #    rather than a path; a traversal or absolute entry points the lint outside the
 #    repository, contradicting the module's own "repo-relative selector pattern".
-_LM_BAD_PATHS = ("../../../etc/passwd", "/etc/passwd", "..", "../../*.sh",
+# `a/../b` is the INTERIOR-traversal case: it locks the per-segment semantics of
+# `_validate_path_shape`, which a `value.startswith("..")` rewrite would silently lose.
+_LM_BAD_PATHS = ("../../../etc/passwd", "/etc/passwd", "..", "../../*.sh", "a/../b",
                  "-x", "-rf", "--exclude", "-")
 for _lm_bad in _LM_BAD_PATHS:
     assert_eq(f"#1276 M3 include_globs rejects {_lm_bad!r}",

--- a/lib/test/test_python_scripts.py
+++ b/lib/test/test_python_scripts.py
@@ -27527,6 +27527,86 @@ def _lm_cli_exit(argv):
 assert_eq("#1276 CLI usage error (missing path) exits 1, NOT 2 (no collision with unestablished)",
           1, _lm_cli_exit([]))
 
+# ── Audit finding H1: a manifest that lints NOTHING must not validate as
+#    `established`. A caller reading ESTABLISHED, enumerating zero files and
+#    reporting a clean lint is the canonical unknown-is-not-zero fail-open. Each
+#    non-empty guard gets its own assertion, so deleting any one of them goes RED.
+assert_eq("#1276 H1 empty selectors array rejected (non-empty guard is discriminated)",
+          (False, "invalid-value"), _lm_mut(lambda o: o.__setitem__("selectors", [])))
+assert_eq("#1276 H1 empty full_profiles array rejected (non-empty guard is discriminated)",
+          (False, "invalid-value"), _lm_mut(lambda o: o.__setitem__("full_profiles", [])))
+assert_eq("#1276 H1 empty tool artifacts array rejected (non-empty guard is discriminated)",
+          (False, "invalid-value"),
+          _lm_mut(lambda o: o["tools"]["ruff"].__setitem__("artifacts", [])))
+assert_eq("#1276 H1 empty include_globs rejected (a selector matching nothing lints nothing)",
+          (False, "invalid-value"),
+          _lm_mut(lambda o: o["selectors"][0].__setitem__("include_globs", [])))
+assert_eq("#1276 H1 EVERY selector with empty include_globs rejected (whole manifest lints nothing)",
+          (False, "invalid-value"),
+          _lm_mut(lambda o: [s.__setitem__("include_globs", []) for s in o["selectors"]]))
+assert_eq("#1276 H1 present-but-empty exclude_globs rejected (declares nothing)",
+          (False, "invalid-value"),
+          _lm_mut(lambda o: o["selectors"][0].__setitem__("exclude_globs", [])))
+assert_eq("#1276 H1 present-but-empty exclusions rejected (declares nothing)",
+          (False, "invalid-value"), _lm_mut(lambda o: o.__setitem__("exclusions", [])))
+# Positive control for H1: omitting the two OPTIONAL keys entirely still validates,
+# so the non-empty guards reject an empty declaration without banning absence.
+assert_eq("#1276 H1 positive control: omitting exclusions and exclude_globs still establishes",
+          (True, None),
+          _lm_mut(lambda o: (_lm_del(o, "exclusions"),
+                             _lm_del(o["selectors"][0], "exclude_globs"))))
+
+# ── Audit finding: the two isinstance(..., bool) guards are load-bearing because
+#    `True in {1}` is True and `1 <= True <= 3600` is True — without the bool
+#    exclusion a JSON `true` would validate as a version/timeout. ────────────────
+assert_eq("#1276 boolean true schema_version rejected (True in {1} is True)",
+          (False, "wrong-type"), _lm_mut(lambda o: o.__setitem__("schema_version", True)))
+assert_eq("#1276 boolean false schema_version rejected",
+          (False, "wrong-type"), _lm_mut(lambda o: o.__setitem__("schema_version", False)))
+assert_eq("#1276 boolean true timeout_seconds rejected (1 <= True <= 3600 is True)",
+          (False, "wrong-type"),
+          _lm_mut(lambda o: o["tools"]["ruff"].__setitem__("timeout_seconds", True)))
+
+# ── Audit finding M3: path-shaped fields must be repo-relative and argv-safe. A
+#    leading-dash entry spliced into a shellcheck/ruff argv is parsed as an OPTION
+#    rather than a path; a traversal or absolute entry points the lint outside the
+#    repository, contradicting the module's own "repo-relative selector pattern".
+_LM_BAD_PATHS = ("../../../etc/passwd", "/etc/passwd", "..", "../../*.sh",
+                 "-x", "-rf", "--exclude", "-")
+for _lm_bad in _LM_BAD_PATHS:
+    assert_eq(f"#1276 M3 include_globs rejects {_lm_bad!r}",
+              (False, "invalid-value"),
+              _lm_mut(lambda o, _b=_lm_bad: o["selectors"][0]["include_globs"].append(_b)))
+    assert_eq(f"#1276 M3 exclude_globs rejects {_lm_bad!r}",
+              (False, "invalid-value"),
+              _lm_mut(lambda o, _b=_lm_bad: o["selectors"][0]["exclude_globs"].append(_b)))
+    assert_eq(f"#1276 M3 exclusions rejects {_lm_bad!r}",
+              (False, "invalid-value"),
+              _lm_mut(lambda o, _b=_lm_bad: o["exclusions"].append(_b)))
+    assert_eq(f"#1276 M3 special_invocation path rejects {_lm_bad!r}",
+              (False, "invalid-value"),
+              _lm_mut(lambda o, _b=_lm_bad: o["special_invocations"][0].__setitem__("path", _b)))
+
+# Positive controls for M3: legitimate repo-relative patterns must STILL validate,
+# so the rejections above cannot pass vacuously by banning every path.
+_LM_GOOD_GLOBS = ("**/*.sh", "lib/test/**", "scripts/*.py", ".github/workflows/*.yml",
+                  "docs/**/*.md", "a-b/c_d.sh", "lib/test/fixtures/**", "..foo/*.py")
+for _lm_good in _LM_GOOD_GLOBS:
+    assert_eq(f"#1276 M3 positive control: include_globs still accepts {_lm_good!r}",
+              (True, None),
+              _lm_mut(lambda o, _g=_lm_good: o["selectors"][0]["include_globs"].append(_g)))
+    assert_eq(f"#1276 M3 positive control: exclusions still accepts {_lm_good!r}",
+              (True, None),
+              _lm_mut(lambda o, _g=_lm_good: o["exclusions"].append(_g)))
+assert_eq("#1276 M3 positive control: special_invocation path still accepts a repo-relative file",
+          (True, None),
+          _lm_mut(lambda o: o["special_invocations"][0].__setitem__("path", "scripts/config-get.sh")))
+# The shipped manifest is itself the end-to-end positive control for M3: every one
+# of its globs and paths is repo-relative and argv-safe, so it still establishes.
+assert_eq("#1276 M3 positive control: the shipped manifest still establishes",
+          True,
+          lint_manifest.load_manifest(SCRIPTS.parent / ".prflow" / "lint-manifest.json").established)
+
 
 print()
 print(f"{PASS} passed, {FAIL} failed")

--- a/scripts/devflow-cloud-writer-contract.json
+++ b/scripts/devflow-cloud-writer-contract.json
@@ -17,7 +17,7 @@
     "scripts/parse-acs.py": "c4bacc2a4a8a6ba4d8f425ba7ef42f709d229f97bb809f51bfa17caefc2ad4af",
     "scripts/react-to-trigger.sh": "652b657c01693bb854bbdabb841ce08dd30f5f146d2b4dd25d13b9bf1d8b7802",
     "scripts/reception_identity.py": "983565c531961be7d47c083feb2d34e67f261a21efda5a825f2b4b6a42924f94",
-    "scripts/render-prompt-extension.sh": "099a43ca8519c54993ff2f8329a8cfb4c79c0d8b1140c469df56f8b02df3c946",
+    "scripts/render-prompt-extension.sh": "4613404b649c945bc9759a1061e067303132822c22fab2342d3080d336a05c85",
     "scripts/resolve-existing-pr.sh": "372452a8bf310f96700375550380389df0e8e3c852ebd9e89b978841d62db478",
     "scripts/resolve-review-overrides.py": "d6281afc429636c7c59774c2ac3f0c1d7fde80be6e084993fee452066a2444af",
     "scripts/run-jq.sh": "1bcf3697f7fb24a50cbc246ef42ab9503be8fef4478103da0d183dcd971ad1fd",

--- a/scripts/lint_manifest.py
+++ b/scripts/lint_manifest.py
@@ -318,6 +318,18 @@ def _validate_artifact(name, idx, art) -> ManifestResult:
     member = art["member"]
     if not isinstance(member, str) or not _MEMBER_RE.match(member):
         return _unestablished(f"invalid-value: {where} member {member!r}")
+    # `_MEMBER_RE`'s character class admits `.`, `..` and `-rf`, so the member —
+    # the name the extractor pulls out of the archive and then invokes — takes
+    # the same path-shape guard as every other path-shaped field. `.` is the one
+    # remaining directory spelling that guard does not cover (`/` is already
+    # barred by `_MEMBER_RE`, so `.` cannot be a segment of a longer path here),
+    # and a directory name is not an extractable executable.
+    if member == ".":
+        return _unestablished(
+            f"invalid-value: {where} member {member!r} names a directory entry, "
+            "not an extractable file")
+    if (reason := _validate_path_shape(where, "member", member)) is not None:
+        return _unestablished(reason)
     return _established(art)
 
 
@@ -364,7 +376,9 @@ def _validate_path_shape(where, label, value) -> str | None:
       repository. The check is per segment, so `..foo` is a normal name.
 
     Without these a manifest selector can direct a lint at a path the repository
-    does not own, or turn a file argument into a tool flag.
+    does not own, or turn a file argument into a tool flag. Shared by every
+    path-shaped field — selector globs, exclusions, special-invocation paths and
+    an artifact `member` — so their accepted sets cannot drift apart.
     """
     if value.startswith("-"):
         return (f"invalid-value: {where} {label} {value!r} starts with '-' "

--- a/scripts/lint_manifest.py
+++ b/scripts/lint_manifest.py
@@ -56,6 +56,8 @@ _FLAG_RE = re.compile(r"\A--[a-z0-9][a-z0-9-]*(=[A-Za-z0-9._-]+)?\Z")
 # A glob is a repo-relative selector pattern: path separators and glob
 # metacharacters only. `$` (env expansion), whitespace, and shell metacharacters
 # are rejected, so a URL template or command string can never masquerade as one.
+# The character class alone does NOT make a value repo-relative or argv-safe —
+# `_validate_path_shape` below enforces those two properties separately.
 _GLOB_RE = re.compile(r"\A[A-Za-z0-9._*/?\[\]{}-]+\Z")
 
 # Timeout bounds (seconds). A value outside the inclusive range is rejected.
@@ -337,22 +339,54 @@ def _validate_selectors(selectors, out_ids: set[str]) -> ManifestResult:
         out_ids.add(sid)
         if sel["language"] not in KNOWN_LANGUAGES:
             return _unestablished(f"unknown-enum: {where} language {sel['language']!r}")
-        glob_result = _validate_globs(where, sel["include_globs"])
+        glob_result = _validate_globs(where, sel["include_globs"], label="include_globs")
         if not glob_result.established:
             return glob_result
         if "exclude_globs" in sel:
-            glob_result = _validate_globs(where, sel["exclude_globs"])
+            glob_result = _validate_globs(where, sel["exclude_globs"], label="exclude_globs")
             if not glob_result.established:
                 return glob_result
     return _established(selectors)
 
 
-def _validate_globs(where, globs) -> ManifestResult:
+def _validate_path_shape(where, label, value) -> str | None:
+    """Reject a path-shaped value that is not a repo-relative, argv-safe pattern.
+
+    Returns a reason string on rejection, or `None` when the value is acceptable.
+    Three properties beyond `_GLOB_RE`'s character class:
+
+    * **argv-safe** — a leading `-` (`-x`, `-rf`, `--exclude`, a bare `-`) is
+      parsed as an *option* by ShellCheck/Ruff when the entry is spliced into an
+      argv, silently changing tool behavior instead of naming a file.
+    * **not absolute** — a leading `/` points the lint outside the repository.
+    * **no traversal** — a `..` path segment (`..`, `../../*.sh`,
+      `../../../etc/passwd`) likewise escapes the repository.
+
+    Without these a manifest selector can direct a lint at a path the repository
+    does not own, or turn a file argument into a tool flag.
+    """
+    if value.startswith("-"):
+        return (f"invalid-value: {where} {label} {value!r} starts with '-' "
+                "(would be parsed as an option, not a path)")
+    if value.startswith("/"):
+        return f"invalid-value: {where} {label} {value!r} is absolute, not repo-relative"
+    if any(seg == ".." for seg in value.split("/")):
+        return f"invalid-value: {where} {label} {value!r} escapes the repository via '..'"
+    return None
+
+
+def _validate_globs(where, globs, *, label="globs") -> ManifestResult:
+    """Validate a glob list. Empty is rejected: a selector that matches nothing
+    would let a caller report a clean lint having enumerated zero files."""
     if not isinstance(globs, list):
-        return _unestablished(f"wrong-type: {where} globs must be an array")
+        return _unestablished(f"wrong-type: {where} {label} must be an array")
+    if not globs:
+        return _unestablished(f"invalid-value: {where} {label} must be a non-empty array")
     for g in globs:
         if not isinstance(g, str) or not _GLOB_RE.match(g):
             return _unestablished(f"invalid-value: {where} glob {g!r}")
+        if (reason := _validate_path_shape(where, "glob", g)) is not None:
+            return _unestablished(reason)
     return _established(globs)
 
 
@@ -382,6 +416,8 @@ def _validate_special_invocations(sis) -> ManifestResult:
         path = si["path"]
         if not isinstance(path, str) or not _GLOB_RE.match(path):
             return _unestablished(f"invalid-value: {where} path {path!r}")
+        if (reason := _validate_path_shape(where, "path", path)) is not None:
+            return _unestablished(reason)
         flags = si["extra_flags"]
         if not isinstance(flags, list):
             return _unestablished(f"wrong-type: {where} extra_flags must be an array")

--- a/scripts/lint_manifest.py
+++ b/scripts/lint_manifest.py
@@ -359,8 +359,9 @@ def _validate_path_shape(where, label, value) -> str | None:
       parsed as an *option* by ShellCheck/Ruff when the entry is spliced into an
       argv, silently changing tool behavior instead of naming a file.
     * **not absolute** — a leading `/` points the lint outside the repository.
-    * **no traversal** — a `..` path segment (`..`, `../../*.sh`,
-      `../../../etc/passwd`) likewise escapes the repository.
+    * **no traversal** — a `..` path segment anywhere in the value, leading
+      (`..`, `../../*.sh`) or interior (`a/../b`), likewise escapes the
+      repository. The check is per segment, so `..foo` is a normal name.
 
     Without these a manifest selector can direct a lint at a path the repository
     does not own, or turn a file argument into a tool flag.
@@ -391,7 +392,9 @@ def _validate_globs(where, globs, *, label="globs") -> ManifestResult:
 
 
 def _validate_exclusions(exclusions) -> ManifestResult:
-    return _validate_globs("exclusions", exclusions)
+    # `where` already names the field, so the label must not repeat the word
+    # "globs" — the default would render the doubled "exclusions globs".
+    return _validate_globs("exclusions", exclusions, label="entries")
 
 
 def _validate_special_invocations(sis) -> ManifestResult:

--- a/scripts/render-prompt-extension.sh
+++ b/scripts/render-prompt-extension.sh
@@ -6,6 +6,9 @@
 # Usage: render-prompt-extension.sh SKILL_NAME
 #
 # This is the command behind a `!`…`` render-time placeholder in a SKILL.md body.
+# No SKILL.md carries such a placeholder today — PRs #1471 and #1473 removed every
+# one — so nothing currently reaches this script; the description below is of the
+# mechanism it was built for, not of a live call path.
 # Claude Code executes such a placeholder BEFORE the model sees the skill and
 # substitutes this script's stdout in its place, so the extension arrives as prompt
 # text rather than as a command the agent must choose to run (issue #1264: the load


### PR DESCRIPTION
Closes three schema-side fail-opens in `scripts/lint_manifest.py`, corrects three claims the tree has falsified, and makes the guards involved discriminated by test.

**Scope added after the first review pass:** the third fail-open (Fix 2b below) is the single acceptance criterion of issue #1484, which names this PR as its home because the `_validate_path_shape` helper it reuses is introduced here. Filing it separately would have meant a second PR that only rebases onto this one.

## Why now: every finding is latent

Nothing consumes `scripts/lint_manifest.py` or `.prflow/lint-manifest.json` today — no production caller, and no commit has touched either file since the merge that added them (`fe826cc`, PR #1386). They are the declared foundation of the planned lint consolidation (#1388–#1392). So none of these defects can currently harm a run.

That is exactly why this is the cheap moment. Once #1388's consumers land, an `established` verdict starts gating real lint enumeration, and each of these becomes a behaviour change with callers to migrate rather than a validator edit with none.

The audit that produced these findings also confirmed the reader's degraded-**bytes** handling is genuinely solid — missing / unreadable / empty / invalid-UTF-8 / malformed / truncated / duplicate-key all fail closed with distinct reasons, `RecursionError` is caught, and exit codes 0/1/2 do not collide. The gaps were entirely in the **schema** half.

## Fix 1 (H1) — a manifest that lints nothing validated as `established`

Verified against `origin/main` by validating the shipped manifest with one field mutated. Every one of these returned `established`:

| Input | Before | After |
| --- | --- | --- |
| `selectors[0].include_globs = []` | `established` | `invalid-value: selector #0 include_globs must be a non-empty array` |
| every selector's `include_globs = []` | `established` | `invalid-value: …` |
| `selectors[0].exclude_globs = []` | `established` | `invalid-value: selector #0 exclude_globs must be a non-empty array` |
| `exclusions = []` | `established` | `invalid-value: exclusions globs must be a non-empty array` |

A consumer reading `ESTABLISHED`, enumerating zero files and reporting a clean lint is this repo's canonical *unknown-is-not-zero* fail-open, in the one place it matters most for a lint.

The asymmetry is the evidence this was an oversight rather than a design: `selectors`, `full_profiles` and `artifacts` already enforced non-empty (`or not selectors` / `or not profiles` / `or not artifacts`); the three glob lists did not. `_validate_globs` now rejects an empty list, so the glob lists are consistent with their siblings. Omitting the two *optional* keys (`exclusions`, `exclude_globs`) entirely still validates — a positive control asserts this, so the guard rejects an empty *declaration* without banning absence.

### The `["**"]` case — deliberately NOT fixed

`exclude_globs: ["**"]` and `exclusions: ["**"]` still validate. They are semantically "lint nothing" but syntactically legitimate patterns, and rejecting them would over-reach for a concrete reason: **the manifest does not yet define its glob dialect.** Whether `**` matches everything depends on the matcher a consumer picks — `fnmatch`, `pathlib.Path.glob`, and gitignore semantics all differ on it, and on whether `**` crosses a path separator at all. Banning a pattern in a language nobody has specified would bake in a dialect assumption that #1388 is entitled to make differently. The empty-list case needs no such assumption: an empty list matches nothing under every dialect.

## Fix 2 (M3) — path-shaped fields accepted traversal, absolute paths, and option-looking tokens

`include_globs`, `exclude_globs`, `exclusions` and `special_invocations[].path` all accepted, and returned `established` for, every one of:

`../../../etc/passwd` · `/etc/passwd` · `..` · `../../*.sh` · `-x` · `-rf` · `--exclude` · `-`

The leading-dash class is the sharp one: such an entry spliced into a `shellcheck` or `ruff` argv is parsed as an **option**, not a path — `--exclude` and `-x` silently change what the tool does rather than naming a file, and the change is invisible in the tool's output. The traversal and absolute cases point a lint outside the repository, contradicting the module's own inline comment that "a glob is a repo-relative selector pattern".

The discipline already existed in this module — `_MEMBER_RE` correctly forbids `/` so an executable member can never be a path. The new `_validate_path_shape` applies the same rigour to the path-shaped fields, rejecting a leading `-`, a leading `/`, and any `..` path segment. It is applied at both call sites (`_validate_globs` and `_validate_special_invocations`).

Positive controls assert that legitimate repo-relative patterns still validate — `**/*.sh`, `lib/test/**`, `scripts/*.py`, `.github/workflows/*.yml`, `docs/**/*.md`, `a-b/c_d.sh`, `lib/test/fixtures/**`, and `..foo/*.py` (a segment that merely *starts* with dots is not traversal) — plus an end-to-end control that the shipped `.prflow/lint-manifest.json` still establishes. Without these the rejections could pass vacuously by banning every path.

## Fix 2b (#1484) — an artifact `member` skipped that same guard

`_MEMBER_RE = re.compile(r"\A[A-Za-z0-9._-]+\Z")` correctly forbids `/`, but its character class admits `.`, `..` and `-rf`. Re-derived at this branch's head before changing anything — all three returned `established`:

| `tools.ruff.artifacts[0].member` | Before | After |
| --- | --- | --- |
| `.` | `established` | `invalid-value: … member '.' names a directory entry, not an extractable file` |
| `..` | `established` | `invalid-value: … member '..' escapes the repository via '..'` |
| `-rf` | `established` | `invalid-value: … member '-rf' starts with '-' (would be parsed as an option, not a path)` |

A `member` is the name an extractor pulls out of the archive and then invokes, so it is path-shaped exactly like a selector glob — Fix 2 simply did not reach it. `_validate_artifact` now routes `member` through the same `_validate_path_shape` helper rather than a second copy of its logic, so the two accepted sets cannot drift; the `..` and leading-dash reasons above are that shared helper's own arms, unchanged.

One arm is new and lives at the call site rather than in the helper: a bare `.`. It is not a path-shape property (`.` is repo-relative, argv-safe and contains no traversal) but a member-specific one — `_MEMBER_RE` already bars `/`, so `.` here can only be the whole value, and a directory entry is not an extractable executable. Putting it in `_validate_path_shape` would have changed what a *glob* accepts, which no criterion asks for and which would tighten the schema under an already-installed consumer manifest.

The three assertions pin the **full** reason string, not the `:`-prefix, so a different guard rejecting the same input cannot masquerade as this one — the same discrimination lesson the Fix 4 mutation pass recorded for `selectors: []`. They are their own cases rather than new members of the `_LM_BAD_PATHS` fan-out: every `/`-bearing entry in that tuple is already rejected by `_MEMBER_RE`, so reusing it would have attributed the rejection to the wrong guard. Positive controls keep `member: "shellcheck"` and `member: "ruff.exe"` establishing, and the shipped `.prflow/lint-manifest.json` still establishes (asserted twice already in the same block).

Each of the three failed RED against this branch's pre-fix code with `actual: (True, None)` — established, the exact wrong behaviour — and passes after.

## Fix 3 — three false claims corrected (all behaviour-inert)

1. **`.gitignore`** — the comment added by #1386 said the manifest is re-included "so the plugin ships it". It does not ship: `devflow_copy_slice` copies an explicit three-file list from `.prflow/` (`config.example.json`, `config.schema.json`, `tool-presets.json`), and `install.sh` has no lint-manifest handling, so a consumer gets the reader and no manifest. The comment now states that, and names #1388 as the owner of whether it *should* ship. **The installer is not changed here** — that is a design decision, not a comment fix.
2. **`lib/test/cloud_writer_contract.py`** — three registration comments stated that `render-prompt-extension.sh` is "reached from every entry `SKILL.md` through the render-time `` !`…` `` placeholder". PRs #1471 and #1473 removed every such placeholder; `git grep render-prompt-extension origin/main -- skills agents` returns nothing. Each comment now records that no call path reaches it today and that the grant is retained deliberately.
3. **`scripts/render-prompt-extension.sh`** — its own header made the same reachability claim; it now says no `SKILL.md` carries such a placeholder today and that what follows describes the mechanism it was built for, not a live call path.

**No registration, SHA pin, or grant is removed or narrowed.** The audit established those still point the strict way, and narrowing `lib/capability-profiles.json` or `lib/review-profile.tokens` is a security-boundary change out of scope here. The only generated-artifact change is the regenerated SHA for `render-prompt-extension.sh` in `scripts/devflow-cloud-writer-contract.json`, produced by `lib/test/regenerate-artifacts.py` because the header edit changed the file's bytes.

## Fix 4 — the guards are now discriminated, and mutation-checked

The pre-existing 46 assertions were strong on degraded bytes and weak on degraded schema. Established by grep before writing anything: **no test set `selectors`, `full_profiles` or `artifacts` to `[]`**, so the three existing non-empty guards were themselves undiscriminated — deleting any of them failed nothing.

Added: an assertion per non-empty guard (the three that already existed and the ones added here); both `isinstance(…, bool)` guards on `schema_version` and `timeout_seconds`, which are load-bearing because `True in {1}` is `True` and `1 <= True <= 3600` is `True`, and which had no bool test at all; and every Fix 2 rejection across all four path-shaped fields, each with the positive controls described above.

### Mutations run

Each guard was broken on a **scratch copy** of `scripts/lint_manifest.py` loaded under a temp module name — the working-tree file was never edited — and the assertions that guard owns were replayed, comparing `(established, reason-prefix)` exactly as the suite's `_lm_reason` helper does. All 11 went RED:

| Mutation | Result |
| --- | --- |
| `selectors` non-empty guard removed | RED |
| `full_profiles` non-empty guard removed | RED |
| `artifacts` non-empty guard removed | RED |
| glob-list non-empty guard removed (covers all three glob fields) | RED |
| `schema_version` bool exclusion removed | RED |
| `timeout_seconds` bool exclusion removed | RED |
| `_validate_path_shape` leading-dash arm disabled | RED |
| `_validate_path_shape` absolute-path arm disabled | RED |
| `_validate_path_shape` traversal arm disabled | RED |
| `_validate_path_shape` call site in `_validate_globs` removed | RED |
| `_validate_path_shape` call site in `_validate_special_invocations` removed | RED |

One finding from the mutation pass worth recording: the `selectors` non-empty guard is **not** discriminated by an established-only probe. With it removed, `selectors: []` is still rejected — but as `conflicting-id`, because `full_profiles` then reference selectors that do not exist. It is discriminated only because the assertion pins the reason *prefix* (`invalid-value`). An assertion that checked "rejected" alone would have passed against the mutant.

## Changeset: `patch`

Added, deliberately. `scripts/lint_manifest.py` is under `scripts/` and reaches consumer repos through the vendor slice, so a change to what it accepts and rejects is engine surface, not internal — a consumer whose manifest carries an empty glob list or a leading-dash entry stops validating after this update. That is the smallest meaningful step (a bug fix in behaviour that no caller yet depends on), hence `patch` rather than `minor`. The Fix 3 comment corrections on their own would have been internal-only and owed nothing.

## Explicitly out of scope — each needs #1388's design intent, not a unilateral call here

These are now recorded in the tree's issue tracker as the decision register in **#1484**, so #1388/#1389's implementer inherits them rather than re-deriving them from this PR body. Fix 2b above is the one entry of that register that needed no decision, which is why it lands here.

- **`extra_flags` is an open vocabulary while the docstring and AC claim "closed special-invocation IDs".** `--exit-zero`, `--severity=error` and `--help` all validate today (confirmed). The contradiction is real, but the two resolutions — close the vocabulary to an enumerated set, or correct the claim — are opposite decisions about what the manifest *is*, and closing it requires knowing which flags the consumer actually needs to pass. That set exists only once #1388's invoker does.
- **No cross-field check between a profile's `tool` and its selector's `language`.** `language` is validated and then read by nothing, so a `ruff` profile can point at a `shell` selector. Whether that is an error depends on whether the consumer dispatches on `tool`, on `language`, or on both — undecided until there is a consumer.
- **Whether the manifest should ship to consumers at all.** Named in Fix 3 above; the `.gitignore` comment now states the true situation and defers the decision.
- **No repo-root anchoring.** Sibling readers carry the SHARED REPO-ROOT CONFIG CONTRACT and resolve their default path from `git rev-parse --show-toplevel`; this module takes a path argument only. Adding anchoring means choosing the default path the consumer will use, which is the consumer's call.
- **`reason` exposes its category only as a `:`-prefix, and `_established` returns the caller's dict by reference.** Both are API-shape decisions (a typed category field; a defensive copy) whose cost falls entirely on callers that do not exist yet. Changing the result type before its first consumer would be designing against a guess.

## Verification

- `lib/test/run-shard.sh python-pool` — 0 failed
- `lib/test/run-shard.sh monolith` — 0 failed
- `git ls-files '*.py' | xargs -r ruff check` — clean
- `git ls-files '*.sh' | grep -v '^lib/test/' | xargs -r shellcheck --severity=warning -e SC1091` — clean
- `lib/test/regenerate-artifacts.py` run last; the one regenerated SHA is committed

For the Fix 2b commit:

- `lib/test/test_python_scripts.py` (the covering focused test — `coverage-map.json` records `scripts/lint_manifest.py` as `owner: unmodularized`, `focused_test: lib/test/test_python_scripts.py`) — **4227 passed, 0 failed**; against the pre-fix module the same file read **4224 passed, 3 failed**, the three new rejection assertions
- `ruff check scripts/lint_manifest.py lib/test/test_python_scripts.py` — clean
- `scripts/lint_manifest.py` and `lib/test/test_python_scripts.py` are not assets in `scripts/devflow-cloud-writer-contract.json`, re-confirmed at this head, so no artifact regeneration is owed for this commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

