### PR TITLE
Stale-prose lint: name _COUNT_NOUNS in the R3 spec, cover the rest of _NUM_LOOKBEHIND

### DIFF
--- a/.changeset/pr-1412-carried-suggestions.md
+++ b/.changeset/pr-1412-carried-suggestions.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Stale-prose lint: the module-header recognition-tier spec now names `_COUNT_NOUNS` — the constant the widened noun set is actually interpolated from — instead of `_COUNT_RE`, and states it without a transcribed count that rots when a noun is added. Adds discriminating unit coverage for the `§` / `.` / `-` members of `_NUM_LOOKBEHIND`, which were live but unasserted (only the `#` member was covered).

--- a/lib/test/test_python_scripts.py
+++ b/lib/test/test_python_scripts.py
@@ -5632,6 +5632,23 @@ _ac2_1405 = _rows_1405(["see #402 checks for the list."] + _ASSERT2_1405)
 assert_eq("#1405/AC2: `see #402 checks` emits no STALE row (numeral lookbehind; noun is plural)",
           [], [(r.verdict, r.rule) for r in _ac2_1405 if r.verdict == stale_prose_lint.STALE])
 
+# AC2b (carried Suggestion from PR #1412) — AC2 above exercises only the `#` member of
+# _NUM_LOOKBEHIND, leaving its `§` / `.` / `-` members live but unasserted: dropping any one of
+# them from the character class re-admits its own fixture below as a gating count claim, so this
+# covers the rest of the class. Each line pairs a plural noun with an adjacent block of a
+# differing size, so a member that stops guarding surfaces as a STALE R3 rather than as silence.
+_ac2b_1405 = {
+    "-": "superseded by -5 checks in the table.",
+    "§": "see §5 checks for the list.",
+    ".": "see v1.5 checks for the list.",
+}
+assert_eq("#1405/AC2b: the `§` / `.` / `-` members of _NUM_LOOKBEHIND each block a glued numeral "
+          "(no STALE row for any of them)",
+          [(k, []) for k in _ac2b_1405],
+          [(k, [(r.verdict, r.rule) for r in _rows_1405([line] + _ASSERT2_1405)
+                if r.verdict == stale_prose_lint.STALE])
+           for k, line in _ac2b_1405.items()])
+
 # AC3 — a genuine PLURAL count claim still gates; its matched-count sibling is VERIFIED.
 _ac3_1405 = _rows_1405(["This header locks in 3 assertions below:"] + _ASSERT2_1405)
 assert_eq("#1405/AC3: a real plural count claim (`3 assertions`, block has 2) still gates STALE R3",

--- a/scripts/devflow-cloud-writer-contract.json
+++ b/scripts/devflow-cloud-writer-contract.json
@@ -22,7 +22,7 @@
     "scripts/resolve-review-overrides.py": "d6281afc429636c7c59774c2ac3f0c1d7fde80be6e084993fee452066a2444af",
     "scripts/run-jq.sh": "1bcf3697f7fb24a50cbc246ef42ab9503be8fef4478103da0d183dcd971ad1fd",
     "scripts/section_parse.py": "9333d432e81365eb92e44709bf4317d4d0f37046098b0c0f0d866eb11cd33108",
-    "scripts/stale-prose-lint.py": "93b6c0bdd5f940c7feabfe416df075683a7654bf1a82bacaeee6bff3e2d145fa",
+    "scripts/stale-prose-lint.py": "b2f22f36fed90bfed9f3fd53e4afd682fe7ab49d7a077c710ab0337debbf797f",
     "scripts/update-branch-checkpoint.sh": "c60408fb8f9e2227aabf9cf1094462a946a1471230f8e9b5e598a490c5f290b5",
     "scripts/workpad.py": "59d8262dd47f5bb4c086fd065db1de91d6ff9fb1865bbda89f03980d8568deed",
     "skills/docs-release-notes/SKILL.md": "8e99c043863499f9246f50d5fcabba3d188d4d882ba7f1d225745a07ee56eb7b",

--- a/scripts/stale-prose-lint.py
+++ b/scripts/stale-prose-lint.py
@@ -80,8 +80,8 @@ gating ``_COUNT_RE``) claims emits a single ``UNRESOLVABLE`` ``R3`` row whose de
 ``count-locked: recognition-only (<n> <noun>) — pin or drift-proof this claim``.
 The widened shape is: a spelled-out numeral word (``two`` … ``twelve``, case-insensitive ASCII)
 or a digit run; up to two intervening modifier words (each optionally wrapped in ``**…**`` /
-``*…*`` / backticks); and a noun from the *widened* set — the seven ``_COUNT_RE`` nouns plus
-the plural-only additions ``tags`` / ``members`` / ``fields`` / ``rows`` / ``columns`` /
+``*…*`` / backticks); and a noun from the *widened* set — every noun in the gating
+``_COUNT_NOUNS`` constant (interpolated in its ``s?`` form) plus the plural-only additions ``tags`` / ``members`` / ``fields`` / ``rows`` / ``columns`` /
 ``arms`` / ``files`` / ``rules`` / ``sites``. This tier is **non-gating by construction**: it
 runs **no** referent resolution (no adjacency walk, no table parsing), never emits STALE, and
 never affects the exit code (``UNRESOLVABLE`` never gates). Its only job is to surface the


### PR DESCRIPTION
## Summary

Two carried-over Suggestions from the review of #1412, accepted there and deferred. A third is refuted with evidence rather than applied.

## Changes

**`scripts/stale-prose-lint.py`** — the module-header R3 recognition-tier spec described the widened noun set as "the seven `_COUNT_RE` nouns". Wrong symbol: the nouns live in `_COUNT_NOUNS`, which `_RECOG_NOUN` interpolates directly in its `s?` form; `_COUNT_RE` consumes only the derived `_COUNT_NOUNS_PLURAL` alternation. The sentence now names `_COUNT_NOUNS`, and drops the transcribed `seven` — a self-referential count that rots the moment a noun is added (CLAUDE.md, *Prefer generated evidence over exact checked-in numbers*).

**`lib/test/test_python_scripts.py`** — `#1405/AC2` exercised only the `#` member of `_NUM_LOOKBEHIND`. Its `§`, `.` and `-` members were live but unasserted. New `#1405/AC2b` drives `examine_file` over one fixture per uncovered member, each pairing a plural trigger noun with an adjacent assertion block of a differing size, so a member that stops guarding surfaces as a `STALE R3` rather than as silence.

**`scripts/devflow-cloud-writer-contract.json`** — the SHA pin for the edited lint, regenerated in the same commit.

## Refuted finding: the `\d` member is not inert

The claim was that `\d` in `_NUM_LOOKBEHIND` can never match and should be removed. It is redundant in the gating `_COUNT_RE` only — the pattern is `{_NUM_LOOKBEHIND}\b(\d+)`, and the `\b` already refuses a numeral whose preceding character is a digit. But `_RECOG_NUM` is `_NUM_LOOKBEHIND + r"(?:\b(?P<word>…)\b|(?P<digit>\d+))"`, whose digit alternative carries **no** `\b`. With `\d` dropped from the shared constant, `see #402 checks` re-matches at offset 2 as `02 checks` (the `#` guard blocks only offset 1). Removing it changes recognition-tier behaviour, so it stays.

## Mutation evidence (AC2b discriminates per member)

Each member dropped from the character class in turn, focused test re-run, class restored:

| mutation | `#1405/AC2b` |
| --- | --- |
| `(?<![#§\d.])` (dropped `-`) | FAIL |
| `(?<![#\d.\-])` (dropped `§`) | FAIL |
| `(?<![#§\d\-])` (dropped `.`) | FAIL |
| unmutated | PASS |

## Test Plan

- [x] `lib/test/test_python_scripts.py` — 4158 passed, 0 failed (the covering focused test per `lib/test/modules/coverage-map.json`).
- [x] `ruff check scripts/stale-prose-lint.py lib/test/test_python_scripts.py` — clean.
- [x] `lib/test/regenerate-artifacts.py --preflight` — every eligible artifact reconciled, exit 0.
- [ ] CI (`lib + python tests`) across all five shards.

## Breaking Changes

None. Verdict vocabulary, TSV format and exit codes are unchanged; the docstring edit is prose only and the new assertion adds coverage of existing behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)