### PR TITLE
fix: bind REPO_ROOT as its own operand in Phase 1.6 auditor dispatch

### DIFF
--- a/.changeset/issue-1583-repo-root-operand-gap.md
+++ b/.changeset/issue-1583-repo-root-operand-gap.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: Fixed
+---
+
+- **Phase 1.6's issue-claim-auditor dispatch now binds a distinct `REPO_ROOT` operand.** `phase-1-setup.md` previously folded the checkout root into the `SCRIPTS` bullet, which the auditor's own operand list never named, so Pass 6's `--repo-root "$REPO_ROOT"` could resolve empty and route to its fail-closed default. `SCRIPTS` and `REPO_ROOT` are now separate, explicitly bound operands in both `phase-1-setup.md` and `agents/issue-claim-auditor.md`. (PR #1583 review, Important-1)

--- a/agents/issue-claim-auditor.md
+++ b/agents/issue-claim-auditor.md
@@ -25,6 +25,7 @@ The orchestrator's dispatch prompt provides, and you use verbatim:
 - `ISSUE_NUMBER` — the GitHub issue this run implements.
 - `WORKPAD` — the exact `workpad.py` helper path to invoke as a **leading token** for every workpad write (e.g. `.prflow/vendor/prflow/scripts/workpad.py` on the cloud tier). Never substitute an absolute or repo-root form; the granted allowlist matches the leading token.
 - `SCRIPTS` — the directory prefix for the other bundled helpers you invoke (`check-verified-premises.py`), the same prefix `WORKPAD` sits in.
+- `REPO_ROOT` — the checkout root path for Pass 6's `--repo-root` (a distinct value from `SCRIPTS`; do not conflate the two).
 - `ISSUE_BODY_PATH` — the path to the §1.1 issue-body cache (`.prflow/tmp/issue-body/issue-<ISSUE_NUMBER>.md`) to read the body from; **do not re-fetch**. On the degraded arm the dispatch prompt instead pastes the body inline and says so — use that.
 - `BASE` — the base branch (`origin/$BASE` is the read target under the read-target rule).
 - `FRESHNESS` — one of `fresh` / `unverified` / `behind-<n>`, the tree-freshness state Phase 1.4 recorded, so you apply the Fresh-tree verification rules below correctly.
@@ -95,7 +96,7 @@ A `Verified:` bullet licenses this run to *skip its own investigation*, so a pre
 
 **Scope: every `Verified:` bullet the helper's marker recognises.** Read `total=` as a floor on the bullets present, never proof the issue carried no others.
 
-Run the bundled helper over the issue-body cache — no re-fetch (substitute `$SCRIPTS`, `$ISSUE_BODY_PATH`, and the repo root the dispatch prompt gave you):
+Run the bundled helper over the issue-body cache — no re-fetch (substitute `$SCRIPTS`, `$ISSUE_BODY_PATH`, and `$REPO_ROOT`):
 
 ```bash
 "$SCRIPTS"/check-verified-premises.py --body-file "$ISSUE_BODY_PATH" --repo-root "$REPO_ROOT"

--- a/scripts/devflow-cloud-writer-contract.json
+++ b/scripts/devflow-cloud-writer-contract.json
@@ -30,7 +30,7 @@
     "skills/docs-sync-internal/SKILL.md": "6fc13c557605563442c3710dbbbb5f693f072f6a780c9b07aaf43c585081a3e2",
     "skills/docs/SKILL.md": "9ce9a52f0532c64d8cdec5dee8d632f573e30a5fab19701ede5f14ffda177946",
     "skills/implement/SKILL.md": "9610d5aa879a59a8834d1d8269ad40e7a7ae39182253952e73685f8fb9e8f780",
-    "skills/implement/phases/phase-1-setup.md": "9591c1b4f5316c370207f8b149913c20f9e7327c2e6711202e2ae5163a19447a",
+    "skills/implement/phases/phase-1-setup.md": "ca6104656f63fa06d261c2e822787b29abf266fdd4e2a6b019bfc7c3c8d6a9b4",
     "skills/implement/phases/phase-2-implement.md": "897a811a1b8aea33b56d882acc8e13188bf13bfba5a3f5be30e973944931a859",
     "skills/implement/phases/phase-3-review.md": "023535d7da65da109f4979bc3ae8238af928d0ad22adf1944feca97856521755",
     "skills/implement/phases/phase-4-documentation.md": "f744802522e195e6fee2c182b8980242ac2cbce100d67ba8a0de446e0575d14f",

--- a/scripts/devflow-cloud-writer-contract.json
+++ b/scripts/devflow-cloud-writer-contract.json
@@ -30,7 +30,7 @@
     "skills/docs-sync-internal/SKILL.md": "6fc13c557605563442c3710dbbbb5f693f072f6a780c9b07aaf43c585081a3e2",
     "skills/docs/SKILL.md": "9ce9a52f0532c64d8cdec5dee8d632f573e30a5fab19701ede5f14ffda177946",
     "skills/implement/SKILL.md": "9610d5aa879a59a8834d1d8269ad40e7a7ae39182253952e73685f8fb9e8f780",
-    "skills/implement/phases/phase-1-setup.md": "ca6104656f63fa06d261c2e822787b29abf266fdd4e2a6b019bfc7c3c8d6a9b4",
+    "skills/implement/phases/phase-1-setup.md": "9591c1b4f5316c370207f8b149913c20f9e7327c2e6711202e2ae5163a19447a",
     "skills/implement/phases/phase-2-implement.md": "897a811a1b8aea33b56d882acc8e13188bf13bfba5a3f5be30e973944931a859",
     "skills/implement/phases/phase-3-review.md": "023535d7da65da109f4979bc3ae8238af928d0ad22adf1944feca97856521755",
     "skills/implement/phases/phase-4-documentation.md": "f744802522e195e6fee2c182b8980242ac2cbce100d67ba8a0de446e0575d14f",

--- a/skills/implement/phases/phase-1-setup.md
+++ b/skills/implement/phases/phase-1-setup.md
@@ -633,7 +633,8 @@ Use the **Agent tool** with `subagent_type: prflow:issue-claim-auditor` and `run
 
 - `ISSUE_NUMBER` — the issue number (`$ISSUE_NUMBER`).
 - `WORKPAD` — the `workpad.py` helper path this tier uses as a leading token (the vendored literal `.prflow/vendor/prflow/scripts/workpad.py` on the cloud tier; the resolved `"${CLAUDE_SKILL_DIR:-<absolute skill base directory this runner reports in context>}"/../../scripts/workpad.py` on the local tier).
-- `SCRIPTS` — the same bundled-helper directory prefix (for `check-verified-premises.py`), and the repo root for `--repo-root`.
+- `SCRIPTS` — the same bundled-helper directory prefix (for `check-verified-premises.py`).
+- `REPO_ROOT` — the checkout root path, for Pass 6's `--repo-root` (a distinct value from `SCRIPTS`).
 - `ISSUE_BODY_PATH` — the §1.1 cache path `.prflow/tmp/issue-body/issue-$ISSUE_NUMBER.md` when the cache was written; on the degraded arm where no cache was written, paste the full issue body inline and say so (the auditor has `Bash` but must not re-fetch a body the run already holds).
 - `BASE` — `$BASE` (the §1.4 base branch; `origin/$BASE` is the read target under the read-target rule).
 - `FRESHNESS` — `fresh` / `unverified` / `behind-<n>`, from Phase 1.4's recorded behind-by count (an absent record reads as `unverified`).


### PR DESCRIPTION
## Summary

Follow-up to the review on #1583 (Important-1 finding), verified against the merged tree rather than the review-time head — the gap was still live at `c029a9768`.

`agents/issue-claim-auditor.md`'s Pass 6 runs:

```bash
"$SCRIPTS"/check-verified-premises.py --body-file "$ISSUE_BODY_PATH" --repo-root "$REPO_ROOT"
```

but its "Operands the dispatch prompt gives you" list never named `REPO_ROOT` — `phase-1-setup.md`'s dispatch prompt folded the checkout root into the `SCRIPTS` bullet ("...and the repo root for `--repo-root`"), overloading one operand with two distinct paths. No operand under any consistent name delivered the repo root to the agent, so `--repo-root` could resolve empty, routing the helper to its fail-closed default (exit 3 → every `Verified:` bullet in the issue treated as unverified and re-investigated from first principles instead of using the pass's intended short-circuit). This fails *closed* (no wrong premise gets silently trusted), which is why the review graded it Important rather than Critical — but it still defeats Pass 6's purpose.

- `skills/implement/phases/phase-1-setup.md`: split the `SCRIPTS` operand bullet into separate `SCRIPTS` and `REPO_ROOT` bullets in the auditor dispatch prompt.
- `agents/issue-claim-auditor.md`: added `REPO_ROOT` to the "Operands the dispatch prompt gives you" list, and updated the Pass 6 prose to name it explicitly instead of "the repo root the dispatch prompt gave you".
- `scripts/devflow-cloud-writer-contract.json` is left byte-identical to the merge base. It was briefly regenerated while that was the required state; PR #1588 then retired the `_TEST_MECHANICAL_ROW` seam, so a branch now leaves the manifest alone and both CI jobs go green. `cloud-writer-retention-check.py` exits 0.

The other three Suggestion-level findings from the #1583 review (an enumeration undercount, a stale PR-description sentence, and a comment-provenance nit) were dropped — each is a wording/prose nit with no behavior or contract impact, consistent with this repo's preference for fewer tests and less prose churn.

## Test plan

- [x] `python3 lib/test/lint-shipped-pruned-path.py` — passes (73/73 files audited, no new pruned-path references).
- [x] Manually re-verified the two `#476/#1576` pins in `lib/test/run.sh` (`P476_ICA` block) still hold against the edited `agents/issue-claim-auditor.md`: the clean-arm `--note` literal count is 1, and `--reflection-kind note` count is 0 — neither string I touched.
- [x] `python3 lib/test/cloud_writer_contract.py verify` reports `manifest matches closure`.
- [ ] CI (`lib + python tests`) — will run on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Writing-skills evidence

Writing-skills evidence: skill-loaded=no (this is a follow-up correction filed from the #1583 review's Important-1 finding; the edit was made directly rather than through a `superpowers:writing-skills` cycle), guidance-applied=no (same reason — no skill session was run for this change), pressure-scenario=no (the edit relaxes no rule and introduces no new discipline; it binds an operand the consumer already referenced), micro-tests=no (no new wording or behaviour is introduced — the change makes an existing `--repo-root "$REPO_ROOT"` reference resolvable).

Recorded as stated dispositions rather than inferred from silence: a `no` with a reason fully discharges each slot, per the marker's own contract.
