### PR TITLE
chore: add the missing changeset for the four prompt-file trims (#1590-#1593)

### DIFF
--- a/.changeset/oversized-prompt-files-read-cap-trims-1590-1593.md
+++ b/.changeset/oversized-prompt-files-read-cap-trims-1590-1593.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: Fixed
+---
+
+- **Four oversized prompt files load whole again.** `skills/implement/phases/phase-1-setup.md`, `skills/implement/phases/phase-4-documentation.md`, `skills/review-and-fix/references/fixing.md` and `skills/review-and-fix/references/shadow-review.md` had each grown past the Read tool's per-call token cap, so a run could no longer see both ends of the file and the boundary-marker check gating them failed. Each is trimmed with its behavior unchanged, so the implement phases and fix-loop steps they gate clear that check again. (#1590, #1591, #1592, #1593)


### PR DESCRIPTION
PRs #1590, #1591, #1592 and #1593 each trimmed an oversized prompt file back under the Read tool's per-call token cap, so its boundary-marker gate can see both ends of the file again. All four edit `skills/` — the engine surface, shipped verbatim into consumer repos — so `.prflow/prompt-extensions/implement.md`'s Versioning policy owes exactly one changeset. None of them carried one: the gate that catches this is a `/prflow:implement` Phase 3 gate, and they went through the standalone review path.

This adds the single covering `.changeset/*.md` entry (`bump: patch`, `type: Fixed`) and touches nothing else — `.claude-plugin/plugin.json` and `CHANGELOG.md` stay owned by the merge-time consolidation workflow.

`patch` per the policy default: no issue body authorized a larger step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)