### PR TITLE
fix(agents): drop retired LS/NotebookRead names from code-explorer and code-architect

### DIFF
--- a/.changeset/agent-tools-drop-removed-names.md
+++ b/.changeset/agent-tools-drop-removed-names.md
@@ -1,0 +1,9 @@
+---
+bump: patch
+---
+
+Drop the removed tool names `LS` and `NotebookRead` from the `code-explorer` and
+`code-architect` agent frontmatter. Claude Code merged `NotebookRead` into `Read` and
+retired `LS` in favour of `Glob`, so both names resolved to nothing; the agents keep the
+same effective tool set and the stale names no longer suggest a broken grant to consumers
+on other runners.

--- a/agents/code-architect.md
+++ b/agents/code-architect.md
@@ -1,7 +1,7 @@
 ---
 name: code-architect
 description: PRFlow's implement-phase planning agent. Designs feature architectures by analyzing existing codebase patterns and conventions, then providing comprehensive implementation blueprints with specific files to create/modify, component designs, data flows, and build sequences
-tools: Glob, Grep, LS, Read, NotebookRead, WebFetch, TodoWrite, WebSearch
+tools: Glob, Grep, Read, WebFetch, TodoWrite, WebSearch
 model: sonnet
 color: green
 ---

--- a/agents/code-explorer.md
+++ b/agents/code-explorer.md
@@ -1,7 +1,7 @@
 ---
 name: code-explorer
 description: PRFlow's implement-phase discovery agent. Deeply analyzes existing codebase features by tracing execution paths, mapping architecture layers, understanding patterns and abstractions, and documenting dependencies to inform new development
-tools: Glob, Grep, LS, Read, NotebookRead, WebFetch, TodoWrite, WebSearch
+tools: Glob, Grep, Read, WebFetch, TodoWrite, WebSearch
 model: sonnet
 color: yellow
 ---


### PR DESCRIPTION
## What

`agents/code-explorer.md` and `agents/code-architect.md` declared `LS` and `NotebookRead` in their `tools:` frontmatter. Both names have been retired from Claude Code — `NotebookRead` was merged into `Read` in v1.0.68, and `LS` was superseded by `Glob`. They were the only two agents in the plugin declaring either name; the other 13 declare only `Read`, `Grep`, `Glob`, `Bash`, `Write` and needed no correction.

Both files were vendored from Anthropic's `feature-dev` plugin and never re-validated against the current tool set.

## Why this is cosmetic, not a bug fix

This came in as consumer feedback claiming the two agents "arrive with no file access" and are "unusable on this runner". **That claim was tested and does not reproduce on Claude Code.** Dispatching the real `prflow:code-explorer` and asking it to enumerate its own tools returned:

- Tools granted: `Read`, `Glob`, `Grep`, `WebFetch`, `WebSearch`
- `Glob agents/*.md` → succeeded, 15 files
- `Read agents/code-explorer.md` → succeeded

Claude Code silently drops names it does not recognise and grants every valid one, so file access was never lost. The reporter's specific symptom — an agent holding "only the session-history tool" — matches no documented Claude Code tool, which points at a different runner. GitHub Copilot CLI, the leading suspect, does not consume this frontmatter field at all.

So this PR removes dead weight and stops the frontmatter from reading like a broken grant. It does not change behaviour.

## Effective tool set

Unchanged on Claude Code. `TodoWrite` is retained: it did not resolve on the runner used for the test, but it remains a documented Claude Code tool and its absence here may be this build substituting task tools. Removing it would be a capability change on runners that do have it, which is out of scope for a cleanup.

## Deliberately not touched

`scripts/implement-context-eval.py` and `lib/test/test_implement_context_eval.py` map `NotebookRead` into a `file_reads` bucket. That is a classifier over recorded transcripts, not a tool grant — historical runs still contain `NotebookRead` events and must keep classifying.

## Verification

The `#628` pins in `lib/test/run.sh` assert these two `tools:` lines are non-empty and omit `KillShell`/`BashOutput`; all four still hold. CI is the gate for this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)