### PR TITLE
Address PR #1704's review notes: stale Step 3.6 citations + shared manifest reader hardening

### DIFF
--- a/.changeset/issue-1702-followup-stale-citations.md
+++ b/.changeset/issue-1702-followup-stale-citations.md
@@ -1,0 +1,9 @@
+---
+bump: patch
+---
+
+Follow-up to issue #1702's Step 3.6 decomposition: repoint four stale intra-skill citations in
+the `create-issue` fallback references at the members that now own the procedures they name, and
+harden the shared Step 3.6 manifest reader (validation on construction, `schema_version`
+recognition, normalized path comparison) plus coverage for the non-numeric `peak_context`
+sentinel paths in the context evaluator.

--- a/lib/test/check-audit-lifecycle-contracts.py
+++ b/lib/test/check-audit-lifecycle-contracts.py
@@ -70,11 +70,8 @@ IAS = REPO / "scripts" / "issue-audit-state.py"
 STEP36_MANIFEST = REPO / "lib" / "test" / "create-issue-step-3-6-members.json"
 STEP4 = REPO / "skills" / "create-issue" / "references" / "step-4-present-create.md"
 
-# Test-injection seam: when a caller rebinds `STEP36` to a single crafted document, the
-# Step 3.6 set is exactly `[STEP36]` and the sequence/fenced arms grade that one file plus
-# `STEP4` — byte-identical to the pre-#1702 single-file contract, so every crafted-document
-# test drives the checker unchanged. In a real run it stays `None` and the set is read from
-# the declared manifest.
+# Test-injection seam, rebound with `STEP4` as a pair. Keep the `None` default: a real path
+# here would make every run grade one file instead of the declared manifest set.
 STEP36 = None
 
 

--- a/lib/test/create-issue-step-3-6-members.json
+++ b/lib/test/create-issue-step-3-6-members.json
@@ -1,5 +1,6 @@
 {
   "comment": "Declared Step 3.6 audit reference set (issue #1702). The single source of the entry + ordered procedure members that lib/test/lint-reference-size.py (per-member 55,000-byte limit + aggregate source-byte budget), lib/test/check-audit-lifecycle-contracts.py (call-sequence + fenced-completeness across the set), and lib/test/modules/create-issue-contract.sh (#614 routing/marker reconciliation + omitted-member positive control) all resolve against. Paths are repo-relative. The members are listed in load order and carry a `<!-- prflow:create-issue-set step=3.6 part=k of=N -->` second-line marker.",
+  "schema_version": 1,
   "entry": "skills/create-issue/references/step-3-6-audit.md",
   "members": [
     "skills/create-issue/references/step-3-6-audit-shared.md",

--- a/lib/test/step36_manifest.py
+++ b/lib/test/step36_manifest.py
@@ -3,59 +3,109 @@
 # SPDX-License-Identifier: MIT
 """Shared typed reader for the declared Step 3.6 audit reference set (issue #1702).
 
-`lib/test/create-issue-step-3-6-members.json` declares the Step 3.6 entry reference plus
-its ordered procedure members, and three independent checks resolve against it:
+`lib/test/create-issue-step-3-6-members.json` declares the Step 3.6 entry reference plus its
+ordered procedure members, and three independent checks resolve against it:
 `lib/test/lint-reference-size.py` (per-member ceiling + aggregate source-byte budget),
-`lib/test/check-audit-lifecycle-contracts.py` (call-sequence + fenced-completeness across
-the set, and the manifest/on-disk marker reconciliation), and
+`lib/test/check-audit-lifecycle-contracts.py` (call-sequence + fenced-completeness across the
+set, and the manifest/on-disk marker reconciliation), and
 `lib/test/modules/create-issue-contract.sh` (the `#614` routing/marker reconciliation).
 
-The two Python readers each validated the record separately and to *different* depths, so a
-malformed manifest was RED under one tool and accepted by the other. This module owns the one
-validation, and returns it as a NAMED record rather than a positional tuple: a reorder of two
-adjacent same-typed byte counts would type-check cleanly and compare against the wrong number.
+Specification
+-------------
+`Step36Manifest` validates in `__new__`, so no construction path can produce an invalid record —
+`load()` parses JSON and constructs, and every other caller gets the same invariants. Field
+access is by name: two adjacent same-typed byte counts read positionally would compare against
+the wrong number and still type-check.
 
-`load()` fails CLOSED on every malformed shape. An unestablished set is never an empty one —
-an empty population would read as a stricter check passing over nothing.
+`SCHEMA_VERSIONS` is the recognised set. An **absent** `schema_version` reads as version 1, the
+shape that shipped before the field existed; any other value is refused rather than read under
+guessed semantics.
+
+Path fields are compared after normalization, so `./a.md` and `a.md` are one member rather than
+two — a duplicate the string-exact comparison admitted.
+
+`load()` fails CLOSED on every malformed shape. An unestablished set is never an empty one: an
+empty population would read as a stricter check passing over nothing.
 """
 
 from __future__ import annotations
 
 import json
+import posixpath
 from pathlib import Path
 from typing import NamedTuple
+
+#: Recognised `schema_version` values. Absent reads as 1 (the pre-field shape).
+SCHEMA_VERSIONS = (1,)
 
 
 class Step36ManifestError(Exception):
     """The Step 3.6 member manifest could not be read as a well-formed record."""
 
 
-class Step36Manifest(NamedTuple):
-    """The validated manifest record. Read by field name, never by position."""
-
-    entry: str
-    members: tuple[str, ...]
-    per_member_limit_bytes: int
-    aggregate_baseline_bytes: int
-    aggregate_baseline_commit: str
+def _normalize(path: str) -> str:
+    """The comparison form of a declared repo-relative path."""
+    return posixpath.normpath(path.strip())
 
 
-def _require_positive_int(data: dict, key: str) -> int:
-    value = data.get(key)
+def _require_positive_int(value: object, key: str) -> int:
     # `isinstance(True, int)` is True, so a bare int check would accept a JSON boolean as a
-    # byte count and compare file sizes against 1.
+    # byte count and compare every file size against 1.
     if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
         raise Step36ManifestError(
             f"the Step 3.6 manifest's `{key}` must be a positive integer")
     return value
 
 
-def _require_nonempty_str(data: dict, key: str) -> str:
-    value = data.get(key)
+def _require_nonempty_str(value: object, key: str) -> str:
     if not isinstance(value, str) or not value.strip():
         raise Step36ManifestError(
             f"the Step 3.6 manifest's `{key}` must be a non-empty string")
     return value
+
+
+class _Step36ManifestFields(NamedTuple):
+    """The field set. `Step36Manifest` below is the constructible type — use that one."""
+
+    entry: str
+    members: tuple[str, ...]
+    per_member_limit_bytes: int
+    aggregate_baseline_bytes: int
+    aggregate_baseline_commit: str
+    schema_version: int = 1
+
+
+class Step36Manifest(_Step36ManifestFields):
+    """The validated manifest record. Read by field name, never by position.
+
+    A NamedTuple rather than a dataclass: `dataclasses` resolves `cls.__module__` through
+    `sys.modules`, and both readers import this file via `module_from_spec` without registering
+    it there, so a dataclass here raises at class-creation time inside every consumer.
+    """
+
+    def __new__(cls, *args, **kwargs):
+        record = super().__new__(cls, *args, **kwargs)
+        record._validate()
+        return record
+
+    def _validate(self) -> None:
+        if self.schema_version not in SCHEMA_VERSIONS:
+            raise Step36ManifestError(
+                f"the Step 3.6 manifest declares schema_version {self.schema_version!r}, not "
+                f"one of {list(SCHEMA_VERSIONS)} — refusing to read it under guessed semantics")
+        _require_nonempty_str(self.entry, "entry")
+        if not isinstance(self.members, tuple) or not self.members or not all(
+            isinstance(member, str) and member.strip() for member in self.members
+        ):
+            raise Step36ManifestError("the Step 3.6 manifest's `members` must be a non-empty "
+                                      "list of non-empty strings")
+        normalized = [_normalize(member) for member in self.members]
+        if len(set(normalized)) != len(normalized) or _normalize(self.entry) in normalized:
+            raise Step36ManifestError("the Step 3.6 manifest names a duplicate or "
+                                      "entry-as-member path")
+        _require_positive_int(self.per_member_limit_bytes, "per_member_limit_bytes")
+        _require_positive_int(self.aggregate_baseline_bytes, "aggregate_baseline_bytes")
+        _require_nonempty_str(self.aggregate_baseline_commit, "aggregate_baseline_commit")
 
 
 def load(path: Path) -> Step36Manifest:
@@ -72,20 +122,15 @@ def load(path: Path) -> Step36Manifest:
             f"the Step 3.6 manifest is not valid JSON ({path}): {exc}") from exc
     if not isinstance(data, dict):
         raise Step36ManifestError("the Step 3.6 manifest's top-level value must be an object")
-    entry = _require_nonempty_str(data, "entry")
     members = data.get("members")
-    if not isinstance(members, list) or not members or not all(
-        isinstance(member, str) and member.strip() for member in members
-    ):
+    if not isinstance(members, list):
         raise Step36ManifestError("the Step 3.6 manifest's `members` must be a non-empty list "
                                   "of non-empty strings")
-    if len(set(members)) != len(members) or entry in members:
-        raise Step36ManifestError("the Step 3.6 manifest names a duplicate or entry-as-member "
-                                  "path")
     return Step36Manifest(
-        entry=entry,
+        entry=data.get("entry"),
         members=tuple(members),
-        per_member_limit_bytes=_require_positive_int(data, "per_member_limit_bytes"),
-        aggregate_baseline_bytes=_require_positive_int(data, "aggregate_baseline_bytes"),
-        aggregate_baseline_commit=_require_nonempty_str(data, "aggregate_baseline_commit"),
+        per_member_limit_bytes=data.get("per_member_limit_bytes"),
+        aggregate_baseline_bytes=data.get("aggregate_baseline_bytes"),
+        aggregate_baseline_commit=data.get("aggregate_baseline_commit"),
+        schema_version=data.get("schema_version", 1),
     )

--- a/lib/test/test_create_issue_context_eval.py
+++ b/lib/test/test_create_issue_context_eval.py
@@ -1647,6 +1647,102 @@ class PairedDeltaDegradedChannelsTest(unittest.TestCase):
         self.assertEqual(set(skipped), set(self._CHANNELS))
 
 
+class NonNumericPeakContextTest(unittest.TestCase):
+    """A non-numeric `peak_context` reports `unestablished`, never raising (issue #1702).
+
+    Every `peak_context` axis does arithmetic on the field — a sum, a mean, a median — so an
+    unmeasured value that reached them would raise `TypeError` out of a module whose contract
+    is to publish the `unestablished` sentinel. Both guarded sites are driven here: the
+    `_paired_delta` context keys and `_manifest_comparison`'s median pair.
+    """
+
+    _CHANNELS = ("non_json_line", "not_object", "no_type", "unreadable_file",
+                 "escaped_path", "walk_error", "malformed_record",
+                 "sidechain_only_file")
+    _CONTEXT_KEYS = ("total_peak_context", "mean_peak_context_per_run",
+                     "median_main_thread_context")
+
+    def _report(self, peak_context):
+        return {"runs": [{"attributed_auditor_cost": 10, "peak_context": peak_context,
+                          "dispatch_rounds": [1]}],
+                "skipped": {k: 0 for k in self._CHANNELS},
+                "finding_count": 3}
+
+    def test_paired_delta_context_keys_go_unestablished_not_raising(self):
+        # Positive control FIRST: numeric peaks yield real numbers on the same fixture, so
+        # each `unestablished` below is attributable to the non-numeric value alone.
+        clean = CICE._paired_delta(self._report(10), self._report(10))
+        for key in self._CONTEXT_KEYS:
+            self.assertNotEqual(clean[key], CICE.UNESTABLISHED, key)
+        # A non-numeric peak on EITHER side degrades all three, and the non-context keys
+        # stay measured — the guard is scoped to the axis that reads the field.
+        for label, (before, after) in (
+            ("before", (self._report(CICE.UNESTABLISHED), self._report(10))),
+            ("after", (self._report(10), self._report(CICE.UNESTABLISHED))),
+            ("both", (self._report(None), self._report(None))),
+        ):
+            delta = CICE._paired_delta(before, after)
+            for key in self._CONTEXT_KEYS:
+                self.assertEqual(delta[key], CICE.UNESTABLISHED,
+                                 "{} stayed measured with a non-numeric peak ({})"
+                                 .format(key, label))
+            self.assertEqual(delta["total_attributed_auditor_cost"], 0, label)
+            self.assertEqual(delta["total_round_count"], 0, label)
+
+    def test_a_boolean_peak_is_not_a_number(self):
+        """`isinstance(True, int)` is True, so a bare int check would admit it and publish a
+        median derived from booleans as a measured token cost."""
+        delta = CICE._paired_delta(self._report(True), self._report(10))
+        for key in self._CONTEXT_KEYS:
+            self.assertEqual(delta[key], CICE.UNESTABLISHED, key)
+
+    def _manifest_run(self, configuration, peak_context):
+        return {
+            "configuration": configuration,
+            "scenario_id": "s1",
+            "repetition": 1,
+            "run_id": "run-" + configuration,
+            "peak_context": peak_context,
+            "attributed_auditor_cost": 10,
+            "dispatch_rounds": [1],
+            "finding_count": 2,
+            "state_established": True,
+            "grade": None,
+            "occurrence": {"boundary_confidence": "exact"},
+            "provenance": {"repo_sha": "abc", "prompt_fingerprint": "p", "model": "m",
+                           "effort": "high", "output_style": "o", "provider": "v",
+                           "skill_fingerprint": "s"},
+        }
+
+    def test_manifest_comparison_median_pair_goes_unestablished(self):
+        # Positive control on the same pair shape: numeric peaks establish both medians and
+        # the verdict, so the sentinels below cannot come from an unrelated earlier gate.
+        clean = CICE._manifest_comparison([self._manifest_run("baseline", 100),
+                                           self._manifest_run("revised", 90)])
+        self.assertEqual(clean["status"], "established", clean.get("diagnostic"))
+        self.assertEqual(clean["median_main_thread_context"]["baseline"], 100)
+        self.assertEqual(clean["median_main_thread_context"]["revised"], 90)
+        self.assertIs(clean["revised_median_within_baseline"], True)
+        # One unmeasured peak makes BOTH medians and the verdict the sentinel — never a
+        # number on the measurable side beside an unknown on the other, which would read as
+        # a comparison against a value that was never measured.
+        for label, (before_peak, after_peak) in (
+            ("baseline unmeasured", (CICE.UNESTABLISHED, 90)),
+            ("revised unmeasured", (100, CICE.UNESTABLISHED)),
+        ):
+            report = CICE._manifest_comparison([
+                self._manifest_run("baseline", before_peak),
+                self._manifest_run("revised", after_peak)])
+            self.assertEqual(report["status"], "established", label)
+            median = report["median_main_thread_context"]
+            self.assertEqual(median["baseline"], CICE.UNESTABLISHED, label)
+            self.assertEqual(median["revised"], CICE.UNESTABLISHED, label)
+            self.assertEqual(report["revised_median_within_baseline"],
+                             CICE.UNESTABLISHED, label)
+            self.assertEqual(report["delta"]["median_main_thread_context"],
+                             CICE.UNESTABLISHED, label)
+
+
 class ManifestIngestionTest(unittest.TestCase):
     def setUp(self):
         self.manifest_path = os.path.join(_MANIFEST_FIX, "two-occurrences.json")

--- a/lib/test/test_python_scripts.py
+++ b/lib/test/test_python_scripts.py
@@ -33383,6 +33383,57 @@ assert_eq("#1702: the shared loader refuses a BOOLEAN byte count (isinstance(Tru
               "entry": "e.md", "members": ["m.md"], "per_member_limit_bytes": True,
               "aggregate_baseline_bytes": 1, "aggregate_baseline_commit": "s"}))
 
+# An unrecognized `schema_version` is refused rather than read under guessed semantics; an
+# ABSENT one reads as the pre-field shape, version 1, so the record predating the field loads.
+assert_eq("#1702 follow-up: both readers refuse an unrecognized schema_version",
+          (True, True), _s36_1702_both_readers({
+              "schema_version": 2, "entry": "e.md", "members": ["m.md"],
+              "per_member_limit_bytes": 1, "aggregate_baseline_bytes": 1,
+              "aggregate_baseline_commit": "s"}))
+assert_eq("#1702 follow-up: a non-integer schema_version is refused, not coerced",
+          (True, True), _s36_1702_both_readers({
+              "schema_version": "1", "entry": "e.md", "members": ["m.md"],
+              "per_member_limit_bytes": 1, "aggregate_baseline_bytes": 1,
+              "aggregate_baseline_commit": "s"}))
+assert_eq("#1702 follow-up positive control: an ABSENT schema_version reads as version 1",
+          (False, False), _s36_1702_both_readers({
+              "entry": "e.md", "members": ["m.md"], "per_member_limit_bytes": 1,
+              "aggregate_baseline_bytes": 1, "aggregate_baseline_commit": "s"}))
+assert_eq("#1702 follow-up: an explicit schema_version 1 is accepted",
+          (False, False), _s36_1702_both_readers({
+              "schema_version": 1, "entry": "e.md", "members": ["m.md"],
+              "per_member_limit_bytes": 1, "aggregate_baseline_bytes": 1,
+              "aggregate_baseline_commit": "s"}))
+
+# Path comparison is normalized, so `./a.md` and `a.md` are one member — the duplicate the
+# string-exact comparison admitted, which would have measured one file twice in the aggregate.
+assert_eq("#1702 follow-up: a duplicate member differing only by path spelling is refused",
+          (True, True), _s36_1702_both_readers({
+              "entry": "e.md", "members": ["m.md", "./m.md"],
+              "per_member_limit_bytes": 1, "aggregate_baseline_bytes": 1,
+              "aggregate_baseline_commit": "s"}))
+assert_eq("#1702 follow-up: an entry re-spelled as a member path is refused",
+          (True, True), _s36_1702_both_readers({
+              "entry": "./e.md", "members": ["e.md", "m.md"],
+              "per_member_limit_bytes": 1, "aggregate_baseline_bytes": 1,
+              "aggregate_baseline_commit": "s"}))
+
+# The record validates on CONSTRUCTION, not only through `load()`: a caller reaching for the
+# type directly cannot mint one that every consumer then trusts.
+_s36_1702_direct = False
+try:
+    _s36_1702.Step36Manifest(entry="e.md", members=(), per_member_limit_bytes=1,
+                             aggregate_baseline_bytes=1, aggregate_baseline_commit="s")
+except _s36_1702.Step36ManifestError:
+    _s36_1702_direct = True
+assert_eq("#1702 follow-up: the type itself refuses an invalid record (not only load())",
+          True, _s36_1702_direct)
+assert_eq("#1702 follow-up positive control: a valid direct construction succeeds",
+          "e.md",
+          _s36_1702.Step36Manifest(entry="e.md", members=("m.md",), per_member_limit_bytes=1,
+                                   aggregate_baseline_bytes=1,
+                                   aggregate_baseline_commit="s").entry)
+
 # The REAL declared set on the live tree stays within both limits (guards the shipped split).
 _f1702_real, _r1702_real = _rsz1702.check_step36_set(
     SCRIPTS.parent,

--- a/skills/create-issue/references/fallback-audit-boundary-offer.md
+++ b/skills/create-issue/references/fallback-audit-boundary-offer.md
@@ -2,7 +2,7 @@
 
 ## The Step 3.6 → Step 4 boundary offer
 
-`references/step-3-6-audit.md` loads this file when its unconditional `query-boundary` call reports a trigger component at `hold`, or when it found an `unledgered_revise` round. Read that answer back rather than re-calling it.
+`references/step-3-6-audit-adjudication.md` loads this file when its unconditional `query-boundary` call reports a trigger component at `hold`, or when it found an `unledgered_revise` round. Read that answer back rather than re-calling it.
 
 Its trigger component answers `t1=hold|not-hold t2=hold|not-hold coverage=hold|not-hold calibration=hold|not-hold reason=…`.
 

--- a/skills/create-issue/references/fallback-audit-evidence-degraded.md
+++ b/skills/create-issue/references/fallback-audit-evidence-degraded.md
@@ -2,7 +2,7 @@
 
 ## Degraded arms of an audit round
 
-Each arm below is a terminal degraded state of one audit round. The round's own observable answer selects the arm; `references/step-3-6-audit.md` names which. Every arm here is a disclosure, never a stop.
+Each arm below is a terminal degraded state of one audit round. The round's own observable answer selects the arm; `references/step-3-6-audit-dispatch.md` names which. Every arm here is a disclosure, never a stop.
 
 **Carriage evidence absent or mismatched.** A `record-return` classified `no-parseable-verdict` because the carriage evidence was **absent** or **mismatched** writes a named breadcrumb to **stderr** — `carriage-absent` when the auditor quoted no object ID, `carriage-mismatch` when it quoted one that disagrees with the recorded dispatch digest — while its stdout `classification=…` line and its exit code are unchanged. The remedy the breadcrumb names is to **re-run `record-return` supplying `--carriage-object-id` with the object id of the draft the auditor actually audited** (`git hash-object --no-filters <draft>`), so read the stderr breadcrumb before treating the round as genuinely unreadable.
 

--- a/skills/create-issue/references/fallback-draft-write-recovery.md
+++ b/skills/create-issue/references/fallback-draft-write-recovery.md
@@ -4,7 +4,7 @@
 
 **Recovery on disagreement (revision writes)**
 
-When `agree=no` after a revision write, record `record-write-failure --ordinal <N>` (N from the `record-revision --stdin-digest` step of the **Staged canonical-draft write** procedure in `references/step-3-6-audit.md`, same turn), present from the in-context revision bytes rather than the canonical file, and re-run `apply` **exactly once** from the still-present staging artifact — **named from the durably recorded path, never "the newest artifact on disk"**. Resolve it with:
+When `agree=no` after a revision write, record `record-write-failure --ordinal <N>` (N from the `record-revision --stdin-digest` step of the **Staged canonical-draft write** procedure in `references/step-3-6-audit-shared.md`, same turn), present from the in-context revision bytes rather than the canonical file, and re-run `apply` **exactly once** from the still-present staging artifact — **named from the durably recorded path, never "the newest artifact on disk"**. Resolve it with:
 
 ```bash
 python3 "${CLAUDE_SKILL_DIR:-<absolute skill base directory this runner reports in context>}"/../../scripts/issue-audit-state.py query-staged-write "<slug>" --nonce "<nonce>" --digest "<the revision's stdin_digest>"
@@ -14,6 +14,6 @@ If that single re-attempt also disagrees, stop retrying, report `--write-landed 
 
 **Foreign-nonce arm (a drifted nonce is NOT an unbound run — surface it, never fold it into `bound=none`)**
 
-`bound=none … reason=foreign-nonce` means the run **is** bound; only the nonce you hold has drifted from the one the record holds. On this answer: **do not compose a path and do not silently proceed.** First attempt recovery — re-derive the run's nonce with `query-nonce "<slug>"` and re-query with the recovered value; if it then answers a real absolute root, continue on the already-bound branch of `references/step-3-6-audit.md`’s **Bind the draft root** step. If recovery is unavailable or the answer still carries `reason=foreign-nonce`, **stop and tell the user** that this run's nonce has drifted from the recorded draft-root binding, naming that the tool will still emit from the recorded binding so proceeding would file stale bytes.
+`bound=none … reason=foreign-nonce` means the run **is** bound; only the nonce you hold has drifted from the one the record holds. On this answer: **do not compose a path and do not silently proceed.** First attempt recovery — re-derive the run's nonce with `query-nonce "<slug>"` and re-query with the recovered value; if it then answers a real absolute root, continue on the already-bound branch of `references/step-3-6-audit-dispatch.md`’s **Bind the draft root** step. If recovery is unavailable or the answer still carries `reason=foreign-nonce`, **stop and tell the user** that this run's nonce has drifted from the recorded draft-root binding, naming that the tool will still emit from the recorded binding so proceeding would file stale bytes.
 
 <!-- prflow:create-issue-ref step=fallback-draft-write-recovery file=skills/create-issue/references/fallback-draft-write-recovery.md end -->


### PR DESCRIPTION
Follow-up to **#1704** (issue #1702), which merged before its APPROVE-with-notes review findings were addressed. All four findings sat below the `critical` merge threshold, so none gated that merge; they are addressed here.

## Important 1 — four stale intra-skill citations (the substantive finding)

Three unmodified sibling fallback references still named `references/step-3-6-audit.md` as the home of procedures #1704's decomposition moved into members. Each is repointed at the member that now owns it:

| File | Names | Repointed to |
|---|---|---|
| `fallback-draft-write-recovery.md` | *Staged canonical-draft write* | `step-3-6-audit-shared.md` |
| `fallback-draft-write-recovery.md` | *Bind the draft root* | `step-3-6-audit-dispatch.md` |
| `fallback-audit-boundary-offer.md` | the site that loads it | `step-3-6-audit-adjudication.md` |
| `fallback-audit-evidence-degraded.md` | which arm is named | `step-3-6-audit-dispatch.md` |

`step-4-present-create.md` already cited the owning member, so this brings the rest to a convention the file set already had.

**The class was swept, not just the cited instances.** The remaining citations of the entry are correct as written and are unchanged: `degradation-routing.md`'s routing rows (the entry and the three members are each a routed reference), `SKILL.md`'s Step 3.6 load, `step-3-5-steelman.md`'s pointer at the entry-confirmation gate (which really does live in the entry file), and the internal docs.

## Important 2 — untested `UNESTABLISHED` branches

`NonNumericPeakContextTest` covers `_paired_delta`'s three `peak_context` keys and `_manifest_comparison`'s median pair plus its non-regression verdict, each with a positive control on the same fixture, and a boolean-peak row (`isinstance(True, int)` is `True`).

## Suggestion 1 — `Step36Manifest` hardening

- **Constructible-but-invalid** → validation moves into `__new__`, so no construction path yields an invalid record, not just `load()`.
- **No `schema_version` recognition** (unlike its sibling reader's `KNOWN_SCHEMA_VERSIONS`) → `SCHEMA_VERSIONS` refuses an unrecognized value; an **absent** one reads as version 1, the pre-field shape, so no fixture churn.
- **String-exact path comparison** → compared normalized, so `./m.md` and `m.md` are one member.

It stays a `NamedTuple` deliberately, and this is load-bearing: `dataclasses` resolves `cls.__module__` through `sys.modules`, and both readers import this file via `module_from_spec` without registering it there — a dataclass raises at class-creation time inside every consumer. Found by trying it.

## Suggestion 2 — comment length

The `STEP36 = None` seam comment is trimmed to the prohibition and its consequence.

## Verification

Focused, in-environment, on the committed tree: `test_python_scripts.py` (5,284 passed / 21 failed — all 21 the pre-existing `#1655` model-clause rows that reproduce on `main` on this host and are green in CI), `test_create_issue_context_eval.py` (156 passed), `run-module.sh create-issue-contract` (350 passed), `check-audit-lifecycle-contracts.py` rc 0, `lint-reference-size.py` whole-tree rc 0, `ruff` clean. Step 3.6 aggregate unchanged at 72,407 / 72,458 bytes.

Every new guard was mutation-checked and observed RED for the reason it pins, with positive controls staying green:

| Mutation | Result |
|---|---|
| remove path normalization | both path-spelling rows RED |
| disable `schema_version` recognition | both version rows RED; absent-version control green |
| drop `__new__` validation | direct-construction row + duplicate-member row RED |
| unguard `_context_delta` | all three context rows RED (two as the `TypeError` the guard prevents) |

The citation repointings carry no automated coverage by design — agent-executed prompt prose whose only reader is the runtime agent (the recorded issue #843/#876 decision). Each was verified by locating the named procedure's actual home before repointing.

Writing-skills evidence: skill-loaded=no (no `SKILL.md` body edited — the changed prompt surfaces are `references/*.md` fallback files), guidance-applied=yes (repointings follow the sibling `step-4-present-create.md` convention and the instruction-plus-consequence prose rule), pressure-scenario=no (a path-literal repointing has no triggering behavior to pressure-test), micro-tests=no (prose no tool reads; verified instead by locating each procedure's owning member).
