### PR TITLE
Scaffold stale_prose off for fresh consumers; demote it to suggestion here

### DIFF
--- a/.changeset/stale-prose-consumer-default-off.md
+++ b/.changeset/stale-prose-consumer-default-off.md
@@ -1,0 +1,13 @@
+---
+bump: patch
+type: Changed
+---
+
+- **Fresh installs now scaffold `prflow_review.stale_prose.enabled` to `false`.** The Phase 0.6
+  stale counted-prose lint is tuned to prose idioms common in the PRFlow repository itself, and
+  its false-positive carry-forward join only honours payloads from an allowed bot author — so on
+  the local and standalone review paths a consumer has no working way to make an adjudication
+  stick, and every false positive re-fires each run. The resolver semantics are unchanged: an
+  absent key still resolves enabled, and only an explicit `false` disables, so an existing
+  consumer's config is untouched by the scaffold backfill. Set the key to `true` to opt back in.
+  The `/prflow:implement` Phase 2.3.4 sweep runs the same helper and is not governed by this key.

--- a/.prflow/config.example.json
+++ b/.prflow/config.example.json
@@ -40,7 +40,7 @@
     "verdict_severity_threshold": "critical",
     "live_progress_comment_enabled": true,
     "stale_prose": {
-      "enabled": true,
+      "enabled": false,
       "severity": "important"
     },
     "require_up_to_date": true,

--- a/.prflow/config.json
+++ b/.prflow/config.json
@@ -130,7 +130,7 @@
     "live_progress_comment_enabled": true,
     "stale_prose": {
       "enabled": true,
-      "severity": "important"
+      "severity": "suggestion"
     },
     "require_up_to_date": true,
     "require_ci_green": true,

--- a/docs/external/docs/configuration/review.md
+++ b/docs/external/docs/configuration/review.md
@@ -11,7 +11,7 @@ Tune the shared review engine and the local review-and-fix loop to match your re
 | --- | --- | --- | --- | --- |
 | `prflow_review.verdict_severity_threshold` | `critical`, `important` or `suggestion` | `critical` | Standalone review and review-and-fix review pass. Lowering the threshold makes more findings reject. | `"verdict_severity_threshold": "critical"` |
 | `prflow_review.live_progress_comment_enabled` | Boolean | `true` | Pull-request review. When true, each run maintains its own progress comment. Comment writes are best effort. | `"live_progress_comment_enabled": true` |
-| `prflow_review.stale_prose.enabled` | Boolean | `true`; anything except explicit false enables | Shared review engine. Disabling removes the automatic check for prose that contains stale numeric claims. | `"enabled": true` |
+| `prflow_review.stale_prose.enabled` | Boolean | Fallback `true`; scaffold: `false`. Anything except explicit false enables | Shared review engine. Fresh installs scaffold this off, because the check is tuned to prose idioms that are common in the PRFlow repository itself and its false-positive suppression channel only works for bot-authored review comments. Set it to true to enable the automatic check for prose that contains stale numeric claims. | `"enabled": false` |
 | `prflow_review.stale_prose.severity` | `critical`, `important` or `suggestion` | `important` | Shared review engine. The chosen severity participates in verdict computation. | `"severity": "important"` |
 
 ## Review and Fix

--- a/lib/test/run.sh
+++ b/lib/test/run.sh
@@ -39140,15 +39140,15 @@ assert_eq "#423 T9 schema: stale_prose is an object" "object" "$(jq -r "$SP_PROP
 assert_eq "#423 T9 schema: enabled default true" "true" "$(jq -r "$SP_PROP.properties.enabled.default" "$SP_SCHEMA")"
 assert_eq "#423 T9 schema: severity default important" "important" "$(jq -r "$SP_PROP.properties.severity.default" "$SP_SCHEMA")"
 assert_eq "#423 T9 schema: severity enum is exactly the three values" '["critical","important","suggestion"]' "$(jq -c "$SP_PROP.properties.severity.enum" "$SP_SCHEMA")"
-assert_eq "#423 T9 example: enabled matches schema default" "true" "$(jq -r '.prflow_review.stale_prose.enabled' "$SP_EXAMPLE")"
+assert_eq "#423 T9 example: enabled scaffolds false (consumer default off)" "false" "$(jq -r '.prflow_review.stale_prose.enabled' "$SP_EXAMPLE")"
 assert_eq "#423 T9 example: severity matches schema default" "important" "$(jq -r '.prflow_review.stale_prose.severity' "$SP_EXAMPLE")"
 assert_eq "#423 T9 tracked config carries stale_prose.enabled explicitly" "true" "$(jq -r '.prflow_review.stale_prose.enabled' "$SP_CONFIG")"
-assert_eq "#423 T9 tracked config carries stale_prose.severity explicitly" "important" "$(jq -r '.prflow_review.stale_prose.severity' "$SP_CONFIG")"
+assert_eq "#423 T9 tracked config carries stale_prose.severity explicitly" "suggestion" "$(jq -r '.prflow_review.stale_prose.severity' "$SP_CONFIG")"
 # scaffold-config.sh scaffolds config.json FROM config.example.json (cp + deep-merge
 # backfill), so the block flows into the scaffolder's output — proven end-to-end.
 SP_SCAFFOLD_DEST="$(mktemp -d)"
 bash "$LIB/../scripts/scaffold-config.sh" "$SP_SCAFFOLD_DEST" >/dev/null 2>&1
-assert_eq "#423 T9 scaffold-config.sh output carries stale_prose.enabled" "true" "$(jq -r '.prflow_review.stale_prose.enabled' "$SP_SCAFFOLD_DEST/.prflow/config.json" 2>/dev/null)"
+assert_eq "#423 T9 scaffold-config.sh output carries stale_prose.enabled" "false" "$(jq -r '.prflow_review.stale_prose.enabled' "$SP_SCAFFOLD_DEST/.prflow/config.json" 2>/dev/null)"
 assert_eq "#423 T9 scaffold-config.sh output carries stale_prose.severity" "important" "$(jq -r '.prflow_review.stale_prose.severity' "$SP_SCAFFOLD_DEST/.prflow/config.json" 2>/dev/null)"
 rm -rf "$SP_SCAFFOLD_DEST"
 


### PR DESCRIPTION
Turns the review engine's Phase 0.6 stale counted-prose lint **off for fresh installs**, and demotes it to `suggestion` in this repository.

## Why

Measured in this repository — the one the lint was built for:

| Probe | Result |
|---|---|
| 60 merged PRs, merge-base→head | **0 STALE**, 969 UNRESOLVABLE, 27 VERIFIED |
| 190 intermediate commits, last 18 PRs | **18 STALE rows** |
| Those 18, inspected | **18/18 false positives**, four distinct claims |

The four: a numbered list item `2. …in BOTH forms` read as a two-item count claim; `keep the top 100 items` (a cap) read as a count of an adjacent block; `docs/internal/cloud-allowlist.md` — a table documenting *which redirects are permitted* — tripping R4; and a `run.sh` comment explaining that a placeholder contains a `>`.

Noise profile: 90% of UNRESOLVABLE rows are `.md`, 74% under `skills/`. Worst single PR (#1748) emitted 478 informational rows ≈ 141 KB into one review report. Across 62 learning records mentioning the lint, 24 spans are false-positive/friction-only and none records a true positive.

The consumer case is worse than this repo's on two counts: the false-positive carry-forward join only honours payloads from an allowed **bot** author, so on the local and standalone review paths a consumer has no working way to make an adjudication stick and every false positive re-fires each run; and an unrecognised file type **fails open**, giving a repository in an unlisted language the widest scan with the least calibration.

## What changed

- `.prflow/config.example.json` — `prflow_review.stale_prose.enabled` → `false`. This is the scaffold source, so fresh installs get it off.
- `.prflow/config.json` — this repo keeps `enabled: true` but drops `severity` to `suggestion`, so the fix loop (`fix_severity_threshold: suggestion`) stops chasing false positives while the rows stay visible.
- `lib/test/run.sh` — the three coupled `#423 T9` pins.
- `docs/external/docs/configuration/review.md` — the `enabled` row now states `Fallback true; scaffold: false`, following the `.prflow.effort` precedent (schema default `high`, scaffold `low`).

## What deliberately did not change

- **Resolver semantics.** The schema `default` stays `true` and the Phase 0.6 fence keeps its hardcoded `true` fallback, so an absent key still resolves *enabled* and only an explicit `false` disables. The documented feature-on-by-default fail-safe direction is preserved, and no shipped skill body is edited.
- **Existing consumers.** `scaffold-config.sh` keeps existing values and backfills only newly-introduced keys, so an installed config already carrying `enabled: true` is untouched.
- **The implement sweep.** `/prflow:implement` Phase 2.3.4 runs the same helper and is explicitly not governed by this key.

## Verification

Each of the six pinned config reads and the scaffold end-to-end path checked directly:

- `example.enabled=false`, `example.severity=important`, `config.enabled=true`, `config.severity=suggestion`, schema defaults unchanged (`true` / `important`).
- `scaffold-config.sh` into a throwaway root → `enabled=false`, `severity=important`.
- `config-get.sh .prflow_review.stale_prose.enabled true <scaffolded config>` → `false` (the arm Phase 0.6 disables on).
- The generic `config: every schema default appears in the example` check is a path-set presence comparison, not value equality, so it is unaffected.
- ShellCheck 0.11.0 with `--extended-analysis=false` on `lib/test/run.sh`: clean.

Whole-suite gate is the CI reading for this branch's head, per the tiered-suite rung 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Verification evidence: CI reading (local/interactive tier whole-suite completion gate).
- head read: `64aad0c2c758eb54dd67d8dd56c8f6a611d10953`
- required check: `lib + python tests`
- conclusion: **pass**
- run: https://github.com/The01Geek/prflow/actions/runs/32158232648
- shards: lint pass, modules-large pass, modules-pin pass, modules-rest pass, monolith pass, python-pool pass
- `gh pr view --json headRefOid` equalled the pushed SHA both before and after the reading.

No whole-suite launch was performed locally, so no single-flight consult is owed on this path.
