### PR TITLE
chore(config): disable the stale-prose lint for PRFlow's own runs

### DIFF
--- a/.prflow/config.json
+++ b/.prflow/config.json
@@ -128,7 +128,7 @@
     "verdict_severity_threshold": "critical",
     "live_progress_comment_enabled": true,
     "stale_prose": {
-      "enabled": true,
+      "enabled": false,
       "severity": "suggestion"
     },
     "require_up_to_date": true,

--- a/lib/test/run.sh
+++ b/lib/test/run.sh
@@ -39397,7 +39397,7 @@ assert_eq "#423 T9 schema: severity default important" "important" "$(jq -r "$SP
 assert_eq "#423 T9 schema: severity enum is exactly the three values" '["critical","important","suggestion"]' "$(jq -c "$SP_PROP.properties.severity.enum" "$SP_SCHEMA")"
 assert_eq "#423 T9 example: enabled scaffolds false (consumer default off)" "false" "$(jq -r '.prflow_review.stale_prose.enabled' "$SP_EXAMPLE")"
 assert_eq "#423 T9 example: severity matches schema default" "important" "$(jq -r '.prflow_review.stale_prose.severity' "$SP_EXAMPLE")"
-assert_eq "#423 T9 tracked config carries stale_prose.enabled explicitly" "true" "$(jq -r '.prflow_review.stale_prose.enabled' "$SP_CONFIG")"
+assert_eq "#423 T9 tracked config carries stale_prose.enabled explicitly" "false" "$(jq -r '.prflow_review.stale_prose.enabled' "$SP_CONFIG")"
 assert_eq "#423 T9 tracked config carries stale_prose.severity explicitly" "suggestion" "$(jq -r '.prflow_review.stale_prose.severity' "$SP_CONFIG")"
 # scaffold-config.sh scaffolds config.json FROM config.example.json (cp + deep-merge
 # backfill), so the block flows into the scaffolder's output — proven end-to-end.


### PR DESCRIPTION
Sets `prflow_review.stale_prose.enabled` to `false` in `.prflow/config.json`. `severity` is unchanged; nothing else in the file changed.

## Why

The Phase 0.6 deterministic stale-counted-prose lint has **zero measured true positives over ~60 PRs**.

PR #1749 (commit `64aad0c2c`) already scaffolded it off for fresh consumers in `.prflow/config.example.json`, but only demoted its severity here. This aligns PRFlow's own live config with the consumer default.

It also removes 12,025 B of phase-reference load (`skills/review/phases/phase-0-6-stale-prose-lint.md`) from every review-engine entry — which on an implement run is a per-iteration cost.

## Changeset

None. Per `.prflow/prompt-extensions/implement.md`'s versioning policy and `CONTRIBUTING.md`, a changeset is required for changes reaching consumers via the engine surface (`skills/`, `agents/`, `lib/`, `scripts/`, the workflows, the config schema). `.prflow/config.json` is this repo's own live config and ships to no consumer, so this is an internal-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)