### PR TITLE
feat: advise VS Code Copilot nested-subagent setting in /prflow:init

### DIFF
--- a/.changeset/copilot-nested-subagents-advisory.md
+++ b/.changeset/copilot-nested-subagents-advisory.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: Added
+---
+
+- **`/prflow:init` now advises enabling VS Code Copilot's nested-subagent setting.** When the run is under a VS Code Copilot harness, init recommends turning on `chat.subagents.allowInvocationsFromSubagents` (off by default) so a subagent can dispatch its own subagents, giving review agents better context isolation; with it off a subagent silently does that work inline instead of erroring.

--- a/.changeset/copilot-nested-subagents-advisory.md
+++ b/.changeset/copilot-nested-subagents-advisory.md
@@ -3,4 +3,4 @@ bump: patch
 type: Added
 ---
 
-- **`/prflow:init` now advises enabling VS Code Copilot's nested-subagent setting.** When the run is under a VS Code Copilot harness, init recommends turning on `chat.subagents.allowInvocationsFromSubagents` (off by default) so a subagent can dispatch its own subagents, giving review agents better context isolation; with it off a subagent silently does that work inline instead of erroring.
+- **`/prflow:init` now advises enabling VS Code Copilot's nested-subagent setting.** When the run is under a VS Code Copilot harness, init recommends turning on `chat.subagents.allowInvocationsFromSubagents` (off by default) so a subagent can dispatch its own subagents, giving review agents better context isolation; with it off a subagent silently does that work inline instead of erroring. (#1877)

--- a/skills/init/SKILL.md
+++ b/skills/init/SKILL.md
@@ -366,6 +366,10 @@ Never run the external documentation bootstrap, and never dispatch a subagent th
 
 On every path through this step, `/prflow:init` creates no git commit.
 
+## Then: advise on nested subagents under VS Code Copilot (advisory)
+
+If — and only if — this run is under a VS Code Copilot harness, tell the user that turning on `chat.subagents.allowInvocationsFromSubagents` (a boolean, off by default) lets a subagent dispatch its own subagents, to a nesting depth of 5, and recommend it for better review-agent isolation. Left off, a subagent is simply not given the delegation tool and silently does that work inline in one context, so nothing errors and the lost isolation is invisible. Say nothing about it on any other harness, never edit the user's editor settings yourself, and never present it as something PRFlow requires today.
+
 ## Finally: advisory project-memory check (CLAUDE.md)
 
 Config is scaffolded and the preflight has run, so init has already succeeded — this last step is a purely advisory project-memory check that never creates, writes, or edits `CLAUDE.md` (or any agent-instruction file) and never blocks or fails init regardless of what it finds. A repo with no `CLAUDE.md` gives DevFlow's automations no project memory, so `/prflow:review` and `/prflow:implement` run without the conventions, gotchas, and architecture notes that materially improve their output. Surface that gap once, here, without ever touching a file.


### PR DESCRIPTION
## What

Adds a short, harness-conditional advisory to `skills/init/SKILL.md`: when `/prflow:init` runs under a VS Code Copilot harness, recommend enabling `chat.subagents.allowInvocationsFromSubagents` (a boolean, off by default) so a subagent can dispatch its own subagents, to a nesting depth of 5.

## Why

With that setting off, a subagent is simply not given the delegation tool. It does not error — it silently does the work inline in one context, so the loss of context isolation is invisible to the user.

This is **forward-looking**. PRFlow does not require nested dispatch today, and the prose deliberately does not claim it does or that anything breaks without it; it recommends the setting for better review-agent isolation.

## Notes

- **No new detection machinery.** `skills/init/SKILL.md`'s existing agent-file loop detects repository *files* (`.github/copilot-instructions.md`, `GEMINI.md`, `.cursorrules`), not the running harness, so it is not a harness-detection seam. Per the file's own idiom the advisory is a clearly-conditional sentence ("If — and only if — this run is under a VS Code Copilot harness, ...").
- **No shell added**, so the glob-guard / GNU-flag / bash-builtin conventions are not engaged.
- **No `docs/internal/` or `docs/external/` reference**, and no external URL — the body ships verbatim into consumer repos.
- **Size.** `skills/init/SKILL.md` goes 57,825 B -> 58,505 B (+680 B), against `lib/test/lint-reference-size.py`'s 61,750 B ceiling for a skill root.
- **`scripts/devflow-cloud-writer-contract.json` untouched**, correctly: `main` is its sole writer of digests, this edits an existing asset rather than adding one, and `skills/init/SKILL.md` is not among its 72 pinned entries.
- `.changeset/copilot-nested-subagents-advisory.md` added (`bump: patch`) — this edits the shipped engine surface and reaches consumers.

## Verification

`lib/test/lint-reference-size.py` (direct leading token — the classifier did not deny it) — **rc 0**, `audited 82 of 310 files`. Also ran `lib/test/lint-shipped-pruned-path.py` (rc 0) and `lib/test/lint-skills-glob-guard.py` (rc 0). The full local suite was deliberately not run.

Writing-skills evidence: skill-loaded=yes (invoked `superpowers:writing-skills` via the Skill tool before any edit, per CLAUDE.md's mandate for interactive sessions); guidance-applied=yes (the failure class is "behavior should depend on a condition", so per the skill's Match-the-Form-to-the-Failure table the guidance is written as a conditional keyed to an observable predicate rather than a prohibition, with no nuance clause); pressure-scenario=no (this is an additive advisory to a reference/procedure skill, not a discipline rule an agent would rationalize away under pressure, so no baseline pressure scenario was run); micro-tests=no (no fresh-context wording micro-tests against a no-guidance control were run — the addition is a single conditional sentence with a hard <1,200-byte budget, and the wording was reviewed against the skill's form rules instead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
