### PR TITLE
docs: correct the 2.33.53 changelog entry to match what shipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [2.33.53] — 2026-08-21
 
 ### Fixed
-- **Reframe the nested-subagent-dispatch constraint as cross-harness portability.** The shadow-review and docs-verify prose previously stated that a subagent cannot dispatch its own subagents as a fixed harness property; nested dispatch is in fact available on some harnesses and withheld on others. The shipped `skills/**` bodies now give cross-harness portability as the reason for keeping dispatch to a single subagent layer and name the failure mode as silent flattening — an absent tool rather than an error — while the internal docs single-home the harness capability table and version facts. (#1879)
+- **Reframe the nested-subagent-dispatch constraint as cross-harness portability.** The shadow-review and docs-verify prose previously stated that a subagent cannot dispatch its own subagents as a fixed harness property; nested dispatch is in fact available on some harnesses and withheld on others. The shipped `skills/**` bodies now name the failure mode as silent flattening to a single-agent self-check; the internal docs single-home the cross-harness portability rationale, the harness capability table, and the version facts. (#1879)
 
 ## [2.33.52] — 2026-08-20
 


### PR DESCRIPTION
PR #1879's review raised a Critical `self-contradicting-diff` finding: the changeset line described shipped prose that the same PR's trim commit had already removed. #1879 merged before that was addressed, and `version-consolidate` has since folded the line into `CHANGELOG.md`, which consumers read.

**Before:** claims the shipped `skills/**` bodies give cross-harness portability as the reason and carry the "absent tool rather than an error" phrasing.
**Reality at HEAD:** both bodies carry the rule plus the silent-flattening consequence only — that is what AC4 of #1878 requires. The rationale, harness table and version facts live solely in `docs/internal/shadow-review.md`.

No changeset: this corrects an already-published CHANGELOG entry rather than shipping a new change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)