### PR TITLE
fix: issue_acceptance FAILs are never normalization-eligible

### DIFF
--- a/.changeset/normalize-verdicts-issue-acceptance-blocker.md
+++ b/.changeset/normalize-verdicts-issue-acceptance-blocker.md
@@ -1,0 +1,11 @@
+---
+bump: patch
+---
+
+Harden `scripts/normalize-verdicts.py`: an item whose `category` is `issue_acceptance` is now
+a real-value normalization blocker, so a raw `FAIL` on an acceptance criterion is never stored
+as a `PASS`. Such items satisfy the first two normalization conjuncts structurally — the
+checklist generator defaults them to `claim_provenance: generated_paraphrase` and they are
+never `lite`-eligible, so they always run in `agent` mode — which left only the verifier's own
+self-reported `property_proven` / `inaccuracy_scope` fields between a failing acceptance
+criterion and a silently stored pass that Phase 4.2 rule 1 would never see.

--- a/.changeset/normalize-verdicts-issue-acceptance-blocker.md
+++ b/.changeset/normalize-verdicts-issue-acceptance-blocker.md
@@ -1,11 +1,13 @@
 ---
 bump: patch
+type: Fixed
 ---
 
-Harden `scripts/normalize-verdicts.py`: an item whose `category` is `issue_acceptance` is now
-a real-value normalization blocker, so a raw `FAIL` on an acceptance criterion is never stored
-as a `PASS`. Such items satisfy the first two normalization conjuncts structurally — the
-checklist generator defaults them to `claim_provenance: generated_paraphrase` and they are
-never `lite`-eligible, so they always run in `agent` mode — which left only the verifier's own
-self-reported `property_proven` / `inaccuracy_scope` fields between a failing acceptance
-criterion and a silently stored pass that Phase 4.2 rule 1 would never see.
+- **A raw `FAIL` on an issue acceptance criterion is never stored as a `PASS`.**
+  `scripts/normalize-verdicts.py` now treats an item whose `category` is `issue_acceptance`
+  as a real-value normalization blocker. Such items satisfy the first two normalization
+  conjuncts structurally — the checklist generator defaults them to
+  `claim_provenance: generated_paraphrase` and they are never `lite`-eligible, so they always
+  run in `agent` mode — which left only the verifier's own self-reported `property_proven` /
+  `inaccuracy_scope` fields between a failing acceptance criterion and a silently stored pass
+  that Phase 4.2 rule 1 would never see. (#1907)

--- a/lib/test/fixtures/normalize-verdicts/category-issue-acceptance-aux-defect.json
+++ b/lib/test/fixtures/normalize-verdicts/category-issue-acceptance-aux-defect.json
@@ -1,0 +1,8 @@
+{
+  "pairs": [
+    {
+      "item": {"id": "VC-AD", "category": "issue_acceptance", "verification_mode": "agent", "claim_provenance": "generated_paraphrase"},
+      "response_text": "Here is my verdict.\n```json\n{\"id\": \"VC-AD\", \"verdict\": \"FAIL\", \"evidence\": \"criterion not satisfied at the named site\", \"file_checked\": \"a.py\", \"inaccuracy_scope\": \"generated_claim_text\"}\n```"
+    }
+  ]
+}

--- a/lib/test/fixtures/normalize-verdicts/category-issue-acceptance.json
+++ b/lib/test/fixtures/normalize-verdicts/category-issue-acceptance.json
@@ -1,0 +1,8 @@
+{
+  "pairs": [
+    {
+      "item": {"id": "VC-A", "category": "issue_acceptance", "verification_mode": "agent", "claim_provenance": "generated_paraphrase"},
+      "response_text": "Here is my verdict.\n```json\n{\"id\": \"VC-A\", \"verdict\": \"FAIL\", \"evidence\": \"criterion not satisfied at the named site\", \"file_checked\": \"a.py\", \"property_proven\": true, \"inaccuracy_scope\": \"generated_claim_text\"}\n```"
+    }
+  ]
+}

--- a/lib/test/fixtures/normalize-verdicts/category-non-acceptance.json
+++ b/lib/test/fixtures/normalize-verdicts/category-non-acceptance.json
@@ -1,0 +1,8 @@
+{
+  "pairs": [
+    {
+      "item": {"id": "VC-B", "category": "dependency_interaction", "verification_mode": "agent", "claim_provenance": "generated_paraphrase"},
+      "response_text": "Here is my verdict.\n```json\n{\"id\": \"VC-B\", \"verdict\": \"FAIL\", \"evidence\": \"the code handles the branch the claim oversimplifies\", \"file_checked\": \"a.py\", \"property_proven\": true, \"inaccuracy_scope\": \"generated_claim_text\"}\n```"
+    }
+  ]
+}

--- a/lib/test/normalize-verdicts-test.py
+++ b/lib/test/normalize-verdicts-test.py
@@ -321,9 +321,6 @@ check("containment control: mutant writes a real traceback to stderr",
       "Traceback" in _r2.stderr and "helper defect" in _r2.stderr, repr(_r2.stderr[:120]))
 
 # --- issue_acceptance is never normalization-eligible ----------------------------
-# An issue_acceptance item satisfies conjuncts 1 and 2 structurally (agent mode,
-# generated_paraphrase provenance), so only the verifier's self-reported aux fields
-# would stand between a raw FAIL on an acceptance criterion and a stored PASS.
 o,_=run("category-issue-acceptance.json")
 r=res0(o)
 check("issue_acceptance FAIL is not normalized",
@@ -335,6 +332,20 @@ o,_=run("category-non-acceptance.json")
 r=res0(o)
 check("non-acceptance category still normalizes",
       r["normalized"] and r["verdict"]=="PASS" and r["raw_verdict"]=="FAIL", str(r))
+
+# The guard belongs in real_blockers, not field_defect_blockers: an issue_acceptance
+# item carrying an aux defect must stay off both the field-defect tally and the
+# auxiliary re-ask, which a field_defect_blockers placement would silently restore.
+o,_=run("category-issue-acceptance-aux-defect.json")
+r=res0(o)
+check("issue_acceptance + aux defect not normalized",
+      not r["normalized"] and r["verdict"]=="FAIL" and r["raw_verdict"]=="FAIL", str(r))
+check("issue_acceptance + aux defect is not a field-defect fail",
+      o["counts"]["field_defect_fail_count"]==0, str(o["counts"]))
+check("issue_acceptance + aux defect is not re-dispatched",
+      not o["needs_retry"], str(o["needs_retry"]))
+check("issue_acceptance + aux defect still stamps the auxiliary defect",
+      r.get("defect")=="aux:property_proven" and r.get("defect_class")=="auxiliary", str(r))
 
 print("\nFAILURES:", fails if fails else "NONE")
 sys.exit(1 if fails else 0)

--- a/lib/test/normalize-verdicts-test.py
+++ b/lib/test/normalize-verdicts-test.py
@@ -320,5 +320,21 @@ check("containment control: helper defect is not routed to the verifier-retry ch
 check("containment control: mutant writes a real traceback to stderr",
       "Traceback" in _r2.stderr and "helper defect" in _r2.stderr, repr(_r2.stderr[:120]))
 
+# --- issue_acceptance is never normalization-eligible ----------------------------
+# An issue_acceptance item satisfies conjuncts 1 and 2 structurally (agent mode,
+# generated_paraphrase provenance), so only the verifier's self-reported aux fields
+# would stand between a raw FAIL on an acceptance criterion and a stored PASS.
+o,_=run("category-issue-acceptance.json")
+r=res0(o)
+check("issue_acceptance FAIL is not normalized",
+      not r["normalized"] and r["verdict"]=="FAIL" and r["raw_verdict"]=="FAIL", str(r))
+check("issue_acceptance is not a field-defect fail", o["counts"]["field_defect_fail_count"]==0)
+check("issue_acceptance normalized_count is 0", o["counts"]["normalized_count"]==0)
+
+o,_=run("category-non-acceptance.json")
+r=res0(o)
+check("non-acceptance category still normalizes",
+      r["normalized"] and r["verdict"]=="PASS" and r["raw_verdict"]=="FAIL", str(r))
+
 print("\nFAILURES:", fails if fails else "NONE")
 sys.exit(1 if fails else 0)

--- a/scripts/normalize-verdicts.py
+++ b/scripts/normalize-verdicts.py
@@ -95,6 +95,11 @@ when ALL hold: (1) ``verification_mode == "agent"``; (2)
 ``inaccuracy_scope == "generated_claim_text"``. No malformed shape of any class
 ever resolves to a stored PASS.
 
+An item whose ``category`` is ``issue_acceptance`` is additionally never
+normalization-eligible: such items satisfy conjuncts (1) and (2) structurally, so
+only the verifier's own self-reported auxiliary fields would stand between a raw
+FAIL on an acceptance criterion and a stored PASS.
+
 Exit codes:
     0  Helper ran (results OR bad-input report printed).
     1  Unsupported Python (< 3.11).
@@ -366,6 +371,8 @@ def _process_pair(pair):
     field_defect_blockers = []
     if mode != "agent":
         real_blockers.append("not agent")
+    if item.get("category") == "issue_acceptance":
+        real_blockers.append("issue_acceptance category")
     if provenance != "generated_paraphrase":
         if provenance == "source_authored":
             real_blockers.append("source_authored provenance")


### PR DESCRIPTION
## The silent failure

`scripts/normalize-verdicts.py`'s `_process_pair` computes a five-conjunct predicate that converts a raw `FAIL` verdict into a **stored `PASS`**:

```python
can_normalize = raw == "FAIL" and not real_blockers and not field_defect_blockers
```

The conjuncts are (1) `verification_mode == "agent"`; (2) `claim_provenance == "generated_paraphrase"`; (3) raw verdict byte-exact `FAIL`; (4) `property_proven` is JSON boolean `true`; (5) `inaccuracy_scope == "generated_claim_text"`.

An `issue_acceptance` checklist item satisfies conjuncts (1) and (2) **structurally**, not by coincidence:

- `agents/checklist-generator.md` lists `issue_acceptance` among the enumeration categories whose default `claim_provenance` is `generated_paraphrase`.
- `lite` mode is permitted only when `category` is `api_contract` or `string_presence`, so an `issue_acceptance` item always runs in `agent` mode.

That leaves only the verifier's own **self-reported** `property_proven` / `inaccuracy_scope` fields between a raw FAIL on an acceptance criterion and a stored PASS. A verifier that read a single diff site cannot legitimately have proven such a property, yet nothing prevented it from emitting `property_proven: true` + `inaccuracy_scope: "generated_claim_text"`. The FAIL was then silently stored as PASS, and Phase 4.2 rule 1 never saw it.

The normalization stays correct for its intended case — a genuine wording artifact over code the verifier positively established. It is unsafe for an acceptance criterion.

## The fix

Two lines in `_process_pair`, adding the category to the **real-value** blocker set (not the field-defect set, so it does not route to a field-completion re-ask):

```python
if item.get("category") == "issue_acceptance":
    real_blockers.append("issue_acceptance category")
```

Plus the matching paragraph in the module docstring, which enumerates the normalization predicate.

The spike also floats a narrower `criterion_scope == "universal"` variant. **That field does not exist**, so this ships the category form, which protects the current path today.

## Tests

Two unit cases in the existing `lib/test/normalize-verdicts-test.py` (driven by `run.sh`'s `#556` block), over two new fixtures:

- `category-issue-acceptance.json` — an `issue_acceptance` item with all five conjuncts otherwise satisfied stays `FAIL`, is not `normalized`, `normalized_count == 0`, and is **not** counted as a field-defect fail.
- `category-non-acceptance.json` — a `dependency_interaction` item with the identical five conjuncts still normalizes to `PASS` (the intended case is unbroken).

Written RED first: against the unmodified helper the `issue_acceptance` fixture reported `verdict: PASS, normalized: true`, and both assertions failed. Green after the fix, with the non-acceptance control passing throughout. `ruff check` over all tracked `.py` is clean.

## Provenance

Came out of the "Normalization hazard" section of the spike document in PR #1789 (`docs/internal/universal-criteria-grading-spike.md`). **No issue was filed** — this was scoped as a small, self-contained direct change.
