### PR TITLE
Capture the implement context instrument's real-corpus snapshot and reconcile the pages that disagree about it

### DIFF
--- a/docs/internal/implement-context.md
+++ b/docs/internal/implement-context.md
@@ -111,12 +111,9 @@ resume-precheck/Signals/creation/Verdict-B procedure out of `phase-1-setup.md` i
 dispatched `branch-setup` subagent, following #1576's earlier move of Phase 1.6's
 Issue-Claim Audit procedure into `issue-claim-auditor`). These are on-disk `wc -c` byte
 counts, quoted in KiB. They rot as the phase files change; re-derive them rather than
-trusting these numbers.
-
-**The phase-file set has grown from four files to eight since this table was taken** —
-issue #1606 split Phases 2 and 3 into ordered sets — so the four rows below are the set as
-it stood at `2c85a931d`, not today's. The table is a frozen record and is deliberately not
-re-rendered; re-derive today's figures with the command beneath it.
+trusting these numbers. **The phase-file set has since grown from four files to eight** —
+issue #1606 gave Phases 2 and 3 the three-member sets described above — so the four rows
+below are that set as it stood, not today's.
 
 | file | bytes | KiB | loader |
 |---|---|---|---|
@@ -316,17 +313,16 @@ run over 200K, and a phase-3 re-entry); they are **not** a measurement of any re
 
 The corpus that produced these figures lives only on the maintainer's machine, so
 **no CI check can re-derive them**. They are a documented past-time snapshot, stamped
-with provenance, and are **never** presented as a live-generated figure. No gate,
-ceiling, or threshold reads them; the snapshot's integrity rests on its stamped
-provenance alone.
+with provenance, and no gate, ceiling, or threshold reads them.
 
 | Field | Value |
 | --- | --- |
 | Generating instrument | `scripts/implement-context-eval.py` |
 | Generating revision | `cccf0e5f7038c5e5460383ce3c7bdd962b3e21a7` |
 | Capture date | 2026-08-25 |
-| Corpus size | 6,647 session transcripts from one local Claude Code account, yielding **148** bounded `/prflow:implement` runs |
-| Tier covered | local/interactive only (see *Cloud-tier runs are not measurable today* below) |
+| Corpus root | `~/.claude*/projects/**/*.jsonl` (one local account; the others were empty) |
+| Corpus size | 6,647 session transcripts, yielding **148** bounded `/prflow:implement` runs |
+| Tier covered | local/interactive only |
 | Median peak main-thread context | **138K** tokens |
 | Max peak main-thread context | **424K** tokens |
 | Runs exceeding 200K | **31** of 148 |
@@ -336,7 +332,7 @@ provenance alone.
 | Phase-file reads, corpus total | phase-1 157, phase-2 59, phase-3 23, phase-4 4 |
 | Median / max phase-file reads per run | **1** / **8** |
 | Median / max main-thread tool calls per run | **6** / **167** |
-| Turns with no `usage` object | **0** |
+| Turns with no `usage` object | **0** — a non-zero count would mean the peak figures rest on fewer turns than the run held |
 
 A later maintainer adds a second stamped record beneath this one rather than editing this
 one in place: re-rendering a past-time record overwrites the measurement and falsifies it.
@@ -347,16 +343,14 @@ Re-derive a real-corpus figure by pointing the instrument at a transcript direct
 python3 scripts/implement-context-eval.py <transcript-dir> --format json
 ```
 
-That is a different command from the fixture reproduction above, which runs against the
-committed synthetic corpus and re-derives nothing about a real run. The transcript directory
-is deliberately not named on this page: `lib/test/test_implement_context_eval.py` scans it
-against a fixed owner-identifying pattern set, so writing such a path in turns the suite red.
+Its transcript-directory operand is what separates it from the fixture reproduction above.
+Substitute the corpus root, not an absolute path: `lib/test/test_implement_context_eval.py`
+scans this page against a fixed owner-identifying pattern set, so a path naming a machine
+owner turns the suite red.
 
 **What the corpus shows.** Phase-1 reads dominate the corpus total, and the per-run
-distribution is heavily skewed — a median run reads one phase file while the heaviest reads
-eight. The tail, not the median, is what the re-read multiplier costs: a median run peaks at
-138K while the heaviest reaches 424K. Compaction fired in 11 of 148 runs, so it is an
-observed local-tier event rather than a hypothetical one.
+distribution is heavily skewed. The tail, not the median, is what the re-read multiplier
+costs. Compaction is an observed local-tier event rather than a hypothetical one.
 
 **Cloud-tier runs are not measurable by this tool today.** `devflow-implement.yml` uploads
 its scrubbed transcript under a name ending `.json`, while the collector in

--- a/docs/internal/implement-context.md
+++ b/docs/internal/implement-context.md
@@ -91,9 +91,9 @@ rests on specific entry-gate text in `skills/implement/SKILL.md`, quoted here.
 routes every phase from that single statement. Since issue #1606 a phase routes to an
 **ordered set** of reference files rather than to one file, so the entry gate reads, verbatim:
 
-> **Each phase routes to an ordered SET of reference files, not to one file.** At the start
-> of **every** phase, before taking any action in it, `Read` every member of that phase's set
-> under `<skill-dir>/phases/`, in the order stated here, and follow them exactly …
+> Each phase routes to an ordered SET of reference files, not to one file. At the start of
+> every phase, before taking any action in it, `Read` every member of that phase's set under
+> `<skill-dir>/phases/`, in the order stated here, and follow them exactly:
 
 followed by a table pairing each phase with its ordered set. Phase 1 and Phase 4 hold one
 member each; Phases 2 and 3 hold three each.
@@ -112,6 +112,11 @@ dispatched `branch-setup` subagent, following #1576's earlier move of Phase 1.6'
 Issue-Claim Audit procedure into `issue-claim-auditor`). These are on-disk `wc -c` byte
 counts, quoted in KiB. They rot as the phase files change; re-derive them rather than
 trusting these numbers.
+
+**The phase-file set has grown from four files to eight since this table was taken** —
+issue #1606 split Phases 2 and 3 into ordered sets — so the four rows below are the set as
+it stood at `2c85a931d`, not today's. The table is a frozen record and is deliberately not
+re-rendered; re-derive today's figures with the command beneath it.
 
 | file | bytes | KiB | loader |
 |---|---|---|---|
@@ -141,15 +146,15 @@ sum of ~381 KiB — the sum being the figure the framing above gets wrong.
 
 The same single entry-gate statement continues, verbatim:
 
-> These reads are required **on every entry** — including a resumed or re-entrant run that
+> These reads are required on every entry — including a resumed or re-entrant run that
 > picks up at a later phase — never relying on a read from an earlier phase or session.
 
 and `skills/implement/SKILL.md`'s **Mid-phase re-anchor after a Skill-tool return**
 rule adds, verbatim (since issue #1876 scoped it to the displaced member):
 
 > after **every** Skill-tool return mid-phase — `simplify`, `review-and-fix`, or any
-> other — read it back (`workpad.py resume-point`), re-`Read` **only the one member of
-> the reference set under `<skill-dir>/phases/` holding it**, and resume …
+> other — read it back (`workpad.py resume-point`), re-`Read` only the one member of the
+> reference set under `<skill-dir>/phases/` holding it, and resume …
 
 So a run that bounces through Phase 3's fix loop pays for Phase 3's whole file set again on
 every pass, and a run that calls out to a nested skill and returns pays for only the one
@@ -307,11 +312,53 @@ the sidechain exclusion, phase-file basename matching including a vendored path,
 run over 200K, and a phase-3 re-entry); they are **not** a measurement of any real
 `/prflow:implement` run.
 
-### Real corpus snapshot (maintainer measurement obligation — UNFILLED)
+### Real corpus snapshot (documented past-time snapshot — NOT live)
 
-No real-corpus snapshot has been captured yet. When a maintainer captures one, record it
-here stamped with its provenance — the generating revision, the capture date, and the
-corpus size (run count) — and mark it clearly as a **past-time snapshot**, not a live
-figure, exactly as `docs/internal/create-issue-context.md`'s "Corpus-derived headline
-snapshot" section does. Re-derive any figure with the command above rather than trusting a copied
-number; a figure a reader treats as current rots the moment the measured thing changes.
+The corpus that produced these figures lives only on the maintainer's machine, so
+**no CI check can re-derive them**. They are a documented past-time snapshot, stamped
+with provenance, and are **never** presented as a live-generated figure. No gate,
+ceiling, or threshold reads them; the snapshot's integrity rests on its stamped
+provenance alone.
+
+| Field | Value |
+| --- | --- |
+| Generating instrument | `scripts/implement-context-eval.py` |
+| Generating revision | `cccf0e5f7038c5e5460383ce3c7bdd962b3e21a7` |
+| Capture date | 2026-08-25 |
+| Corpus size | 6,647 session transcripts from one local Claude Code account, yielding **148** bounded `/prflow:implement` runs |
+| Tier covered | local/interactive only (see *Cloud-tier runs are not measurable today* below) |
+| Median peak main-thread context | **138K** tokens |
+| Max peak main-thread context | **424K** tokens |
+| Runs exceeding 200K | **31** of 148 |
+| Runs exceeding 400K | **1** of 148 |
+| `compact_boundary` events | **13** across **11** of 148 runs |
+| Median / max turns per run | **13** / **255** |
+| Phase-file reads, corpus total | phase-1 157, phase-2 59, phase-3 23, phase-4 4 |
+| Median / max phase-file reads per run | **1** / **8** |
+| Median / max main-thread tool calls per run | **6** / **167** |
+| Turns with no `usage` object | **0** |
+
+A later maintainer adds a second stamped record beneath this one rather than editing this
+one in place: re-rendering a past-time record overwrites the measurement and falsifies it.
+
+Re-derive a real-corpus figure by pointing the instrument at a transcript directory:
+
+```
+python3 scripts/implement-context-eval.py <transcript-dir> --format json
+```
+
+That is a different command from the fixture reproduction above, which runs against the
+committed synthetic corpus and re-derives nothing about a real run. No transcript path is
+recorded here: `lib/test/test_implement_context_eval.py` scans this page for owner-identifying
+path shapes, so writing one in turns the suite red.
+
+**What the corpus shows.** Phase-1 reads dominate the corpus total, and the per-run
+distribution is heavily skewed — a median run reads one phase file while the heaviest reads
+eight. The tail, not the median, is what the re-read multiplier costs: a median run peaks at
+138K while the heaviest reaches 424K. Compaction fired in 11 of 148 runs, so it is an
+observed local-tier event rather than a hypothetical one.
+
+**Cloud-tier runs are not measurable by this tool today.** `devflow-implement.yml` uploads
+its scrubbed transcript under a name ending `.json`, while the collector in
+`scripts/context_eval_shared.py` accepts only names ending `.jsonl` — so a cloud transcript
+is skipped with no error at all, and the corpus above is local/interactive by construction.

--- a/docs/internal/implement-context.md
+++ b/docs/internal/implement-context.md
@@ -348,9 +348,9 @@ python3 scripts/implement-context-eval.py <transcript-dir> --format json
 ```
 
 That is a different command from the fixture reproduction above, which runs against the
-committed synthetic corpus and re-derives nothing about a real run. No transcript path is
-recorded here: `lib/test/test_implement_context_eval.py` scans this page for owner-identifying
-path shapes, so writing one in turns the suite red.
+committed synthetic corpus and re-derives nothing about a real run. The transcript directory
+is deliberately not named on this page: `lib/test/test_implement_context_eval.py` scans it
+against a fixed owner-identifying pattern set, so writing such a path in turns the suite red.
 
 **What the corpus shows.** Phase-1 reads dominate the corpus total, and the per-run
 distribution is heavily skewed — a median run reads one phase file while the heaviest reads

--- a/docs/internal/implement-context.md
+++ b/docs/internal/implement-context.md
@@ -320,15 +320,15 @@ with provenance, and no gate, ceiling, or threshold reads them.
 | Generating instrument | `scripts/implement-context-eval.py` |
 | Generating revision | `cccf0e5f7038c5e5460383ce3c7bdd962b3e21a7` |
 | Capture date | 2026-08-25 |
-| Corpus root | one local Claude Code account's `~/.claude*/projects` directory, passed whole (the sibling accounts' held no transcripts); the tool walks it and selects the `*.jsonl` members itself |
+| Corpus root | one local Claude Code account's `~/.claude*/projects` directory, passed whole (the sibling accounts held no transcripts); the tool walks it and selects the `*.jsonl` members itself |
 | Corpus size | 6,647 session transcripts, yielding **148** bounded `/prflow:implement` runs |
 | Tier covered | local/interactive only |
 | Median peak main-thread context | **138K** tokens |
 | Max peak main-thread context | **424K** tokens |
 | Runs exceeding 200K | **31** of 148 |
 | Runs exceeding 400K | **1** of 148 |
-| `compact_boundary` events | **13** across **11** of 148 runs |
-| Median / max turns per run | **13** / **255** |
+| `compact_boundary` events (hand-aggregated) | **13** across **11** of 148 runs |
+| Median / max turns per run (hand-aggregated) | **13** / **255** |
 | Phase-file reads, corpus total | phase-1 157, phase-2 59, phase-3 23, phase-4 4 |
 | Median / max phase-file reads per run | **1** / **8** |
 | Median / max main-thread tool calls per run | **6** / **167** |
@@ -360,7 +360,7 @@ its scrubbed transcript under a name ending `.json`, while the collector in
 is skipped with no error at all, and the corpus above is local/interactive by construction.
 The drop is untallied, so a corpus of wrong-suffixed files reports zero runs and exits 0
 rather than saying anything was skipped — and a mixed corpus silently under-counts by
-however many of its transcripts carry the other suffix. Renaming the artifact would not be enough on its
-own: `scripts/scrub-transcript.sh` prepends a `#`-comment caveat header to it, and
+however many of its transcripts carry the other suffix. Renaming the artifact would not be
+enough on its own: `scripts/scrub-transcript.sh` prepends a `#`-comment caveat header to it, and
 `scripts/extract-execution-cost.py` records its observed shapes as a single object, a JSON
 array, or JSONL — so the suffix is the first barrier, not the only one.

--- a/docs/internal/implement-context.md
+++ b/docs/internal/implement-context.md
@@ -320,7 +320,7 @@ with provenance, and no gate, ceiling, or threshold reads them.
 | Generating instrument | `scripts/implement-context-eval.py` |
 | Generating revision | `cccf0e5f7038c5e5460383ce3c7bdd962b3e21a7` |
 | Capture date | 2026-08-25 |
-| Corpus root | the `projects/` directory of one local Claude Code account (the sibling accounts' were empty); the tool walks it and selects the `*.jsonl` members itself |
+| Corpus root | one local Claude Code account's `~/.claude*/projects` directory, passed whole (the sibling accounts' held no transcripts); the tool walks it and selects the `*.jsonl` members itself |
 | Corpus size | 6,647 session transcripts, yielding **148** bounded `/prflow:implement` runs |
 | Tier covered | local/interactive only |
 | Median peak main-thread context | **138K** tokens |
@@ -346,7 +346,7 @@ python3 scripts/implement-context-eval.py <transcript-dir> --format json
 The command shape is identical to the fixture reproduction above; what differs is the
 directory it is pointed at — a real transcript corpus rather than the committed synthetic
 one. The operand must be a directory the tool can walk, not a glob. The corpus directory is
-deliberately not written on this page: `lib/test/test_implement_context_eval.py` scans it
+deliberately not written out here: `lib/test/test_implement_context_eval.py` scans this page
 against a fixed owner-identifying pattern set, so a path naming a machine owner turns the
 suite red.
 
@@ -358,6 +358,8 @@ costs. Compaction is an observed local-tier event rather than a hypothetical one
 its scrubbed transcript under a name ending `.json`, while the collector in
 `scripts/context_eval_shared.py` accepts only names ending `.jsonl` — so a cloud transcript
 is skipped with no error at all, and the corpus above is local/interactive by construction.
-The barrier is the suffix alone, and the drop is untallied: a renamed copy of the same
-artifact collects normally, which is how a maintainer took cloud figures by hand before this
-snapshot, and a corpus of wrong-suffixed files reports zero runs and exits 0.
+The drop is untallied, so a corpus of wrong-suffixed files reports zero runs and exits 0
+rather than saying anything was skipped. Renaming the artifact would not be enough on its
+own: `scripts/scrub-transcript.sh` prepends a `#`-comment caveat header to it, and
+`scripts/extract-execution-cost.py` records its observed shapes as a single object, a JSON
+array, or JSONL — so the suffix is the first barrier, not the only one.

--- a/docs/internal/implement-context.md
+++ b/docs/internal/implement-context.md
@@ -345,8 +345,8 @@ python3 scripts/implement-context-eval.py <transcript-dir> --format json
 
 The command shape is identical to the fixture reproduction above; what differs is the
 directory it is pointed at — a real transcript corpus rather than the committed synthetic
-one. The operand must be a directory the tool can walk, not a glob. The corpus directory is
-deliberately not written out here: `lib/test/test_implement_context_eval.py` scans this page
+one. The operand must be a directory the tool can walk, not a glob. The absolute corpus path
+is deliberately not written out here: `lib/test/test_implement_context_eval.py` scans this page
 against a fixed owner-identifying pattern set, so a path naming a machine owner turns the
 suite red.
 
@@ -359,7 +359,8 @@ its scrubbed transcript under a name ending `.json`, while the collector in
 `scripts/context_eval_shared.py` accepts only names ending `.jsonl` — so a cloud transcript
 is skipped with no error at all, and the corpus above is local/interactive by construction.
 The drop is untallied, so a corpus of wrong-suffixed files reports zero runs and exits 0
-rather than saying anything was skipped. Renaming the artifact would not be enough on its
+rather than saying anything was skipped — and a mixed corpus silently under-counts by
+however many of its transcripts carry the other suffix. Renaming the artifact would not be enough on its
 own: `scripts/scrub-transcript.sh` prepends a `#`-comment caveat header to it, and
 `scripts/extract-execution-cost.py` records its observed shapes as a single object, a JSON
 array, or JSONL — so the suffix is the first barrier, not the only one.

--- a/docs/internal/implement-context.md
+++ b/docs/internal/implement-context.md
@@ -320,7 +320,7 @@ with provenance, and no gate, ceiling, or threshold reads them.
 | Generating instrument | `scripts/implement-context-eval.py` |
 | Generating revision | `cccf0e5f7038c5e5460383ce3c7bdd962b3e21a7` |
 | Capture date | 2026-08-25 |
-| Corpus root | `~/.claude*/projects/**/*.jsonl` (one local account; the others were empty) |
+| Corpus root | the `projects/` directory of one local Claude Code account (the sibling accounts' were empty); the tool walks it and selects the `*.jsonl` members itself |
 | Corpus size | 6,647 session transcripts, yielding **148** bounded `/prflow:implement` runs |
 | Tier covered | local/interactive only |
 | Median peak main-thread context | **138K** tokens |
@@ -343,10 +343,12 @@ Re-derive a real-corpus figure by pointing the instrument at a transcript direct
 python3 scripts/implement-context-eval.py <transcript-dir> --format json
 ```
 
-Its transcript-directory operand is what separates it from the fixture reproduction above.
-Substitute the corpus root, not an absolute path: `lib/test/test_implement_context_eval.py`
-scans this page against a fixed owner-identifying pattern set, so a path naming a machine
-owner turns the suite red.
+The command shape is identical to the fixture reproduction above; what differs is the
+directory it is pointed at — a real transcript corpus rather than the committed synthetic
+one. The operand must be a directory the tool can walk, not a glob. The corpus directory is
+deliberately not written on this page: `lib/test/test_implement_context_eval.py` scans it
+against a fixed owner-identifying pattern set, so a path naming a machine owner turns the
+suite red.
 
 **What the corpus shows.** Phase-1 reads dominate the corpus total, and the per-run
 distribution is heavily skewed. The tail, not the median, is what the re-read multiplier
@@ -356,3 +358,6 @@ costs. Compaction is an observed local-tier event rather than a hypothetical one
 its scrubbed transcript under a name ending `.json`, while the collector in
 `scripts/context_eval_shared.py` accepts only names ending `.jsonl` — so a cloud transcript
 is skipped with no error at all, and the corpus above is local/interactive by construction.
+The barrier is the suffix alone, and the drop is untallied: a renamed copy of the same
+artifact collects normally, which is how a maintainer took cloud figures by hand before this
+snapshot, and a corpus of wrong-suffixed files reports zero runs and exits 0.

--- a/docs/internal/improvement-loops/runtime-evaluations.md
+++ b/docs/internal/improvement-loops/runtime-evaluations.md
@@ -21,7 +21,7 @@ Prompt size, delivered context, and model behavior are related but not identical
 
 ## Source of truth
 
-- `scripts/create-issue-context-eval.py` and `scripts/implement-context-eval.py` — legacy context instruments; `scripts.create_issue_eval` also owns run-addressable manifest analysis and formal grading.
+- `scripts/create-issue-context-eval.py` and `scripts/implement-context-eval.py` — context instruments; `scripts.create_issue_eval` also owns run-addressable manifest analysis and formal grading.
 - `scripts/create-issue-benchmark.py` — provider-neutral paired execution, statistical reporting, and anonymized review export.
 - `scripts/workflow_flight_recorder.py` — transcript and workflow evidence.
 - `scripts/prompt-surface-growth.py` — prompt-surface measurement.

--- a/docs/internal/improvement-loops/runtime-evaluations.md
+++ b/docs/internal/improvement-loops/runtime-evaluations.md
@@ -18,6 +18,11 @@ Prompt size, delivered context, and model behavior are related but not identical
 - A self-report is weaker evidence than a harness-recorded event.
 - A measurement over one tier, runner, or corpus does not establish behavior for every tier or future corpus.
 - An absent transcript or corpus is reported as unavailable rather than measured as zero.
+- That guarantee covers a corpus the instrument reads, not one it never selects. The shared
+  collector in `scripts/context_eval_shared.py` walks a corpus root and keeps only names ending
+  `.jsonl`; every other name is dropped with no tally and no breadcrumb. So a corpus of
+  wrong-suffixed transcripts yields a run count of zero and exit status 0, and a mixed corpus
+  under-counts silently. Confirm the suffix before reading a zero as an empty corpus.
 
 ## Source of truth
 


### PR DESCRIPTION
<!-- PR_BODY_START -->
## Summary
- Stamps the real-corpus measurement that `docs/internal/implement-context.md` had been declaring unfilled, so the page now carries a past-time snapshot of 148 bounded local-tier `/prflow:implement` runs instead of an open obligation.
- Reconciles the two pages that disagreed about where that measurement record stands: the tracked page holds the record, and the untracked private page now carries its own stamped provenance instead of pointing outward for it.
- Clears three residual defects in the tracked page (an ambiguous "the command above", a frozen four-file byte table a reader takes as current, and a blockquote that added emphasis its source does not carry) and drops the word "legacy" from the one page describing the instrument that way.

## Changes

**`docs/internal/implement-context.md`**: The "Real corpus snapshot" section is retitled from "maintainer measurement obligation — UNFILLED" to "documented past-time snapshot — NOT live" and now holds a stamped field table — generating instrument, generating revision as a full 40-character commit id, capture date, corpus root description, corpus size in runs, tier covered, and the measured distribution figures. The section states plainly that the corpus lives only on the maintainer's machine and that no CI check can re-derive the figures, names the re-derivation command explicitly (`python3 scripts/implement-context-eval.py <transcript-dir> --format json`) rather than saying "the command above", and records that cloud-tier runs are not measurable today, naming the file-suffix mismatch as the reason. The frozen phase-file byte table gains a bridging note that the phase-file set has grown from four files to eight since the table was taken; the table's own numbers are unchanged. Two entry-gate blockquotes and the mid-phase re-anchor blockquote lose bold emphasis their source sentences in `skills/implement/SKILL.md` do not carry.

**`docs/internal/improvement-loops/runtime-evaluations.md`**: Drops "legacy" from the line describing `scripts/create-issue-context-eval.py` and `scripts/implement-context-eval.py`, since no retirement of either is under way. Adds an evidence-discipline bullet qualifying the existing "an absent corpus is reported as unavailable rather than measured as zero" guarantee: it covers a corpus the instrument reads, not one it never selects.

**`docs/internal/agent-context-economics.private.md` (untracked — carried by no commit in this PR)**: This file matches the `*.private.md` rule in `.gitignore`, so it is untracked, was edited only in the maintainer's local checkout, and appears in **no commit and no diff on this branch** — a reviewer cannot see the edit here. Stating that plainly rather than leaving it invisible is an explicit instruction of issue #1836. The edit gives the page its own stamped provenance beside its own two figures (instrument, revision `9ad8406f4`, capture date 2026-08-10, and a statement that they were computed before #1899 changed how an unmeasured turn is reported) and removes the sentence asserting that the warrant for those figures lives in `docs/internal/implement-context.md`. Its two figure tables are unchanged.

## Resolves
Resolves #1836

## Test Plan
- [x] `lib/test/test_implement_context_eval.py` passes after the change — 66 tests, OK. This PR authors **no test**; the file is pre-existing and unmodified here, run as a gate. Its owner-identifier scan over `docs/internal/implement-context.md` is the residual risk this change could have tripped (a corpus path naming a machine owner in the page), and it stays clean.
- [ ] Read the "Real corpus snapshot" section and the private page's "Measured snapshots" section and confirm they make the same claim about where the implement-run measurement record stands.
- [ ] Confirm the two figure tables in the private page and the phase-file byte table in `docs/internal/implement-context.md` carry the same numbers after the change as before it.
- [ ] Diff each retouched blockquote against its source sentence in `skills/implement/SKILL.md` and confirm a character-for-character match including emphasis.

## Verification notes
Claims in this body were checked against the artifact rather than against the run's narration:
- The `.jsonl`-only selection the cloud-tier paragraph blames is real: `scripts/context_eval_shared.py`'s corpus walk skips every name not ending `.jsonl`, with no tally and no breadcrumb; `.github/workflows/devflow-implement.yml` writes its scrubbed transcript as `claude-execution-scrubbed.json`.
- The generating revision stamped in the new table is this branch's merge base, `cccf0e5f7038c5e5460383ce3c7bdd962b3e21a7`.
- The diff contains **no test changes and no code changes** — two internal documentation pages only.

## Prompt-surface size
```
prompt-surface growth: no tracked `*.md` under `skills/`, `agents/`, or `.prflow/prompt-extensions/` changed between `cccf0e5f7038c5e5460383ce3c7bdd962b3e21a7` and `079196626119f732a671c3bf491a595cdb79dcff` — no table rendered.
```

## Visual Changes
N/A

## Breaking Changes
None

<!-- PR_BODY_END -->

_Generated via /prflow:implement (v2.34.13, claude-opus-5, low)_
