### PR TITLE
docs: convention for claims about a moving tree (#1322)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -801,6 +801,12 @@ fails the suite. The summary renderer lives in `lib/test/summary.sh`.
   in a skill (the cloud-tier *workflows* are the one exception — see below).
 - **Portability:** avoid GNU-only flags. Use `python3` for date math (not `date -d`)
   and ERE / `sed -E` (not `grep -P`).
+- **A present-tense claim about a moving tree carries a date or names the run/artifact
+  that would settle it — never asserted bare (issue #1322).** A "pending" measurement
+  cell or a "currently X" assertion in internal docs goes stale silently the moment the
+  tree moves, and a reader acting on a stale "pending" cell pays to re-obtain evidence
+  that already exists. Write "PENDING as of 2026-08-25" or "PENDING run NNN", never a
+  bare "PENDING".
 - **Windows / non-UTF-8 hosts.** The helpers self-defend at two layers: a committed
   `.gitattributes` pins every `*.sh`/`*.py`/`*.jq` to `eol=lf` on checkout (so
   `core.autocrlf=true` can't turn a shebang into `bash\r`), and every first-party

--- a/docs/internal/cloud-allowlist.md
+++ b/docs/internal/cloud-allowlist.md
@@ -249,8 +249,8 @@ them read as though they did (issue #871):
 
 - the **Write tool** into `.prflow/tmp/**` (granted in the review profile) —
   **PERMITTED, run 29111394360** (probe shape 9). This is the *orchestrator* grant; the two
-  `PENDING` **dispatched-subagent** `Write` entries further down this file (issue #858,
-  review and implement tiers) are a separate measurement and do not qualify it.
+  **dispatched-subagent** `Write` entries further down this file (issue #858, review and
+  implement tiers; since MEASURED PERMITTED) are a separate measurement and do not qualify it.
 - `… | tee` — probe shape 10; **no per-row verdict is transcribed** in this file.
 - `tee <<'EOF'` — probe shape 6; **no per-row verdict is transcribed** in this file.
 - repo-relative **vendored-literal** helper paths — the **leading-token** form is


### PR DESCRIPTION
## Summary

- **CONTRIBUTING.md** — adds a Conventions bullet: a present-tense claim about a moving tree in internal docs (a "pending" measurement cell, a "currently X" assertion) must carry a date or name the run/artifact that would settle it, never be asserted bare.
- **docs/internal/cloud-allowlist.md** — fixes a stale cross-reference that still called the two issue-#858 dispatched-subagent `Write` entries PENDING; both now read MEASURED PERMITTED, and the sentence keeps its point (a separate measurement that does not qualify the orchestrator grant).

This lands the convention half of issue #1322. The issue's blocked mechanised-check half is being dropped per the #434 stale-prose-lint precedent (zero true positives over 60 PRs, retired in #1749).

Closes nothing automatically — issue #1322 is being closed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)