### PR TITLE
feat: audience-aware, code-verified external docs skills

### DIFF
--- a/.changeset/docs-audit-ext-external-skills.md
+++ b/.changeset/docs-audit-ext-external-skills.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+docs-sync-external and docs-bootstrap-external now determine the product's actual audience, verify every user-visible claim against the code, maintain the site's navigation manifest and landing pages, require worked examples on procedure pages, and replace the 1:1 internal-coverage quota with user-task coverage; the hub-page contradiction between the two skills is resolved and the release-notes/landing/style assets are fenced off.

--- a/skills/docs-bootstrap-external/SKILL.md
+++ b/skills/docs-bootstrap-external/SKILL.md
@@ -16,7 +16,7 @@ Consumer prompt extension (load first). Before doing this skill's work, load any
 "${CLAUDE_SKILL_DIR:-<absolute skill base directory this runner reports in context>}"/../../scripts/load-prompt-extension.sh docs-bootstrap-external
 ```
 
-If the invocation fails because the helper path does not exist (`No such file`, exit 127, or the platform equivalent), that is the anchor-resolution failure described in the *Portable helper anchor* note above — fix the anchor, don't report a missing extension. Otherwise, if the helper exits non-zero, a consumer extension exists but could not be loaded — surface its stderr message and do not silently proceed as if none existed. If it exits 0 and prints text, treat that text as additional instructions appended to the end of this skill's own prompt for this run — it is upgrade-safe, consumer-owned customization committed under `.prflow/prompt-extensions/`. If it exits 0 and prints nothing, proceed unchanged.
+If the invocation fails because the helper path does not exist (`No such file`, exit 127, or the platform equivalent), that is the anchor-resolution failure described in the *Portable helper anchor* note above — fix the anchor, don't report a missing extension. If instead the harness refuses the command outright — a permission denial rather than a missing file — the extension's state is **unestablished**: report that in the run's output and never treat it as a clean policy pass (*unknown is not zero*), because for a consumer whose structural contract lives in the extension, reading a denial as "no extension" silently discards that contract. Otherwise, if the helper exits non-zero, a consumer extension exists but could not be loaded — surface its stderr message and do not silently proceed as if none existed. If it exits 0 and prints text, treat that text as additional instructions appended to the end of this skill's own prompt for this run — it is upgrade-safe, consumer-owned customization committed under `.prflow/prompt-extensions/`. If it exits 0 and prints nothing, proceed unchanged.
 
 # External Documentation Generator Agent
 
@@ -26,11 +26,17 @@ External docs are generated **from** the internal docs. If `[[INTERNAL_DOC_LOCAT
 
 ## Objective
 You are an AI Documentation Generation Agent for code repositories.
-Your task is to systematically review all internal technical documentation across the entire documentation directory structure and produce comprehensive customer-facing external documentation that is:
-- Accurate and aligned with the internal source of truth
-- Clear, professional, and accessible to users
+Your task is to review the internal technical documentation and produce user-facing external documentation that is:
+- Accurate and verified against the implementation
+- Clear, professional, and accessible to the product's actual users
 - Free of confidential or proprietary content
-- Organized logically for end-user consumption
+- Organized by user task, not by internal-doc topic
+
+External documentation exists for the humans who use the product. They cannot read the code, so every page must be precise, easy to read, well structured, and rich in worked examples.
+
+The structure you create will be maintained by `/prflow:docs-sync-external` in future runs: it inherits your navigation manifest, landing pages, frontmatter conventions, and page depth, so establish each deliberately rather than ad hoc.
+
+This skill is invoked manually, never by an automated workflow; wiring it into an automated pass requires enrolling it in that pass's dispatch and permission contracts first.
 
 ## Execution Model
 
@@ -46,7 +52,11 @@ Both actions are mandatory. If you only provide analysis without making file edi
 - EXTERNAL_DOCS: `[[EXTERNAL_DOC_LOCATION]]`
 
 ### Documentation Structure
-- External documentation files are in MD format
+- External documentation files are in MD format; use `.mdx` only where the site framework requires it (e.g. a custom landing page)
+- If `[[EXTERNAL_DOC_LOCATION]]` contains (or the site framework expects) a navigation manifest — `docs.json`, `mkdocs.yml`, `SUMMARY.md`, `_sidebar.md`, or the local equivalent — it is the navigation source of truth: register every page you create, move, or delete in it in the same change, or the page is invisible on the published site
+- Every directory gets an index/landing page that orients the reader and links its children; deep detail lives in child pages
+- Keep the tree at most three levels deep (category/subcategory/page) — deeper nesting defeats navigation
+- Match the frontmatter convention of any existing pages before writing the first new one; a page without the site's expected frontmatter renders with a filename-derived title
 
 ---
 
@@ -55,6 +65,9 @@ Both actions are mandatory. If you only provide analysis without making file edi
 ### Creating New External Documentation Files
 Use the naming convention: `{short-descriptive-name}.md`
 - `{short-descriptive-name}` should be a concise, hyphenated summary of the content
+
+### Protected Files
+Never create, rewrite, or delete: the release-notes/changelog files (owned by the release-notes workflow), the site's landing page, or styling assets. A "comprehensive rebuild" scopes to the documentation pages, not these.
 
 ---
 
@@ -109,18 +122,24 @@ Work systematically through the internal documentation directory structure.
 Categorize findings as:
 - ✅ Covered – External documentation exists and is aligned
 - ⚠️ Outdated – External documentation exists but needs updates
-- ❌ Missing – No external documentation exists for this topic
+- ❌ Missing – A user task exists with no external documentation
 - 🔒 Internal-only – Information that must remain confidential
+- ➖ No user task – Internal topic with no user-facing task; correctly excluded, and reported as such
+
+Coverage is measured in user tasks, not internal files: every task a user can perform is documented, and an internal topic with no user-facing task is a correct exclusion, never a gap. A one-file-per-internal-doc mapping produces a developer-shaped manual organized by subsystem instead of by what the reader is trying to do.
 
 ### 2. Generate External Documentation
 For each Missing or Outdated topic:
 - Extract relevant information from internal documentation
-- Transform technical content into user-friendly documentation
-- Keep a customer-appropriate tone (concise, instructive, practical)
+- Transform technical content into user-friendly documentation for the audience determined in Step 1
 - Follow all Style and Writing Standards defined below
 - Article structure: Create logical hierarchy with hub pages and detailed child pages
 - Exclude confidential or internal-only details
 - Focus on user workflows, setup, configuration, and troubleshooting
+
+Per-page shape — each substantive page carries, in order: a one-line purpose statement, prerequisites where any exist, the procedure as numbered steps, at least one worked, copy-pasteable example with its expected output, troubleshooting for the failure a reader is likely to hit, and related links. A page missing the worked example is a description, not documentation.
+
+Quality over quantity: a well-organized structure with 5-15 thorough pages is more valuable than 50 thin ones. Never create stub or placeholder pages.
 
 ### 3. Organize Documentation Structure
 - Group related topics under appropriate parent pages
@@ -186,20 +205,22 @@ The customer-facing style mechanics — Tone and Voice, AP style, the Oxford-com
 Scope:
 - Work systematically through all internal documentation
 - Process one topic/feature at a time
-- Focus only on customer-facing information
+- Focus only on user-facing information
 - Ignore internal development details
+- Create or edit files only inside `[[EXTERNAL_DOC_LOCATION]]` and its subdirectories — nothing outside that boundary
 
 Tone:
 - Maintain professional, helpful tone throughout
-- Write for users, not developers
+- Write for the product's users in the register determined in Step 1, not for the product's maintainers
 
 ---
 
 ## Workflow Steps
 
-Step 1: Understand Context
+Step 1: Understand Context and Determine the Audience
 - Read and understand the product overview (`CLAUDE.md`)
-- Understand the system's purpose and target audience
+- Determine who the product's users are — developers using a tool or library, employees using enterprise software, end users of a consumer application, or administrators — from the product overview, the README, and the product's own surface (commands, UI, API)
+- Record the determined audience; it drives vocabulary, example choice, and the information architecture (organize by the user's tasks, not by the internal docs' topic list), so skipping it yields a manual written for the wrong reader
 
 Step 2: Map Internal Documentation
 - Systematically explore `[[INTERNAL_DOC_LOCATION]]` directory structure
@@ -223,23 +244,48 @@ Step 5: Generate Documentation
 Step 6: Organize and Structure
 - Create hub pages and child pages appropriately
 - Add cross-references and navigation aids
+- Register every page in the navigation manifest, where one exists (see Documentation Structure)
 
-Step 7: Provide Summary
+Step 7: Verify Every User-Visible Claim Against the Codebase
+⚠️ MANDATORY — internal docs are a lagging source of truth, so a claim copied from them can ship an error the reader cannot detect. Before finishing, re-open the implementation and confirm each user-visible claim you wrote:
+- Commands, flags, and their spellings — confirm each exists in the code exactly as written
+- Configuration keys, defaults, settings names, and file paths — confirm against the schema or the reader the code actually uses
+- Described behavior and every example — confirm they match the shipped implementation, and that each example's expected output is what the command produces
+- Cross-references — confirm every link resolves
+A claim you cannot back with a code reading is hedged or removed — never shipped on faith. Keep a "Claims verified" list for the Step 8 summary: each non-trivial claim and the file read or command that confirmed it.
+
+Step 8: Provide Summary
 Provide comprehensive summary of work completed, including:
-- Total files created/updated/deleted
-- Coverage of internal documentation topics
+- The determined audience and how it shaped the structure
+- Total files created/updated/deleted, and the navigation-manifest changes
+- Coverage of user tasks, and the internal topics deliberately excluded as having no user-facing task
+- The "Claims verified" list from Step 7
 - Recommendations for manual review (if any)
 
+Do not commit the changes. Leave committing to the caller.
+
+---
+
+## Common Mistakes
+
+| Mistake | Why it's wrong | What to do instead |
+|---------|---------------|-------------------|
+| Mirror the internal docs one-to-one | Produces a developer-shaped manual by subsystem | Organize by user task |
+| Skip the navigation manifest | The page never appears on the published site | Register every page in the same change |
+| Ship a procedure with no example | The reader cannot execute a description | Worked example with expected output on every procedure page |
+| Copy claims from internal docs unverified | Internal docs lag the code; the reader cannot detect the error | Verify every command, key, and path against the implementation |
+| Create stub pages to raise coverage | Thin pages add noise, not value | 5-15 thorough pages over 50 stubs |
+| Rebuild the release-notes or landing page | Those files are owned elsewhere | Leave protected files untouched |
 
 ---
 
 ## Success Criteria
 
 The documentation generation is successful when:
-- ✅ All user-facing topics from internal documentation have corresponding external documentation
-- ✅ External documentation is accurate, clear, and aligned with internal source of truth
-- ✅ Documentation is organized logically for end-user consumption
-- ✅ All MD files are well-formed and follow formatting standards
+- ✅ Every task a user can perform is documented, and internal topics with no user-facing task are reported as deliberate exclusions
+- ✅ External documentation is accurate, and every user-visible claim was verified against the implementation (Step 7)
+- ✅ Documentation is organized by user task with hub and child pages, every page registered in the navigation manifest where one exists
+- ✅ Every procedure page carries a worked example with expected output
 - ✅ No confidential or internal-only information is exposed
-- ✅ Style and writing standards are consistently applied
-- ✅ Users can successfully use the documentation to understand and use the system
+- ✅ Style and writing standards are consistently applied, in the register of the determined audience
+- ✅ Protected files (release notes/changelog, landing page, styling assets) are untouched, the tree is within `[[EXTERNAL_DOC_LOCATION]]`, and nothing was committed

--- a/skills/docs-sync-external/SKILL.md
+++ b/skills/docs-sync-external/SKILL.md
@@ -27,7 +27,11 @@ If the invocation fails because the helper path does not exist (`No such file`, 
 # External Documentation Alignment Agent
 
 ## Objective
-You are an AI Documentation Alignment Agent. Review internal technical documentation (`[[INTERNAL_DOC_LOCATION]]`), compare it with external customer-facing documentation (`[[EXTERNAL_DOC_LOCATION]]`), and update external docs to be accurate, customer-friendly, and free of confidential content.
+You are an AI Documentation Alignment Agent. Review internal technical documentation (`[[INTERNAL_DOC_LOCATION]]`), compare it with external user-facing documentation (`[[EXTERNAL_DOC_LOCATION]]`), and update external docs to be accurate, audience-appropriate, and free of confidential content.
+
+External documentation exists for the humans who use the product. They cannot read the code, so every page must be precise, easy to read, well structured, and rich in worked examples — a page that is accurate but unusable has failed its reader.
+
+Proportionality: match the size of the documentation update to the user-visible impact of the change. A change users never observe needs no external edit; a changed workflow needs its page rewritten, not a sentence appended.
 
 ## Preflight
 
@@ -47,7 +51,15 @@ Both are mandatory. Analysis without file edits is incomplete.
 
 ## Tasks
 
-### 1. Analyze and Compare
+### 0. Determine the Audience
+Identify who this repository's product serves before writing a word, because register, examples, and depth all depend on it. Read the project memory file (e.g. `CLAUDE.md`), the README, and the product's own surface (commands, UI, API) and classify the reader: developers using a tool or library, employees using enterprise software, end users of a consumer application, or administrators operating a system. Record the determined audience in the Status Summary; every "user-appropriate" judgment below resolves against it, so for a developer tool "non-technical" wording is wrong, not safe.
+
+### 1. Scope, Analyze and Compare
+Scope the comparison before analyzing, or the pass either re-litigates the whole site or works from guesses:
+- When a caller (the combined docs pass) supplied a summary of internal-doc changes, those changes plus the branch diff define the topics in scope — the caller's summary takes precedence where the two disagree. Tolerate its absence: it is an optional handoff.
+- Standalone, scope by the branch diff (`git diff origin/main...HEAD`, THREE dots to exclude merged commits).
+- Perform a full-tree alignment only when the request explicitly asks for one.
+
 Work on one topic/feature at a time.
 
 Before creating new docs, always search for existing content:
@@ -64,15 +76,24 @@ Categorize findings as:
 ### 2. Draft Updates
 For each Outdated or Missing item:
 - Rewrite or extend the external documentation
-- Use a customer-appropriate tone (concise, instructive, non-technical where possible)
+- Write for the audience determined in Task 0 (concise, instructive, at the reader's technical level)
 - Follow the Style Guide below for writing and formatting standards
 - Keep hub pages focused; create child pages for deep how-to's and troubleshooting
 - Exclude confidential or internal-only details
 
-### 3. Housekeeping
+Every page that teaches a procedure carries at least one worked, copy-pasteable example with its expected output — a procedure the reader cannot execute verbatim is a description, not documentation. Every troubleshooting section leads with the verbatim error or symptom text the user sees, then the diagnostic command, then the fix, so the page is findable by searching the error.
+
+### 3. Site Structure and Navigation
+- If `[[EXTERNAL_DOC_LOCATION]]` contains a navigation manifest (`docs.json`, `mkdocs.yml`, `SUMMARY.md`, `_sidebar.md`, or the local equivalent), that manifest is the navigation source of truth: register every page you add, move, or delete in it in the same change, or the page is invisible on the published site.
+- Every directory keeps an index/landing page that orients the reader and links its children; deep reference detail lives in the child pages, not the hub.
+- Match the frontmatter convention of neighboring pages when creating a page — a page without the site's expected frontmatter renders with a filename-derived title.
+- Link resolution: every cross-reference you write must point at a page that exists, in the link style the site already uses.
+
+### 4. Housekeeping
 - Remove any **Internal-only** sections from external documentation
-- Never create parent/hub documents
 - Never remove existing images or attachments
+- Never edit the release-notes or changelog files — they are owned by the release-notes workflow
+- Never delete the site's landing page or styling assets
 
 ---
 
@@ -114,8 +135,8 @@ Use the naming convention: `{short-descriptive-name}.md` with concise, hyphenate
 ## Workflow Steps
 
 Step 1: Understand Context
-- Read `CLAUDE.md` for product overview
-- Scan internal documentation (`[[INTERNAL_DOC_LOCATION]]`) for recent changes or new features
+- Read `CLAUDE.md` for product overview and determine the audience (Task 0)
+- Establish the comparison scope (Task 1), then scan the in-scope internal documentation for changes or new features
 
 Step 2: Compare Documentation
 - Compare with corresponding external documentation (`[[EXTERNAL_DOC_LOCATION]]`)
@@ -124,8 +145,31 @@ Step 2: Compare Documentation
 Step 3: Create/Update Files
 - Create/update external MD files in `[[EXTERNAL_DOC_LOCATION]]` as needed
 - Follow all naming, formatting, and style guidelines from the Style Guide below
+- Register every added/moved/deleted page in the navigation manifest (Task 3)
 
-Only edit customer-facing files in `[[EXTERNAL_DOC_LOCATION]]` and its subdirectories.
+Step 4: Verify Every User-Visible Claim Against the Code
+⚠️ MANDATORY — internal docs are a lagging source of truth, so a claim copied from them can ship an error two hops from the code. Before finishing, verify each user-visible claim you wrote against the implementation itself:
+- Commands, flags, and their spellings — confirm each exists in the code exactly as written
+- Configuration keys, defaults, and file paths — confirm against the schema or the reader the code actually uses
+- Described behavior and examples — confirm they match the shipped implementation, and that every example's expected output is what the command produces
+- Cross-references — confirm every link you wrote resolves (Task 3)
+A claim you cannot back with a code reading is hedged ("as of this release") or removed — never shipped on faith. Record a short "Claims verified" list in the Status Summary: each claim and the file read or command that confirmed it.
+
+Only edit user-facing files in `[[EXTERNAL_DOC_LOCATION]]` and its subdirectories.
+
+## Verification Checklist
+
+Before completing, verify you have:
+
+- [ ] Determined and recorded the audience (Task 0)
+- [ ] Established the comparison scope and stated it in the Status Summary
+- [ ] Categorized every in-scope topic (Aligned / Outdated / Missing / Internal-only)
+- [ ] Actually edited files — analysis alone is incomplete
+- [ ] Registered every page add/move/delete in the navigation manifest, where one exists
+- [ ] Given every procedure page a worked example with expected output
+- [ ] Performed Step 4: verified commands, keys, paths, behavior, and links against the code, and recorded the "Claims verified" list
+- [ ] Left release-notes/changelog files, the landing page, and styling assets untouched
+- [ ] Stayed within `[[EXTERNAL_DOC_LOCATION]]` boundaries
 
 ---
 
@@ -141,7 +185,7 @@ This Style Guide is the single source for customer-facing style mechanics — AP
 - Maintain a neutral, objective tone
 
 ### General Writing Guidelines
-- Audience: Customers
+- Audience: the reader determined in Task 0 — calibrate vocabulary and depth to them
 - Use "and" instead of ampersands (&); write "percent" instead of %
 - Punctuation outside quotes when quoting UI text
 - Use colon format for defined terms in lists (Term: Description.)
@@ -154,7 +198,7 @@ This Style Guide is the single source for customer-facing style mechanics — AP
 - Add short purpose line under each header
 - Summarize processes in 2-3 sentences, then link to dedicated articles
 - Add "See also" or "Related Articles" links
-- Insert screenshot placeholders at UI/action points (e.g., "[Screenshot: Save button location]")
+- Illustrate a UI step with a real committed screenshot or omit the image — never publish a placeholder, which reads as a broken page
 
 ### Abbreviations and Numbers
 - Spell out numbers < 10; use numerals >= 10
@@ -172,10 +216,20 @@ This Style Guide is the single source for customer-facing style mechanics — AP
 - Prefer "use" over "utilize"
 - Prefer "enter" over "type", "display" over "show"
 
-### User Actions
+### User Actions — Match the Product's Shape
+For a product with a graphical interface:
 - Click: Desktop (buttons, links); Tap: Mobile
 - Press: Keyboard keys; Select: Dropdowns, menus
 - Bold UI element names; omit element type unless needed for clarity
+
+For a CLI, API, or library product these rules do not apply — the equivalents are:
+- Verbatim commands in fenced blocks, each followed by its expected output
+- Configuration shown as a copyable snippet in the product's actual config format
+- Errors quoted verbatim, so the reader can search for the exact text they see
+
+### Rich Components and Diagrams
+- Where the site framework supports rich components (e.g. Mintlify), select by content shape: per-client or per-platform instructions → tabs; configuration keys → parameter fields; a caveat or destructive action → note/warning callout; a sequential procedure → steps; a hub page's children → card group. Plain Markdown headings for all of these waste the framework the site already pays for.
+- When a flow spans three or more moving parts, a diagram earns its place: mermaid or a committed SVG that matches the site's palette, carries descriptive alt text, and stays legible in both light and dark modes.
 
 ### MD Formatting
 - Start page headings with H1; use title case for headings


### PR DESCRIPTION
## Summary

External-docs audit implementation (fork A): rewrites `skills/docs-sync-external/SKILL.md` and `skills/docs-bootstrap-external/SKILL.md` so the pair produces documentation for the product's actual human users, verified against the code.

### docs-sync-external (17,130 B)
- **Task 0 audience determination** with a recorded output replaces the hardcoded "Audience: Customers"; register/examples/depth calibrate to it.
- **Change scoping**: caller-supplied Step-1 changes take precedence (consumer arm of the router handoff, tolerant of absence); standalone runs scope by `git diff origin/main...HEAD`; full-tree only on explicit request.
- **Site structure & navigation**: generalized nav-manifest maintenance (docs.json/mkdocs.yml/SUMMARY.md/_sidebar.md), landing page per directory, frontmatter matching, link resolution.
- **Hub-page contradiction resolved**: "Never create parent/hub documents" deleted; replaced by the landing-page contract.
- **Human-quality recipes**: worked copy-pasteable example with expected output on every procedure page; troubleshooting leads with the verbatim error + diagnostic command; rich-component selection table (tabs/param fields/callouts/steps/cards, phrased framework-generically); diagram guidance (3+ moving parts, palette-matched, alt text, both themes). Screenshot-placeholder rule replaced with real-asset-or-omit.
- **Product-shape style branch**: Click/Tap/UI rules scoped to GUI products; CLI/API equivalents defined.
- **Step 4 verify-claims-against-code** (commands, keys, defaults, paths, behavior, links) + a closing Verification Checklist (the skill previously had neither).
- **Ownership fencing**: release-notes/changelog, landing page, styling assets untouchable. Mission + proportionality principles added.

### docs-bootstrap-external (18,980 B)
- **Step 7 claim verification** — the skill previously had zero verification of any kind.
- **Unestablished-state arm** added to its extension loader (permission denial ≠ "no extension"). Deliberately NOT upgraded to the vendored-literal three-tier ladder: the #855 pointer-population snapshot in `test_python_scripts.py` is exact set equality and unmerged PR #1975 already edits that set — adding a member here would conflict. The single-tier anchor form stays, unenrolled, matching `lint-anchor-fallback-arm.py`'s current expectations.
- **Structural contract in the skill**: nav-manifest registration, landing page per directory, depth ≤ 3, frontmatter matching, .mdx only where required.
- **User-task coverage** replaces the 1:1 internal-topic quota; a new ➖ "No user task" category makes exclusions a first-class reported outcome.
- **Audience determination** (Step 1) with recorded output driving vocabulary and task-shaped IA.
- **Downstream contract named** (docs-sync-external maintains the structure), scope boundary, do-not-commit, protected files, per-page template, quality-over-quantity, Common Mistakes table, manual-only/cloud-closure status stated. The upgraded Success Criteria serve as the closing checklist.

### Pins & constraints
- Greped `lib/`, `scripts/`, `.github/` for every deleted/reworded literal ("Never create parent/hub documents", "Audience: Customers", "All user-facing topics", screenshot placeholder, hub-page phrases): **zero pins reference them**.
- Extension-loader blocks and portable-anchor paragraphs byte-intact; `_E1354_MAP` rows unchanged; no new files under either skill dir; cloud-writer manifest not regenerated; no new bash fences; no bare `jq`; `## Style Guide` heading kept (bootstrap's cross-skill pointer target).
- Lints all rc 0: `lint-anchor-fallback-arm.py`, `lint-reference-size.py` (82 audited), `lint-shipped-pruned-path.py` (98/98), `lint-skills-glob-guard.py` (83/83).

Writing-skills evidence: skill-loaded=yes (content in session context); guidance-applied=yes (recipe-form mandates, no nuance clauses, triggers-only descriptions untouched); pressure-scenario=no (baseline failures taken from the three-agent corpus audit of the live docs/external output rather than fresh subagent scenarios); micro-tests=no (not run this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)