### PR TITLE
feat: harden the /prflow:docs router (cloud-safe gates, extension ladder, per-step outcomes)

### DIFF
--- a/.changeset/docs-router-hardening.md
+++ b/.changeset/docs-router-hardening.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Harden the /prflow:docs router for the tiers it actually runs on: the two config-gate reads become direct leading-token invocations (the former `VAR=$(…)` capture is silently refused by the cloud matcher and worktree-isolated sessions), the prompt-extension load gains the vendored-literal-first three-tier ladder with the unestablished arm, each step now ends in a declared outcome (completed / skipped / failed / unestablished) that the Final Summary reports alongside the carried-forward public-doc impact list, and Step 3's ungated status is stated with its rationale.

--- a/lib/test/fixtures/anchor-fallback-arm/green/skills/docs/SKILL.md
+++ b/lib/test/fixtures/anchor-fallback-arm/green/skills/docs/SKILL.md
@@ -1,0 +1,9 @@
+# GREEN fixture — vendored-literal leading token + anchor fallback arm (issue #1124)
+
+```bash
+.prflow/vendor/prflow/scripts/load-prompt-extension.sh docs
+```
+
+```bash
+"${CLAUDE_SKILL_DIR:-<absolute skill base directory this runner reports in context>}"/../../scripts/load-prompt-extension.sh docs
+```

--- a/lib/test/lint-anchor-fallback-arm.py
+++ b/lib/test/lint-anchor-fallback-arm.py
@@ -112,6 +112,11 @@ ENROLLED: tuple[tuple[str, str], ...] = (
     # as the four #1432 rows above, so the vendored-literal-first arm must stay present.
     ("skills/docs-bootstrap-internal/SKILL.md",
      "load-prompt-extension.sh docs-bootstrap-internal"),
+    # Enrolled with the docs-router hardening pass: the router runs inside implement
+    # Phase 4.1's docs subagent, which receives no $CLAUDE_SKILL_DIR — the same
+    # unresolvable-anchor case as the #1432 rows — so its extension load carries the
+    # vendored-literal-first arm with the anchor as fallback.
+    ("skills/docs/SKILL.md", "load-prompt-extension.sh docs"),
 )
 
 #: The portable source anchor prefix (issue #275), byte-identical to the ``lpe-coverage``

--- a/lib/test/test_python_scripts.py
+++ b/lib/test/test_python_scripts.py
@@ -14804,7 +14804,7 @@ assert_eq("#855: the pointer-population sweep matches the recorded snapshot exac
           "(a new skill emitting a bare repo-relative command path turns this RED)",
           {"implement", "retrospective-weekly", "review", "review-and-fix",
            "pr-description", "docs-sync-internal", "docs-sync-external",
-           "docs-release-notes", "docs-bootstrap-internal"},
+           "docs-release-notes", "docs-bootstrap-internal", "docs"},
           _wd_pointer_pop)
 
 # Regression pin: `Bash(cd:*)` is revoked from prflow_implement.allowed_tools

--- a/skills/docs/SKILL.md
+++ b/skills/docs/SKILL.md
@@ -5,13 +5,19 @@ description: Use when documentation generally needs to catch up with a branch be
 
 **Portable helper anchor (single-statement).** The bundled-helper commands in this skill resolve the skill directory inline at each call site via `${CLAUDE_SKILL_DIR:-<absolute skill base directory this runner reports in context>}`. When `$CLAUDE_SKILL_DIR` is set and non-empty (Claude Code), run each command exactly as written. Otherwise locate the directory yourself — this text lives in a file inside it, whose sibling `../../scripts/` directory exists — by replacing the placeholder with the skill base directory the runner reports in context (e.g. a `Base directory for this skill:` line) and accepting a candidate only once `ls <candidate>/../../scripts/` succeeds in the same shell the helper commands run in. If a path form is rejected, use the form that shell reports (`pwd` shows it); a Windows-form base directory (`C:\...`) may first be converted with one standalone `wslpath -u '<path>'` then `cygpath -u '<path>'` command in order — no platform branch — using the output only when the command succeeded and printed a non-empty path, else falling through to the filesystem check. Resolve the anchor inline at every call site — never capture it into a shell variable that a later statement reads, because some runners' inline-bash marshaling drops such variables. If no candidate validates — neither `$CLAUDE_SKILL_DIR` nor a runner-reported base directory whose `../../scripts/` exists — stop and report that the helper anchor could not be resolved rather than running a command with a broken path.
 
-Consumer prompt extension (load first). Before doing this skill's work, load any consumer-supplied prompt extension for this skill and honor it. From the repo root, run:
+Consumer prompt extension (load first). Before doing this skill's work, load any consumer-supplied prompt extension for this skill and honor it. From the repo root, emit the granted vendored-literal leading token first:
+
+```bash
+.prflow/vendor/prflow/scripts/load-prompt-extension.sh docs
+```
+
+On a `command not found` / `No such file` / exit-127 reading (this repository's own local tier, where `.prflow/vendor/` is materialized only at runtime), re-invoke the same helper with the `.prflow/vendor/prflow/` prefix removed (`scripts/load-prompt-extension.sh docs`) as a single leading-token statement. If that too is not found (a non-Claude-Code runner where neither repo-relative path exists), fall back to the portable anchor form:
 
 ```bash
 "${CLAUDE_SKILL_DIR:-<absolute skill base directory this runner reports in context>}"/../../scripts/load-prompt-extension.sh docs
 ```
 
-If the invocation fails because the helper path does not exist (`No such file`, exit 127, or the platform equivalent), that is the anchor-resolution failure described in the *Portable helper anchor* note above — fix the anchor, don't report a missing extension. Otherwise, if the helper exits non-zero, a consumer extension exists but could not be loaded — surface its stderr message and do not silently proceed as if none existed. If it exits 0 and prints text, treat that text as additional instructions appended to the end of this skill's own prompt for this run — it is upgrade-safe, consumer-owned customization committed under `.prflow/prompt-extensions/`. If it exits 0 and prints nothing, proceed unchanged.
+If the invocation fails because the helper path does not exist (`No such file`, exit 127, or the platform equivalent) on every form above, that is the anchor-resolution failure described in the *Portable helper anchor* note above — fix the anchor, don't report a missing extension. If instead the harness refuses the command outright — a permission denial rather than a missing file — the extension's state is **unestablished**: report that in the run's output and never treat it as a clean policy pass (*unknown is not zero*). Otherwise, if the helper exits non-zero, a consumer extension exists but could not be loaded — surface its stderr message and do not silently proceed as if none existed. If it exits 0 and prints text, treat that text as additional instructions appended to the end of this skill's own prompt for this run — it is upgrade-safe, consumer-owned customization committed under `.prflow/prompt-extensions/`. If it exits 0 and prints nothing, proceed unchanged.
 
 ## Objective
 
@@ -21,23 +27,33 @@ This skill is a router: it composes no prose of its own, delegating each step to
 
 ### Config gates (read once, up front)
 
-Read both toggles before starting (they default to `true` — enabled — when absent):
+Read both toggles before starting (they default to `true` — enabled — when absent). Run each read as a direct leading-token invocation and use its printed output as the value — never capture it into a variable via command substitution, a shape some harnesses (the cloud tier's matcher, a worktree-isolated session) silently refuse, which would leave both gates unread:
 
 ```bash
-INTERNAL_ENABLED=$("${CLAUDE_SKILL_DIR:-<absolute skill base directory this runner reports in context>}"/../../scripts/config-get.sh .docs.internal_enabled true)
-EXTERNAL_ENABLED=$("${CLAUDE_SKILL_DIR:-<absolute skill base directory this runner reports in context>}"/../../scripts/config-get.sh .docs.external_enabled true)
+.prflow/vendor/prflow/scripts/config-get.sh .docs.internal_enabled true
 ```
 
-- `INTERNAL_ENABLED == "false"` → skip Step 1.
-- `EXTERNAL_ENABLED == "false"` → skip Step 2.
+```bash
+.prflow/vendor/prflow/scripts/config-get.sh .docs.external_enabled true
+```
 
-Step 3 (release notes) is not gated by these flags. Note which steps you skipped — the Final Summary must report it.
+On a `command not found` / `No such file` / exit-127 reading, re-invoke each read with the `.prflow/vendor/prflow/` prefix removed (`scripts/config-get.sh` plus the same operands) as a single leading-token statement; if that too is not found, use the portable anchor form from the *Portable helper anchor* note above with the same operands.
+
+- The internal toggle printing `false` → skip Step 1.
+- The external toggle printing `false` → skip Step 2.
+- A toggle read the harness refuses outright — a permission denial rather than a missing file — leaves that gate **unestablished**: run the step (the toggles default to `true`) and report the gate as `unestablished` in the Final Summary, never as a clean read (*unknown is not zero*).
+
+Step 3 (release notes) is deliberately ungated: the release-notes skill itself no-ops appropriately when the repository's release-notes artifacts are disabled. Note which steps you skipped — the Final Summary must report it.
+
+### Per-step outcomes
+
+Each step ends in exactly one of four outcomes, and the Final Summary names one per step: **completed** (the nested skill ran to its own completion), **skipped** (disabled by config), **failed** (the nested skill errored, or its Skill-tool load returned an error instead of a skill body), or **unestablished** (the gate or load state could not be determined). On a failed or unestablished step, record the outcome and continue to the next step — this router composes no prose of its own, so never improvise the failed step's work in its place.
 
 ---
 
 ## Step 1: Update Internal Documentation
 
-Skip this step when `INTERNAL_ENABLED == "false"` — record "internal docs disabled by config" for the Final Summary and proceed to Step 2.
+Skip this step when the internal toggle printed `false` — record "internal docs disabled by config" for the Final Summary and proceed to Step 2.
 
 Invoke the Skill tool with `skill: docs-sync-internal` and follow its instructions exactly.
 
@@ -47,7 +63,7 @@ After completing Step 1, note what you changed — you will need this context fo
 
 ## Step 2: Align External Documentation
 
-Skip this step when `EXTERNAL_ENABLED == "false"` — record "external docs disabled by config" for the Final Summary and proceed to Step 3.
+Skip this step when the external toggle printed `false` — record "external docs disabled by config" for the Final Summary and proceed to Step 3.
 
 Invoke the Skill tool with `skill: docs-sync-external` and follow its instructions exactly.
 
@@ -69,7 +85,10 @@ Use the documentation changes from Steps 1 and 2 as additional context when asse
 
 ## Final Summary
 
-After completing the enabled steps, provide a brief summary listing:
-- Internal doc files added or edited (Step 1) — or "skipped: disabled by config (`docs.internal_enabled: false`)"
-- External doc files added or edited (Step 2) — or "skipped: disabled by config (`docs.external_enabled: false`)"
+After the last step, provide a brief summary listing:
+- Each step's outcome — completed / skipped / failed / unestablished — with its one-clause reason (e.g. "skipped: disabled by config (`docs.internal_enabled: false`)"), so a failed or unestablished step is never laundered into a clean pass
+- Internal doc files added or edited (Step 1)
+- Step 1's public-doc impact list, carried forward verbatim (or its explicit "public-doc impact: none")
+- External doc files added or edited (Step 2)
 - Release note entry added or skipped with reason (Step 3)
+- Any config gate whose read was refused, reported as `unestablished`


### PR DESCRIPTION
## The headline bug

The router's two config-gate reads were `INTERNAL_ENABLED=$("${CLAUDE_SKILL_DIR:-…}"/../../scripts/config-get.sh .docs.internal_enabled true)`-style captures: a leading `VAR=` assignment + command substitution + variable expansion. The cloud matcher denies all three shapes, and a worktree-isolated local session refuses substitution-bearing fences — yet the router runs precisely inside implement Phase 4.1's docs subagent on the cloud tier. There, both gate reads were silently undeliverable, so the `docs.internal_enabled` / `docs.external_enabled` toggles could not be read the way the skill instructed.

## Changes (`skills/docs/SKILL.md`)

- **Gate reads** are now direct leading-token vendored-literal invocations whose printed output is the value (no assignment, no substitution), with prefix-stripped and portable-anchor fallbacks and an **unestablished arm**: a permission-refused read runs the step (the keys default to true) and is reported as `unestablished` in the Final Summary, never as a clean read.
- **Extension loader** upgraded to the three-tier ladder (vendored literal → `scripts/` → portable anchor) + unestablished arm, matching the sibling docs skills.
- **Per-step outcome vocabulary**: completed / skipped (config) / failed (nested skill errored or its Skill-tool load returned an error instead of a body — the router records it and continues; it never improvises the step's work) / unestablished. The Final Summary reports one per step, carries Step 1's public-doc impact list forward verbatim, and names any refused gate read.
- **Step 3's ungated status** now states its rationale (the release-notes skill no-ops appropriately when the repo's release-notes artifacts are disabled).

## Test-contract updates in the same change

- Enrolled `skills/docs/SKILL.md · load-prompt-extension.sh docs` in `lib/test/lint-anchor-fallback-arm.py` (same #1432 class: the Phase 4.1 subagent receives no $CLAUDE_SKILL_DIR) and added the green fixture; the red/neither fixture roots need no new file (a missing enrolled file fails closed there, preserving their rc=1 assertions).
- Added `docs` to the #855 pointer-population exact-set snapshot in `lib/test/test_python_scripts.py` (the new vendored-literal fences emit bare repo-relative command paths).

## Pins verified

- `.docs.internal_enabled` / `.docs.external_enabled` each appear exactly once (run.sh docs-toggle `grep -c` == 1 pins).
- The Portable helper anchor paragraph (canonical #275 copy) is byte-untouched; the lpe-coverage whole-line anchor invocation and the 'a consumer extension exists but could not be loaded' prose both survive; the three `Invoke the Skill tool with skill:` phrases are unchanged.
- Cloud-writer manifest untouched (edited-asset digests are main-owned).

## Verification

`lint-anchor-fallback-arm.py` rc 0 (live tree) + red/neither fixture roots still rc 1 with their pinned messages; `lint-reference-size.py` rc 0 (file is 9,086 B); `lint-shipped-pruned-path.py` 98/98; `lint-skills-glob-guard.py` rc 0; `lint-worktree-fence-shapes.py` rc 0; ruff clean on both edited .py files; a replica of the #855 sweep confirms `docs` joins the population and `find_implement_violations` reports none for the new fences.

Writing-skills evidence: skill-loaded=yes (loaded in the dispatching session and applied here); guidance-applied=yes (recipe-form guidance, no nuance clauses, triggers-only description untouched); pressure-scenario=no (change is shape/contract hardening validated by the repo's own lints rather than subagent pressure runs); micro-tests=no (not run this session; the mechanical lints above are the deployed verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)