### PR TITLE
feat: align docs-verify with the docs-family campaign standards

### DIFF
--- a/.changeset/docs-verify-family-alignment.md
+++ b/.changeset/docs-verify-family-alignment.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+docs-verify: index-map routing in Step 1, runner-tool-first searches, an unestablished-state arm on the prompt-extension loader, and write-mode claim-verification, freshness-marker, index-registration, prose-shape, and do-not-commit rules — aligning the last docs-family skill with the campaign standards.

--- a/skills/docs-verify/SKILL.md
+++ b/skills/docs-verify/SKILL.md
@@ -13,7 +13,7 @@ Consumer prompt extension (load first). Before doing this skill's work, load any
 "${CLAUDE_SKILL_DIR:-<absolute skill base directory this runner reports in context>}"/../../scripts/load-prompt-extension.sh docs-verify
 ```
 
-If the invocation fails because the helper path does not exist (`No such file`, exit 127, or the platform equivalent), that is the anchor-resolution failure described in the *Portable helper anchor* note above — fix the anchor, don't report a missing extension. Otherwise, if the helper exits non-zero, a consumer extension exists but could not be loaded — surface its stderr message and do not silently proceed as if none existed. If it exits 0 and prints text, treat that text as additional instructions appended to the end of this skill's own prompt for this run — it is upgrade-safe, consumer-owned customization committed under `.prflow/prompt-extensions/`. If it exits 0 and prints nothing, proceed unchanged.
+If the invocation fails because the helper path does not exist (`No such file`, exit 127, or the platform equivalent), that is the anchor-resolution failure described in the *Portable helper anchor* note above — fix the anchor, don't report a missing extension. If instead the harness refuses the command outright — a permission denial rather than a missing file — the extension's state is **unestablished**: report that in the run's output and never treat it as a clean policy pass (*unknown is not zero*). Otherwise, if the helper exits non-zero, a consumer extension exists but could not be loaded — surface its stderr message and do not silently proceed as if none existed. If it exits 0 and prints text, treat that text as additional instructions appended to the end of this skill's own prompt for this run — it is upgrade-safe, consumer-owned customization committed under `.prflow/prompt-extensions/`. If it exits 0 and prints nothing, proceed unchanged.
 
 ## Mode
 
@@ -187,13 +187,14 @@ Read the shared writing standard before composing in either mode. Both modes com
 
 ### Step 1: Locate Documentation Files
 Search for any existing documentation about the topic **within the supplied `--search-space` operand**; when no operand was supplied, search `[[INTERNAL_DOC_LOCATION]]`:
-- Use `glob` to find files in that search space matching the topic name
-- Search for files containing the topic using `grep` and `find` commands
+- When the search space carries an `index.md` routing map (and a `glossary.md`), read the index first and follow its routing to the page that owns the topic — the index locates the owning page faster than a raw search, and a routed page a name-match would miss is still in scope
+- Use the runner's Glob tool to find files in that search space matching the topic name
+- Search for files containing the topic with the runner's Grep tool first, then `rg` where it resolves on the host, then `grep -rnE`
 - Document all files found (or note if no files exist)
 
 ### Step 2: Search Codebase for Topic
 Identify all code related to the topic, **searching the supplied `--search-space` operand**; when no operand was supplied, search the whole tracked tree. In report-only mode the duty floor above — not the size of that space — bounds how far this search goes:
-- Search that space (`grep`, `find`) for classes, functions, features mentioned in the topic
+- Search that space for classes, functions, and features mentioned in the topic, with the runner's Grep tool first, then `rg` where it resolves on the host, then `grep -rnE`
 - Review all relevant source files
 - Document the key files and features involved
 

--- a/skills/docs-verify/references/write-mode.md
+++ b/skills/docs-verify/references/write-mode.md
@@ -24,6 +24,7 @@ Path C: Documentation is missing
 - Analyze the codebase thoroughly
 - Draft comprehensive documentation
 - Create a new `.md` file in appropriate `[[INTERNAL_DOC_LOCATION]]` subdirectory
+- When the documentation root keeps an `index.md` routing map, place the page where that map's taxonomy says it belongs and add a routing line for the page to the index in the same pass — an unregistered page is invisible to readers who navigate by the map
 - Include all essential information about the topic
 
 ## Quality Checklist
@@ -40,6 +41,7 @@ Path C: Documentation is missing
 ### Creating New Documentation
 - Create in appropriate `[[INTERNAL_DOC_LOCATION]]` subdirectory
 - Use Markdown formatting with clear structure
+- Open with a 2-4 line plain-language summary of what the page covers and who reads it, and write timeless present-tense reference prose — issue numbers stay out of headings and provenance goes in a single trailing line, because per-change narrative turns a reference page into a decision log
 - Include: Overview, Key Components, Code Examples, Configuration, Important Notes
 - Follow existing documentation style and formatting in `[[INTERNAL_DOC_LOCATION]]`
 - Reference source files by bare path only (e.g., `src/app/server.py`) — never append line numbers (e.g., do not write `server.py:42`); use function or class names instead, as line numbers change as code evolves
@@ -59,6 +61,7 @@ Use descriptive names matching the topic:
 
 ## Quality Standards
 
+- Audience: future coding agents and developers exploring this codebase — the documentation is their map, so optimize every page for a reader arriving with zero context
 - Accuracy: Every statement must reflect current code implementation
 - Completeness: All essential information about the topic must be included
 - Clarity: Use simple, clear language that developers can understand
@@ -89,6 +92,9 @@ Before completing, verify you have:
 - [ ] Determined if documentation needs to be Created, Edited, or is Accurate
 - [ ] Created or edited documentation files as needed
 - [ ] Ensured documentation aligns with current code
+- [ ] Re-opened the source for every factual claim you added or edited — file paths, symbol names, counts, described behavior — and corrected any mismatch; a claim you cannot verify against the code is removed or rewritten until you can, never shipped on faith
+- [ ] Set or refreshed a `<!-- verified-against: <short-sha> <date> -->` marker near the top of each page you verified, so a later reader can tell a checked page from an abandoned one
+- [ ] Registered any created page in the documentation root's `index.md` routing map, where one exists
 - [ ] Verified documentation is complete and accurate
 - [ ] Stayed within `[[INTERNAL_DOC_LOCATION]]` boundaries
 
@@ -98,5 +104,6 @@ Before completing, verify you have:
 2. All important details about the topic are documented
 3. No contradictions between documentation and code
 4. Documentation file(s) created/updated in `[[INTERNAL_DOC_LOCATION]]`
+5. Nothing is committed — leave committing to the caller
 
 <!-- prflow:docs-verify-ref mode=write file=skills/docs-verify/references/write-mode.md end -->


### PR DESCRIPTION
Completes the docs-family audit campaign: `docs-verify` was the only member never audited. This PR records the audit and ships the consumer-safe improvements it justified.

## Audit findings and dispositions

**Implemented:**
1. **Loader unestablished arm** — the prompt-extension loader treated a harness permission denial like a missing extension; it now reports the extension state as unestablished, never a clean pass (matches the family standard from the campaign). The `lpe-coverage` whole-line invocation and exit-code phrase are untouched.
2. **Index-map routing in Step 1** — post-campaign, internal docs keep a maintained `index.md`/`glossary.md`; Step 1 now consults the index first to find the owning page before raw search. Additive; the pinned `--search-space` operand sentences are unchanged.
3. **Runner-tool-first searches (Steps 1–2)** — `glob`/`grep`/`find` shell wording replaced with the family's Grep-tool-first / `rg` / `grep -rnE` convention.
4. **Write-mode reference upgrades** (all inside the pinned boundary markers, first/last lines byte-identical): verify-every-claim-against-code checklist row (the family Step-5 discipline — write mode previously had none), `<!-- verified-against: -->` freshness-marker refresh, index registration for created pages, TLDR + timeless-prose authoring rule, agent-reader audience line, and an explicit do-not-commit completion criterion (the one docs skill that lacked it).

**Correct-by-design, deliberately not changed:**
- The internal-only doc-reliability boundary (explicitly scoped and determinism-justified in the skill; external pages are out of its signal by design).
- The report-only contract (duty floor, three-fate doc-claim rule, unestablished-vs-absent discipline) — the strongest verification prose in the family; used as the model elsewhere, not modified.
- The leaf/no-subagent rule and the fail-closed write-mode boundary gate.
- No pinned-path guard added: write mode only creates or edits in place, never renames or deletes.

**Deferred (blocked on open PR #1983):** upgrading the loader to the vendored three-tier ladder — that adds a vendored fence, which joins the `#855` pointer-population exact-set snapshot that #1983 concurrently edits. The unestablished arm ships now; the ladder is a follow-up once #1983 merges.

## Pins verified post-edit
Duty-status token definitions, `RELIABLE`/`UNRELIABLE`/`ABSENT`, the six report-field bullets, the unique grammar line, the `lpe-coverage` invocation line and exit-code phrase, the paged-read disjunction idiom (`lint-paged-read-idiom` enrolled copy), and write-mode.md's boundary-marker first/last lines — all intact.

## Verification
`lint-anchor-fallback-arm`, `lint-reference-size` (SKILL 23,868 B; reference 5,573 B), `lint-shipped-pruned-path` (98/98), `lint-skills-glob-guard`, `lint-paged-read-idiom` — all rc 0. `lib/test/run-module.sh create-issue-contract`: 395 passed, 0 failed, 1 pre-existing host-capability skip (busybox absent).

Writing-skills evidence: skill-loaded=yes (authoring discipline in session context); guidance-applied=yes (recipe-form additions, no nuance clauses, description untouched); pressure-scenario=no (campaign audit evidence served as the baseline); micro-tests=no (not run this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
