### PR TITLE
docs: rebuild external documentation for accuracy and adoption

### DIFF
--- a/docs/external/docs.json
+++ b/docs/external/docs.json
@@ -25,6 +25,7 @@
         "group": "Documentation",
         "pages": [
           "docs/index",
+          "docs/quickstart",
           {
             "group": "Getting started",
             "pages": [
@@ -57,6 +58,8 @@
               "docs/concepts/lifecycle",
               "docs/concepts/workpads-and-resume",
               "docs/concepts/review-system",
+              "docs/concepts/verification",
+              "docs/concepts/security",
               "docs/concepts/human-control"
             ]
           },
@@ -79,9 +82,10 @@
                   "docs/runs/cloud/index",
                   "docs/runs/cloud/installation",
                   "docs/runs/cloud/setup",
-                  "docs/runs/cloud/updates",
-                  "docs/runs/cloud/triggers",
                   "docs/runs/cloud/runners",
+                  "docs/runs/cloud/triggers",
+                  "docs/runs/cloud/auto-review",
+                  "docs/runs/cloud/updates",
                   "docs/runs/cloud/recovery"
                 ]
               }
@@ -96,6 +100,7 @@
               "docs/configuration/implementation",
               "docs/configuration/review",
               "docs/configuration/review-agents",
+              "docs/configuration/prompt-extensions",
               "docs/configuration/providers",
               "docs/configuration/runtime-setup",
               "docs/configuration/tool-permissions",

--- a/docs/external/docs/concepts/human-control.md
+++ b/docs/external/docs/concepts/human-control.md
@@ -1,40 +1,72 @@
 ---
 title: "Human Control"
-description: "See which decisions, permissions and merge actions remain with people."
+description: "See which decisions, permissions and merge actions stay with people."
 ---
 
-PRFlow can prepare and review changes, but people retain authority over the repository. These boundaries clarify what the agent may do and which decisions remain yours.
+See exactly where PRFlow stops and you decide.
+
+PRFlow can prepare and review a change, but people keep authority over the repository. The boundaries below are deliberate. They are what makes an autonomous run something you can adopt without giving up control of what lands.
 
 ## Before a Run
 
-- The `create-issue` workflow displays the complete issue draft and waits for explicit approval before creating it.
-- A local coding client can ask for clarification and tool permission during a run.
-- Repository maintainers decide which configuration, prompt extensions and permission scopes to commit.
-- Cloud comment triggers require an authorized collaborator or allowed bot. An outside fork contributor cannot start a privileged review run.
+- The [create-issue workflow](/docs/workflows/create-issue) shows you the complete issue draft and waits for your explicit approval before it creates anything.
+- A local run can ask you for clarification, and it asks your client for tool permission as it goes. See [Local Permissions](/docs/runs/local/permissions).
+- Maintainers decide which configuration, prompt extensions and permission scopes are committed to the repository. A run can only use what you committed.
+- A cloud run starts only for an authorized collaborator or an allowed bot. An outside fork contributor cannot start one. See [Security and Trust](/docs/concepts/security).
 
 ## During a Run
 
-- Review permission requests at the narrowest useful scope.
-- Inspect `Blocked` workpad entries before retriggering an implementation.
-- Treat scope changes, deferred acceptance criteria and failed verification as decisions that need evidence, not inconveniences to bypass.
-- Keep broad shell, filesystem and credential access outside the run unless the repository workflow genuinely needs it.
-
-PRFlow can create issue comments, branches, commits, pull requests, reviews and follow-up issues when the active identity has permission. Those writes remain visible in Git and GitHub for review.
+<CardGroup cols={2}>
+  <Card title="Grant narrowly" icon="key">
+    Review each permission request at the narrowest scope that still lets the work proceed. Keep broad shell, filesystem and credential access out of the run unless the workflow genuinely needs it.
+  </Card>
+  <Card title="Read Blocked before retrying" icon="octagon-exclamation">
+    A `Blocked` workpad entry names a cause. Read it and resolve it. Retriggering the run without resolving the cause reproduces the same stop.
+  </Card>
+  <Card title="Treat gaps as decisions" icon="scale-balanced">
+    A scope change, a deferred acceptance criterion or a verification that did not run is a decision that needs evidence. It is not an inconvenience to route around.
+  </Card>
+  <Card title="Watch the writes" icon="eye">
+    PRFlow writes issue comments, branches, commits, pull requests, reviews and follow-up issues, when the active identity has permission. All of it stays visible in Git and GitHub.
+  </Card>
+</CardGroup>
 
 ## Pull-Request State
 
-Implementation opens a draft pull request before its review and documentation phases finish. The default completion path publishes it as ready for review. Maintainers can configure PRFlow to leave it as a draft.
+An implementation run opens a **draft** pull request before its review and documentation work finishes. When the run completes, the default is to publish it as ready for review. Maintainers can configure PRFlow to leave it as a draft instead.
 
-Ready means the configured lifecycle completed. It does not mean a person approved the change, branch protection passed or deployment risk is acceptable.
+<Warning>
+  "Ready for review" means the configured workflow completed. It does not mean a person approved the change, that branch protection passed or that the deployment risk is acceptable.
+</Warning>
 
 ## The Merge Boundary
 
-PRFlow never merges a pull request. A human must:
+PRFlow never merges a pull request. Before you do, work through these:
 
-1. Review the code, tests and documentation.
-2. Read the workpad's acceptance-criteria evidence and reflections.
-3. Evaluate review findings and any remaining caveats.
-4. Wait for required repository checks and approvals.
-5. Merge or request changes through the team's normal process.
+<Steps>
+  <Step title="Review the change">
+    Read the code, the tests and the documentation the run produced, the same way you would read a colleague's pull request.
+  </Step>
+  <Step title="Read the workpad">
+    Check the acceptance-criteria evidence and the `Devflow Reflection` section, which is where blockers, deferrals and dropped work are recorded. See [Workpads and Resume](/docs/concepts/workpads-and-resume).
+  </Step>
+  <Step title="Evaluate the review findings">
+    Read the verdict and any remaining caveats. An approval-family verdict is evidence, not proof. See [The Review System](/docs/concepts/review-system).
+  </Step>
+  <Step title="Wait for your own checks">
+    Required repository checks and required approvals apply exactly as they always did. See [How PRFlow Verifies a Change](/docs/concepts/verification).
+  </Step>
+  <Step title="Merge or request changes">
+    Use your team's normal process. This step has no PRFlow equivalent.
+  </Step>
+</Steps>
 
-This boundary is deliberate. PRFlow automates preparation and evidence gathering while leaving the irreversible integration decision with the repository's maintainers.
+This boundary is the point of the design. PRFlow automates the preparation and the evidence gathering, and leaves the irreversible decision with the people who own the repository.
+
+## Related Documentation
+
+- [Security and Trust](/docs/concepts/security)
+- [The Review System](/docs/concepts/review-system)
+- [How PRFlow Verifies a Change](/docs/concepts/verification)
+- [Workpads and Resume](/docs/concepts/workpads-and-resume)
+- [Local Permissions](/docs/runs/local/permissions)

--- a/docs/external/docs/concepts/index.md
+++ b/docs/external/docs/concepts/index.md
@@ -1,22 +1,43 @@
 ---
 title: "How PRFlow Works"
-description: "Understand PRFlow's lifecycle, progress records, review system and human control points."
+description: "Understand PRFlow's lifecycle, progress records, verification, review system, security posture and human control points."
 ---
 
-Understand how PRFlow moves a request through an established repository while preserving human control, durable progress and independent review.
+Understand how PRFlow moves a request through an established repository while keeping human control, durable progress and independent review.
 
-PRFlow is an orchestrated delivery workflow. It turns an issue into a branch and workpad, builds a draft pull request, verifies and reviews the change, updates documentation and hands the result to a human. It does not merge.
+PRFlow is an orchestrated delivery workflow. It turns a GitHub issue into a branch and a progress record, builds a draft pull request, verifies and reviews the change, updates documentation and hands the result to a person. It does not merge.
 
 ## Core Concepts
 
-- [The PRFlow Lifecycle](/docs/concepts/lifecycle) follows an issue from request to human merge.
-- [Workpads and Resume](/docs/concepts/workpads-and-resume) explains which progress survives an interruption and which work can still be lost.
-- [The Review System](/docs/concepts/review-system) explains verification checklists, specialized reviewers, fix iterations and the shadow pass.
-- [Human Control](/docs/concepts/human-control) identifies every approval, permission and merge boundary that remains yours.
+<CardGroup cols={2}>
+  <Card title="The PRFlow Lifecycle" icon="route" href="/docs/concepts/lifecycle">
+    The seven stages an issue passes through, and the gates that can stop a run at each one.
+  </Card>
+  <Card title="Workpads and Resume" icon="clipboard-list" href="/docs/concepts/workpads-and-resume">
+    The progress comment PRFlow writes on the issue, and which work survives an interruption.
+  </Card>
+  <Card title="How PRFlow Verifies a Change" icon="flask" href="/docs/concepts/verification">
+    What "recorded verification evidence" means, and why an unknown result is never a pass.
+  </Card>
+  <Card title="The Review System" icon="magnifying-glass" href="/docs/concepts/review-system">
+    The reviewers PRFlow runs, the verdict it reports and what drives a rejection.
+  </Card>
+  <Card title="Security and Trust" icon="shield-halved" href="/docs/concepts/security">
+    What PRFlow can write, who can start a run and where a cloud run reads its rules from.
+  </Card>
+  <Card title="Human Control" icon="user-check" href="/docs/concepts/human-control">
+    Every approval, permission and merge boundary that stays with people.
+  </Card>
+</CardGroup>
 
 ## A Useful Vocabulary
 
 - **Run:** One execution of a PRFlow skill against a repository and, for implementation, a GitHub issue.
-- **Workpad:** The single issue comment that records implementation progress, acceptance criteria and durable notes.
-- **Checkpoint:** A remote workpad update or a scoped commit and push that reduces how much progress an interrupted run must reconstruct.
-- **Review-ready:** The authoring workflow completed and recorded its available verification and review evidence. It is not a guarantee of correctness or permission to merge without review.
+- **Workpad:** The issue comment that records implementation progress, acceptance criteria and durable notes.
+- **Checkpoint:** A workpad update, or a scoped commit and push, that reduces how much progress an interrupted run has to reconstruct.
+- **Verification evidence:** The record of which checks a run executed and what each one returned. See [How PRFlow Verifies a Change](/docs/concepts/verification).
+- **Review-ready:** The workflow finished and recorded its available verification and review evidence. It is not a guarantee of correctness and it is not permission to merge without review.
+
+<Note>
+  Claude Code is the documented client. Every command on this site is written as `/prflow:<skill>`, for example `/prflow:implement 123`.
+</Note>

--- a/docs/external/docs/concepts/lifecycle.md
+++ b/docs/external/docs/concepts/lifecycle.md
@@ -1,70 +1,101 @@
 ---
 title: "The PRFlow Lifecycle"
-description: "Follow an issue through implementation, review, documentation and human merge."
+description: "Follow an issue through implementation, verification, review, documentation and human merge."
 ---
 
-Follow a PRFlow request through seven lifecycle stages, from issue preparation to human merge. PRFlow performs the middle stages through four implementation phases, while the final merge remains human-controlled.
+Follow a PRFlow request through seven stages, from issue preparation to human merge. PRFlow performs the middle stages. The merge stays with a person.
 
 ```mermaid
 flowchart TD
     accTitle: Seven stages in the PRFlow lifecycle
-    accDescr: An issue starts a PRFlow run. PRFlow prepares a branch and workpad, implements and verifies the change, then opens a draft pull request. It reviews and routes findings and updates documentation. A person reviews and merges the finished pull request.
-    issue["1. Issue<br/>Define the change"] --> run["2. Run<br/>Load guidance and start or resume"]
+    accDescr: An issue starts a PRFlow run. PRFlow prepares a branch and workpad, clears its setup gates, implements the change, runs the repository's checks and opens a draft pull request. It then simplifies the change, reviews it, applies fixes and updates documentation. A person reviews and merges the finished pull request.
+    issue["1. Issue<br/>Define the change"] --> run["2. Run<br/>Load guidance, start or resume"]
 
     subgraph prflow["PRFlow prepares the change"]
-        run --> branch["3. Branch and workpad<br/>Record progress and decisions"]
-        branch --> draft["4. Draft pull request<br/>Implement and verify, then open"]
-        draft --> review["5. Verification and review<br/>Route findings and apply authorized fixes"]
+        run --> branch["3. Branch and setup gates<br/>Record progress, check dependencies and claims"]
+        branch --> draft["4. Implement and verify<br/>Run the checks, then open the draft pull request"]
+        draft --> review["5. Simplify, review and fix<br/>Route findings, apply authorized fixes"]
         review --> docs["6. Documentation<br/>Explain the finished change"]
     end
 
     docs --> merge["7. Human merge<br/>Review, approve and merge"]
 ```
 
-## 1. Issue
+<Steps>
+  <Step title="Issue">
+    The GitHub issue is the contract for the change. PRFlow reads its description and its acceptance criteria.
 
-The GitHub issue is the change contract. PRFlow reads its description and acceptance criteria, checks declared dependencies and compares important claims with the repository before editing code.
+    The optional [create-issue workflow](/docs/workflows/create-issue) clarifies unresolved decisions and waits for explicit approval before it creates the issue.
+  </Step>
 
-The optional `create-issue` workflow clarifies unresolved decisions and requires explicit approval before it creates the issue.
+  <Step title="Run">
+    An implementation command starts the run.
 
-## 2. Run
+    ```text
+    /prflow:implement 123
+    ```
 
-An implementation command starts the run. PRFlow loads repository guidance and configuration, then creates or resumes the issue workpad.
+    PRFlow loads repository guidance and configuration, then creates or resumes the workpad on issue 123.
 
-Local runs can ask you questions. Cloud runs use the issue and recorded workpad context because no person is present in the session.
+    A local run can ask you questions. A cloud run works from the issue and the recorded workpad, because no person is present in the session.
+  </Step>
 
-## 3. Branch and Workpad
+  <Step title="Branch and Setup Gates">
+    PRFlow creates, reuses or adopts a feature branch, pushes it and records it in the workpad. The workpad mirrors the issue's acceptance criteria and tracks the run's status. See [Workpads and Resume](/docs/concepts/workpads-and-resume).
 
-PRFlow creates, reuses or adopts a feature branch. It pushes the branch and records it in the workpad.
+    Three gates can stop the run here, before any code is written:
 
-The workpad mirrors acceptance criteria and tracks setup, implementation, review, documentation and final pull-request state. A resumed run reads this comment and checks for an open pull request before deciding whether to create another branch.
+    - **A declared open dependency.** If the issue declares a dependency on another issue that is still open, or if the state of that dependency cannot be established, the run stops as `Blocked`. This check runs before branch work, so a blocked run leaves no new branch behind.
+    - **A claim in the issue that does not match the repository.** PRFlow checks the issue's claims about the codebase against the current tree before it treats them as instructions. It also checks that the acceptance criteria represent every independently testable outcome the issue describes. An uncovered outcome sends the issue back for refinement instead of being guessed at.
+    - **A workpad already marked `Blocked`.** PRFlow surfaces the recorded cause instead of continuing through it.
+  </Step>
 
-## 4. Draft Pull Request
+  <Step title="Implement and Verify">
+    PRFlow explores the affected code, plans the change and implements it.
 
-PRFlow explores the codebase, reproduces bug reports before planning when possible, implements the plan and runs repository verification. It commits and pushes the work, then opens a draft pull request that closes the issue.
+    For an issue classified as a bug report, reproduction is a hard gate. PRFlow captures a reproduction signal, such as a failing test or an error log, **before** it plans the fix. If it cannot reproduce the defect, the run stops as `Blocked` and records why. It does not proceed on an unreproduced bug.
 
-The pull request stays draft while PRFlow performs its remaining review and documentation work.
+    PRFlow then runs the repository's own checks in the run environment, commits and pushes the work and opens a draft pull request that closes the issue. The checks run before the draft pull request is opened, not after it. See [How PRFlow Verifies a Change](/docs/concepts/verification).
 
-## 5. Verification and Review
+    The pull request stays a draft while the remaining review and documentation work happens.
+  </Step>
 
-PRFlow runs the repository's configured tests and linters in the run environment. It then applies a cleanup pass and runs the review-and-fix loop.
+  <Step title="Simplify, Review and Fix">
+    First PRFlow runs a **simplification pass** over the code the change added or modified. Its charter is quality only: reuse, simplification, efficiency and altitude. It does not hunt for bugs and it never owns correctness. Every finding it produces is checked against the issue's acceptance criteria before it is applied, so a cleanup cannot quietly undo something the issue required.
 
-The review engine builds a verification checklist, checks it against evidence and dispatches specialized reviewers. Findings can trigger fixes and another review iteration. Acceptance criteria must be satisfied or explicitly routed before the lifecycle can complete.
+    Then the review-and-fix loop runs. The review engine builds a verification checklist, checks it against evidence and dispatches specialized reviewers. Findings can trigger corrections and another review iteration. See [The Review System](/docs/concepts/review-system).
 
-## 6. Documentation
+    Before the run can finish, every in-scope acceptance criterion must be verified, or explicitly routed to a follow-up issue or to post-merge verification.
 
-PRFlow files follow-up issues for properly deferred work, updates relevant internal and external documentation, adds release-note material when needed and refreshes the pull-request description.
+    <Warning>
+      This gate checks the criteria the issue actually lists. An issue with **no** acceptance criteria gives the gate nothing to check, so it passes without verifying anything against the issue. Write acceptance criteria if you want this gate to mean something.
+    </Warning>
+  </Step>
 
-By default, the pull request is then published as ready for review. Repository configuration can leave it as a draft instead.
+  <Step title="Documentation">
+    PRFlow files follow-up issues for deferred work, updates the internal and external documentation the change affects, adds release-note material when it is needed and refreshes the pull-request description.
 
-## 7. Human Merge
+    By default the pull request is then published as ready for review. Repository configuration can leave it as a draft instead.
+  </Step>
 
-A person reviews the pull request, repository checks, workpad and review findings. Branch protection and the team's normal approval process still apply.
+  <Step title="Human Merge">
+    A person reviews the pull request, the repository's own checks, the workpad and the review findings. Branch protection and your team's normal approval process still apply.
 
-PRFlow never performs the merge. The lifecycle ends with a review-ready or deliberately draft pull request, not with code on the default branch.
+    PRFlow never performs the merge. The lifecycle ends with a review-ready or deliberately draft pull request, not with code on the default branch.
+  </Step>
+</Steps>
+
+## Where a Run Can Stop
+
+A run that cannot proceed stops and records the reason instead of guessing. The common terminal causes are an open declared dependency, a bug it could not reproduce, an acceptance criterion it could not verify, a verification command it is not permitted to run and an unresolved critical review finding.
+
+<Tip>
+  A `Blocked` result is information, not a failure of the tool. Read the recorded cause on the workpad, resolve it and run the command again.
+</Tip>
 
 ## Related Documentation
 
 - [Workpads and Resume](/docs/concepts/workpads-and-resume)
+- [How PRFlow Verifies a Change](/docs/concepts/verification)
 - [The Review System](/docs/concepts/review-system)
 - [Human Control](/docs/concepts/human-control)

--- a/docs/external/docs/concepts/review-system.md
+++ b/docs/external/docs/concepts/review-system.md
@@ -1,52 +1,121 @@
 ---
 title: "The Review System"
-description: "Understand how PRFlow verifies claims, combines reviewers and fixes findings."
+description: "Understand which reviewers PRFlow runs, what verdict it reports and what drives a rejection."
 ---
 
-PRFlow combines mechanical evidence with independent review passes to find defects before handoff. The result increases confidence, but it does not prove that a change is perfect.
+PRFlow combines mechanical evidence with independent review passes to find defects before it hands the change to you. That raises confidence. It does not prove the change is correct.
 
 ![The prflow:review skill moves through setup and classification, a verification checklist, specialized reviewers and a verdict. The prflow:review-and-fix skill uses the same engine, applies justified corrections, verifies them and reviews the result again. A shadow pass checks an approval-side result before the loop exits.](/images/review-system-loop.svg)
 
 ## Four Review Phases
 
-### Setup and Classification
+<Steps>
+  <Step title="Setup and Classification">
+    The engine identifies the diff under review, its base, the related issue's acceptance criteria and the risk profile of the changed files.
+  </Step>
 
-The review engine identifies the pull-request or branch diff, its base, related issue acceptance criteria and the risk profile of the changed files.
+  <Step title="Verification Checklist">
+    PRFlow builds a checklist of the claims this specific change makes: dependency interactions, test and mock alignment, data-format assumptions, API contracts and absolute claims. It removes overlapping checks. Simple presence or absence claims are resolved directly. Deeper claims go to a reviewer for evidence-based evaluation.
 
-### Verification Checklist
+    Each item comes back as pass, fail or inconclusive. A failed item and an inconclusive item both prevent a clean approval.
+  </Step>
 
-PRFlow builds a change-specific verification checklist. It removes overlapping checks. It can evaluate simple presence or absence claims automatically. It sends deeper claims to a reviewer for evidence-based evaluation.
+  <Step title="Specialized Reviewers">
+    PRFlow dispatches reviewers with different focus areas, in separate contexts, so they do not inherit each other's conclusions. Four always run and two run only when the change warrants them.
 
-A failed or inconclusive checklist item prevents a clean approval.
+    Findings identify a file, a line and a defect type where possible. PRFlow uses that signature to count independent corroboration: when several reviewers report the same defect, confidence in the finding rises. A finding from a single reviewer stays visible for closer human scrutiny.
+  </Step>
 
-### Specialized Reviewers
+  <Step title="Verdict">
+    PRFlow combines the checklist results, the findings, which reviewers completed and the configured severity threshold into one verdict. It reports incomplete checklist items and any reviewer that did not complete.
+  </Step>
+</Steps>
 
-PRFlow requests reviewers with different focus areas, including code correctness, tests, comments, silent failures and type design. Findings identify a file, line and defect type when possible.
+## Which Reviewers Run
 
-PRFlow uses those signatures to count independent corroboration. Agreement from several reviewers raises confidence in a finding. A single-source finding remains visible for closer human scrutiny.
+Four reviewers run on every review:
 
-### Verdict
+| Reviewer | What it looks for |
+| --- | --- |
+| Code reviewer | Correctness problems, plus adherence to the project's own guidelines, conventions and patterns |
+| Silent-failure hunter | Swallowed errors, over-broad exception handling and fallbacks that mask a failure or fail open |
+| Comment analyzer | Comments and docstrings that do not accurately describe the code they sit beside |
+| Final-pass reviewer | A fresh independent read of the completed work against what it was supposed to do |
 
-PRFlow combines checklist results, findings, completed reviewers and configured severity thresholds into an approval-side or rejection verdict. It reports incomplete checklist items and reviewers that did not complete.
+Two more run only when the diff warrants them:
+
+| Reviewer | When it runs |
+| --- | --- |
+| Type-design analyzer | The change adds new types |
+| Test analyzer | The change touches test files, or adds new logic that can be tested |
+
+<Note>
+  A reviewer that does not run is not a reviewer that found nothing. When two or more reviewers fail to return results, PRFlow adds a partial review coverage note to the verdict so you can see the gap.
+</Note>
+
+## The Verdict Vocabulary
+
+Every review reports one of five verdicts.
+
+| Verdict | What it means |
+| --- | --- |
+| `APPROVE` | No findings and no failed or inconclusive checklist item. |
+| `APPROVE with notes` | Findings exist, but all of them are below the configured severity threshold. |
+| `APPROVE WITH CAVEAT` | Approved, but part of the review could not be completed. It is never a clean approval. |
+| `APPROVE WITH ADVISORY NOTES` | The fix loop approved and parked findings it deliberately did not fix, for a person to read. |
+| `REJECT` | Something blocking was found. |
+
+<Warning>
+  An approval-family verdict is evidence for your review. It is not proof of correctness and it is not authorization to merge.
+</Warning>
+
+## What Drives a Rejection
+
+Any one of these produces a `REJECT`:
+
+- A verification-checklist item that **failed**.
+- A verification-checklist item that was **inconclusive**. An unknown result is treated as blocking, not as a pass.
+- A finding at or above the configured severity threshold. The default is `critical`, so only critical findings reject. Set `prflow_review.verdict_severity_threshold` to `important` or `suggestion` to make more findings reject. See [Review Settings](/docs/configuration/review).
+
+### The Rule That Surprises People
+
+There is one more rejection rule, and it does not read the severity threshold at all.
+
+<Warning>
+  If the change's **own diff** added or modified a documentation line, a code comment or a test that is untrue, that alone produces a `REJECT`. It rejects at every threshold setting, including the default. It cannot be lowered by severity configuration and it cannot be waived by deferring the finding. Only fixing the untrue line clears it.
+</Warning>
+
+"Untrue" here means the added or modified line contradicts the code as it now stands, is already stale or contradicts another part of the same change. PRFlow treats this as a correctness principle rather than a severity grade: a change that documents itself incorrectly is wrong regardless of how minor the wording looks.
+
+<Accordion title="Why this rule is absolute">
+  A wrong comment or a wrong documentation line survives the pull request and misleads every reader afterwards, including the next automated run. A severity threshold exists so a team can decide how much polish blocks a merge. It is not meant to let a change ship a statement about itself that is false. Rating that as a suggestion, and then letting the default threshold ignore it, is exactly how such lines used to reach the default branch.
+</Accordion>
 
 ## Review and Fix
 
-`review-and-fix` uses the same review process in a correction loop. It evaluates findings and applies justified corrections. It verifies each correction and reviews the result again. The configured default cap is five fix iterations.
+`/prflow:review-and-fix` runs the same engine inside a correction loop. It evaluates each finding, applies the corrections it can justify, verifies each correction and reviews the result again. The configured default cap is five fix iterations.
 
-Before an approval-side result stands, a shadow pass reviews the diff again without the primary reviewers' conclusions. It can return a missed finding to another iteration. It also reports which planned reviewers completed and any known coverage gaps. No reported gap proves only that PRFlow recorded no known gap, not that every defect was found.
+Before an approval-side result stands, a shadow pass reviews the diff again without seeing the primary reviewers' conclusions. It can send a missed finding back into another iteration. It also reports which planned reviewers completed and any coverage gap it knows about.
 
-The inline review-and-fix loop reports its result in the session. Run the standalone `review` workflow when you want PRFlow to attempt a formal pull-request review verdict.
+<Note>
+  A report with no gaps means only that PRFlow recorded no known gap. It does not mean every defect was found.
+</Note>
+
+The inline review-and-fix loop reports its result in your session. Run the standalone [review workflow](/docs/workflows/review) when you want a formal pull-request review verdict recorded on GitHub.
 
 ## What Independent Review Means
 
-Independent prompts and reviewer contexts reduce shared blind spots. Agreement from several reviewers and a fresh shadow pass can expose an unsupported approval.
+Separate prompts and separate reviewer contexts reduce shared blind spots. Corroboration across several reviewers, and a fresh shadow pass, can expose an approval that nothing actually supports.
 
-They narrow risk. They do not eliminate it. Reviewers can share model limitations, tests can encode the same mistaken assumption as the implementation and production conditions can differ from the repository environment.
+They narrow the risk. They do not remove it. Reviewers can share the same model limitations, a test can encode the same mistaken assumption as the implementation it covers and production conditions can differ from the repository environment.
 
-Use the review output as structured evidence for human review. Do not treat an `APPROVE` verdict as proof of correctness or as authorization to merge.
+Use the review output as structured evidence for your own review.
 
 ## Related Documentation
 
 - [Review Workflow](/docs/workflows/review)
 - [Review and Fix Workflow](/docs/workflows/review-and-fix)
+- [Review Settings](/docs/configuration/review)
+- [Review Agent Settings](/docs/configuration/review-agents)
+- [How PRFlow Verifies a Change](/docs/concepts/verification)
 - [Human Control](/docs/concepts/human-control)

--- a/docs/external/docs/concepts/security.md
+++ b/docs/external/docs/concepts/security.md
@@ -1,0 +1,146 @@
+---
+title: "Security and Trust"
+description: "Review what PRFlow can write, who can start a run, where a run reads its rules from and which secrets are involved."
+---
+
+Review PRFlow's security posture before you adopt it. This page states what the tool can do, what bounds it and what you still have to decide for yourself.
+
+## What PRFlow Can Write
+
+PRFlow writes to GitHub, and only to GitHub. It has no other destination.
+
+| It can write | Where |
+| --- | --- |
+| Issue comments | The issue the run is working on, including the progress workpad |
+| Branches, commits and pushes | The feature branch for the issue |
+| Pull requests | The pull request for that branch, and its description |
+| Reviews | The pull request under review, as an approval or a request for changes |
+| Follow-up issues | The same repository, for deferred work |
+| Labels and reactions | The issues, pull requests and comments involved in the run |
+
+<Warning>
+  PRFlow never merges a pull request. There is no configuration setting that makes it merge. The integration decision is always a person's.
+</Warning>
+
+Every write is an ordinary GitHub write under an identity you configure, so all of it is visible in the repository's history and audit log. Nothing PRFlow does bypasses branch protection, required checks or required approvals.
+
+<Note>
+  A run can only make a write its identity has permission to make. If you give the run less access, it does less, and it reports what it could not do rather than working around it.
+</Note>
+
+## Who Can Start a Cloud Run
+
+A cloud run starts from a comment. Not from an issue body, not from a pull-request body and not from a title — only from a real comment posted after the fact.
+
+Before any work begins, the run checks who posted that comment:
+
+- **A person** must match `prflow.allowed_users` **and** hold write, maintain or admin permission on the repository. The setting defaults to `*`, which means any collaborator, and the permission check still applies on top of it. Narrow it to specific logins when you want a shorter list.
+- **A bot** must appear in `prflow.allowed_bots`. Automation identities do not get the collaborator check, so list only the ones you intend to let incur runs.
+
+The gate fails closed. If the identity or the permission level cannot be established, the run declines rather than proceeding.
+
+<Note>
+  An outside contributor working from a fork cannot start a privileged run by commenting on their own pull request. They do not hold repository permission, so the gate declines.
+</Note>
+
+See [Cloud Triggers](/docs/runs/cloud/triggers) for the comment forms and [Core Settings](/docs/configuration/core-settings) for the two settings.
+
+## The Trust Boundary on a Cloud Run
+
+This is the part worth reading twice, because it is what makes automated review meaningful.
+
+A cloud run reads the rules that govern it — the workflow definition, the repository configuration, the permitted tool list and the prompt extensions that shape the agent's instructions — from the repository's **default branch**. It does not read them from the pull request being reviewed.
+
+<Warning>
+  A pull request cannot rewrite the rules that review it. It cannot grant itself extra tools, enable extra provisioning for its own review, choose which version of the plugin reviews it or write instructions into the reviewing agent's own prompt.
+</Warning>
+
+```mermaid
+flowchart LR
+    accTitle: Where a cloud review run reads its rules and its code
+    accDescr: The rules that govern a review run — the workflow definition, repository configuration, permitted tools and prompt extensions — are read from the repository's default branch. Only the code under review comes from the pull request. The review job combines them and produces findings and a verdict for a person to act on.
+    subgraph trusted["Default branch — the pull request cannot change this"]
+        rules["Workflow definition<br/>Repository configuration<br/>Permitted tool list<br/>Prompt extensions"]
+    end
+    subgraph untrusted["Pull request — written by the contributor"]
+        code["The code under review<br/>Issue and comment text"]
+    end
+    rules -- "rules" --> job["Review job"]
+    code -- "content to review, treated as data" --> job
+    job --> out["Findings and a verdict<br/>for a person to act on"]
+```
+
+The reason is direct: the review job has to check out the contributor's code in order to review it, and anything that code could change about the review would be a floor the pull request controls. A floor the pull request controls is no floor. So the governing inputs are taken from a source the pull request cannot reach, and when a trusted copy cannot be established the run fails closed rather than falling back to the pull request's copy.
+
+The code under review is still fully reviewed. Only the **rules** come from elsewhere.
+
+## Content From Users Is Data, Not Instructions
+
+A run reads text that people outside your team may have written: issue bodies, pull-request descriptions, comments and the names of CI checks. Anyone who can open a pull request can choose what those say.
+
+PRFlow treats all of it as **data to quote, never as instructions to obey**. Check names in particular are attacker-controlled free text, so a run is told up front to quote a check name and never to act on one — while still trusting the pass or fail conclusion beside it, which comes from the GitHub API rather than from the name.
+
+<Note>
+  This is a mitigation, not a proof. Prompt injection is an unsolved problem in the industry, and no instruction-level defense is complete. Treat it as one layer among the others on this page, and keep human review of the resulting diff.
+</Note>
+
+An unknown CI state is never presented to the agent as a passing one. When PRFlow cannot read the CI results for a commit, it says the results are unavailable rather than reporting green.
+
+## The Reviewer Path Is Read-Only
+
+The reviewing path is separated from the writing path on purpose.
+
+- Review runs use a separate identity from the one that authors pull requests. That separation is what lets a review be recorded at all, since GitHub does not let an author formally review their own pull request.
+- Tools that modify the working tree are removed from the reviewer's permitted set before the run starts, regardless of what the repository's configuration asks for. Configuration can narrow that set. It cannot widen it past the built-in floor.
+- The removal is by tool name, so a narrowed or parameterized spelling of a tree-modifying tool is removed exactly like the plain one.
+- The review agents are contractually forbidden from modifying the working tree. Independently of that, the engine takes a snapshot of the tree before dispatching them and compares it afterwards, so a violation is detected and reported rather than trusted not to happen.
+
+<Warning>
+  Read-only means the reviewer does not modify your code. It does not mean the reviewer is infallible. Read [The Review System](/docs/concepts/review-system) for what a verdict does and does not establish.
+</Warning>
+
+## Credentials
+
+The cloud tier needs **one secret** by default: a Claude Code authentication token, stored as a GitHub Actions secret. GitHub operations use the built-in `GITHUB_TOKEN`, which needs no setup.
+
+Two optional additions exist:
+
+- **A GitHub App**, if you want cloud writes to appear under your own App identity instead of the built-in Actions identity, or if you need runs to be able to edit workflow files. Each step mints a short-lived token scoped to just what that step does.
+- **A model provider key**, if you route a workflow section through a third-party model provider. With no provider configured, the default stays a single secret.
+
+The review path runs under its own identity with read-only repository access, so the identity that reviews cannot push.
+
+See [Cloud Setup](/docs/runs/cloud/setup) and [Providers](/docs/configuration/providers).
+
+## Local Runs
+
+A local run executes in your Claude Code session, on your machine, under your client's permission prompts. It uses your existing Git and GitHub CLI credentials — PRFlow stores none of its own.
+
+The same boundaries apply: it writes only the GitHub artifacts listed above and it never merges. Grant permissions at the narrowest useful scope. See [Local Permissions](/docs/runs/local/permissions).
+
+## What You Should Still Review Yourself
+
+<CardGroup cols={2}>
+  <Card title="Who has write access" icon="users">
+    PRFlow's gate controls who can start a run. It does not change what write access already means. Anyone with write access to a repository can reach its Actions secrets through workflows they push, whether or not PRFlow is installed. Manage that list first.
+  </Card>
+  <Card title="The tool permissions you grant" icon="key">
+    Every command a run may execute comes from a list you commit. Review it as you would review a CI script, and keep broad shell, filesystem and credential access out of it.
+  </Card>
+  <Card title="The prompt extensions you commit" icon="file-pen">
+    Prompt extensions change how PRFlow behaves in your repository. They are committed files on your default branch, so review changes to them like code.
+  </Card>
+  <Card title="Every diff before merging" icon="code-pull-request">
+    The review evidence is input to your decision, not a replacement for it. Read the code, the tests and the workpad reflections before you merge.
+  </Card>
+</CardGroup>
+
+## Related Documentation
+
+- [Human Control](/docs/concepts/human-control)
+- [The Review System](/docs/concepts/review-system)
+- [How PRFlow Verifies a Change](/docs/concepts/verification)
+- [Cloud Triggers](/docs/runs/cloud/triggers)
+- [Cloud Setup](/docs/runs/cloud/setup)
+- [Tool Permissions](/docs/configuration/tool-permissions)
+- [Core Settings](/docs/configuration/core-settings)

--- a/docs/external/docs/concepts/verification.md
+++ b/docs/external/docs/concepts/verification.md
@@ -1,0 +1,121 @@
+---
+title: "How PRFlow Verifies a Change"
+description: "Understand what recorded verification evidence means, which results count and what happens when a check cannot run."
+---
+
+Understand what PRFlow means when it says a run recorded verification evidence.
+
+PRFlow does not decide for itself whether a change works. It runs your repository's own checks, reads what they returned and records that. Everything on this page follows from one rule: **a result PRFlow did not establish is unknown, and unknown never counts as a pass.**
+
+## PRFlow Runs Your Checks, Not Its Own
+
+PRFlow has no test framework of its own. It runs the tests, linters and build commands your repository already has, in the environment the run is executing in, using commands your repository configures and permits.
+
+That means two things:
+
+- The quality of PRFlow's verification is the quality of your test suite. PRFlow can only report what your checks are able to detect.
+- PRFlow can only run a command you have permitted. See [Tool Permissions](/docs/configuration/tool-permissions).
+
+A cloud implementation run can execute a command only if the run's permitted tool list covers it. `prflow_implement.allowed_tools` is where you add your repository's own commands. Here is how you permit a test command:
+
+```json
+{
+  "prflow_implement": {
+    "allowed_tools": [
+      "Bash(npm test:*)",
+      "Bash(npm run lint:*)"
+    ]
+  }
+}
+```
+
+With that in place, a run can execute `npm test` and `npm run lint` and record what they returned. Without it, the same commands are refused before they run.
+
+<Note>
+  `prflow_implement.allowed_tools` covers implementation runs. It does not inherit from `prflow.allowed_tools`, which covers the general cloud command workflow. Set the one that matches the runs you want to change.
+</Note>
+
+## A Focused Check Is Not a Finished Job
+
+While PRFlow is iterating on a change, it runs the narrow check that covers the code it just touched. That is the right thing to do mid-change: it is fast and it tells the run whether the last edit worked.
+
+A focused check is evidence **for that iteration**. It is not evidence that the change is finished, because it only ever covered the part of the repository it was selected for. Before a run can report `Complete`, it needs a result that covers the full set your repository expects, not the slice it happened to iterate on.
+
+<Warning>
+  If you read a run's evidence and see only a narrow test file, that is iteration evidence. It does not tell you the whole suite passed.
+</Warning>
+
+## Unknown Is Never a Pass
+
+This is the rule that decides most of PRFlow's behavior around verification. Each of these is an **unknown** result, and none of them lets a run claim its work is verified:
+
+| Result | Why it is not a pass |
+| --- | --- |
+| The check was skipped | Nothing ran, so nothing was established. |
+| The check could not run | A missing tool, a refused command or a broken environment produced no verdict. |
+| The check is still running | There is no result yet. |
+| The check reported nothing at all | A refused command can produce no output, which looks the same as silence. |
+| The result could not be read | An unreadable or incomplete record is not a verdict. |
+
+A run that ends with any of those in place of a required result stops and says so. It does not round the unknown down to a pass and it does not round it up to a failure. It reports that the result was never established.
+
+<Accordion title="Why silence is treated as unknown rather than success">
+  A command that a permission boundary refuses does not print an error the way a failing test does. It simply produces nothing. If a run treated "no output" as "no problems", every refused check would read as a clean pass, and the runs most likely to be under-verified would be the ones reporting the cleanest results. Treating silence as unknown is what makes that failure visible instead of invisible.
+</Accordion>
+
+## When a Needed Command Is Not Permitted
+
+If verifying an acceptance criterion requires a command the run is not permitted to execute, PRFlow does not skip the criterion and does not quietly mark it satisfied.
+
+The run stops. It records `Blocked` on the workpad, names the criterion it could not verify and names the permission setting you would add to unblock it. On the workpad you see:
+
+```markdown
+**Status:** 👎 Blocked
+```
+
+with the recorded cause in the run's notes. Add the command to the relevant `allowed_tools` list and run the command again.
+
+<Tip>
+  A missing tool or an environment gap is treated the same way. It is a reason to stop and ask a person, not a reason to call the criterion post-merge work.
+</Tip>
+
+## Continuous Integration Is a Different Gate
+
+Your CI is the check a person reads before merging. It runs on the pull request, under your branch protection rules, on your infrastructure. PRFlow does not merge and does not tick anything on your behalf there. See [Human Control](/docs/concepts/human-control).
+
+CI is **not** a substitute for the run verifying its own work. An implementation run has to establish its own result while it is still working, because a run that outsources its verification to a later CI job is reporting on a change it never checked. When the run finishes, both signals exist for you: the evidence the run recorded, and CI's independent result on the pushed commit.
+
+<Note>
+  A cloud implementation run never waits for CI, polls it or cites it as its own test evidence. It verifies in its own environment and leaves CI to you.
+</Note>
+
+## What the Evidence Looks Like
+
+Verification evidence is recorded on the workpad, alongside the run's other progress. The `Review` section of the progress checklist shows the gate that consumes it:
+
+```markdown
+## Progress
+- [ ] **Review**
+  - [x] `/simplify`
+  - [x] `review-and-fix`
+  - [ ] acceptance-criteria gate
+```
+
+The acceptance-criteria gate is where verification evidence is actually spent. Every in-scope acceptance criterion must be supported by a passing check, a documented manual check or a code reference before the run may finish. A criterion that could not be established blocks exactly the same way a criterion that failed blocks.
+
+A criterion that genuinely needs a real deployed environment is the one exception. It is tagged as post-merge work, left unticked and surfaced in the pull-request description for you to verify after merging. A criterion that is merely awkward to verify does not qualify.
+
+## What This Does Not Promise
+
+- Passing checks mean your checks passed. They do not mean the change is correct.
+- Verification evidence cannot show a defect your test suite has no way to detect.
+- The run environment can differ from production.
+- A recorded pass is a record of what a command returned at one point in time on one commit.
+
+## Related Documentation
+
+- [The PRFlow Lifecycle](/docs/concepts/lifecycle)
+- [Workpads and Resume](/docs/concepts/workpads-and-resume)
+- [The Review System](/docs/concepts/review-system)
+- [Tool Permissions](/docs/configuration/tool-permissions)
+- [Implement an Issue](/docs/workflows/implement)

--- a/docs/external/docs/concepts/workpads-and-resume.md
+++ b/docs/external/docs/concepts/workpads-and-resume.md
@@ -1,57 +1,135 @@
 ---
 title: "Workpads and Resume"
-description: "Understand PRFlow's recorded progress and interruption boundaries."
+description: "Read the progress comment PRFlow writes on an issue, and understand which work survives an interruption."
 ---
 
-PRFlow records durable implementation progress so a paused, stopped or retriggered run can continue without reconstructing the work from scratch.
+PRFlow records durable progress on the issue, so a paused, stopped or retriggered run can continue instead of rebuilding the work from scratch.
 
 ![The prflow:implement skill resumes from two kinds of recovery evidence: the GitHub issue workpad and the remote branch. A Blocked workpad causes PRFlow to surface the recorded cause. If matching open work exists, PRFlow adopts it, inspects the current tree and repeats blocking checks.](/images/workpad-resume.svg)
 
 ## The Workpad
 
-An implementation run maintains exactly one dedicated progress comment on its GitHub issue. This workpad is the human-readable progress record for the run.
+The **workpad** is a progress comment PRFlow writes on the GitHub issue. It is the human-readable record of the run. PRFlow edits that same comment as the run proceeds instead of posting a new comment at each step.
 
-It records:
+This is what one looks like partway through a run:
 
-- The current lifecycle status and feature branch.
-- The pull-request link after one exists.
-- The implementation plan and progress checklist.
-- The issue's acceptance criteria and their checked state.
-- Reproduction evidence for bug reports.
-- Blockers, deferrals, dropped work and other reflections a human should inspect.
+```markdown
+# PRFlow Workpad — Issue #123
 
-PRFlow updates the same comment instead of posting a new progress comment at each step. The inline review-and-fix phase also records its review stages in this workpad instead of opening a separate progress comment on the draft pull request. A local run creates the workpad as its first GitHub write. A cloud run can create an initial version before implementation begins, then fill it in during setup.
+**Status:** 🚀 Implementing
+**Branch:** issue-123-retry-on-timeout
+**Run:** https://github.com/acme/api/actions/runs/1234567890
+**PR:** https://github.com/acme/api/pull/456
+**Last updated:** 2026-08-26 09:14 UTC
+
+## Progress
+- [x] **Setup** — branch & workpad
+- [ ] **Implement**
+  - [x] reproduction captured (bug issues only)
+  - [ ] code + sweeps
+- [ ] **Review**
+  - [ ] `/simplify`
+  - [ ] `review-and-fix`
+  - [ ] acceptance-criteria gate
+- [ ] **Documentation**
+- [ ] **PR marked ready**
+
+## Plan
+- [x] Add a bounded retry around the upstream call
+- [ ] Cover the timeout path with a test
+
+## Acceptance Criteria
+- [ ] A request that times out is retried at most three times
+
+## Devflow Reflection
+```
+
+### The Header Fields
+
+| Field | What it tells you |
+| --- | --- |
+| `Status` | The run's current state, with a glyph in front of it. |
+| `Branch` | The feature branch the run is working on. |
+| `Run` | A link to the job log for the run. Open this when you want to see what the run actually did. |
+| `PR` | A link to the pull request, once one exists. Before that it reads `_not yet created_`. |
+| `Last updated` | When PRFlow last edited the comment. |
+
+<Note>
+  On a local run there is no job to link to, so `Run` will not point at a cloud job log.
+</Note>
+
+### The Sections
+
+- **Progress** — the run's own checklist, one row per stage. The `reproduction captured` row appears only on issues classified as bug reports.
+- **Plan** — the implementation plan, ticked as it is carried out.
+- **Acceptance Criteria** — the issue's criteria, mirrored here and ticked as each one is verified.
+- **Devflow Reflection** — blockers, deferrals, dropped work and anything else a person should read before merging. It is collapsed by default. **This heading deliberately keeps the older spelling.** It is not a typo and renaming it would break the tools that read the section.
+- **Reproduction** — reproduction evidence, on bug issues.
+
+## Status Words and Glyphs
+
+The `Status` line carries a glyph and a status word. The glyph tells you the shape of the state at a glance and the word tells you where the run is.
+
+| Glyph | Meaning | Status words |
+| --- | --- | --- |
+| 🚀 | Running | `Setup`, `Discovering`, `Reproducing`, `Planning`, `Implementing`, `Reviewing`, `Documenting` |
+| 🎉 | Finished its configured lifecycle | `Complete` |
+| 👎 | Stopped and needs a person | `Blocked` |
+| 💥 | The run did not reach a normal end | `Failed` |
+| 🛑 | The run was cancelled | `Cancelled` |
+
+Three of those glyphs — 🚀, 🎉 and 👎 — also appear as a reaction on the comment that started the run, so you can see a run's outcome without opening the workpad. `Failed` and `Cancelled` are written by a cloud backstop when a run dies or is cancelled, and they have no matching reaction.
+
+<Tip>
+  A workpad that still shows a 🚀 status long after the run should have ended usually means the run stopped without writing its own terminal state. Open the `Run` link and read the job log.
+</Tip>
+
+## One Comment Per Run, Best Effort
+
+PRFlow aims to keep a single progress comment per issue and it identifies that comment by a marker rather than by who wrote it. That is a best-effort convention, not a concurrency guarantee. Two runs started against the same issue at the same time can both write, and nothing in the design prevents a duplicate progress comment from appearing.
+
+<Warning>
+  Do not treat the presence of exactly one workpad as proof that only one run touched the issue. If you see two, read both and check the `Run` links before deciding which one reflects the current branch.
+</Warning>
 
 ## How Resume Finds Prior Work
 
-On a later implementation command, PRFlow reads the existing workpad before planning. It also queries open pull requests associated with the issue.
+On a later implementation command, PRFlow reads the existing workpad before it plans anything. It also queries the open pull requests linked to the issue.
 
-When it can establish a matching open pull request, it adopts that pull request's head branch. A recorded, in-progress plan can let the run skip repeated discovery. PRFlow still checks the current tree and repeats any check that can block the run.
+When it can establish a matching open pull request, it adopts that pull request's head branch. A recorded, in-progress plan can let the run skip repeated discovery. PRFlow still inspects the current tree and repeats any check that can block the run.
 
-If the workpad is already `Blocked`, PRFlow surfaces the recorded cause instead of silently continuing through it. Resolve the cause and confirm the next step before proceeding.
+If the workpad is already `Blocked`, PRFlow surfaces the recorded cause instead of continuing through it. Resolve the cause first.
 
 ## Code Checkpoints
 
-The workpad preserves decisions and status. Commits and pushes preserve code.
+The workpad preserves decisions and status. Only commits and pushes preserve code.
 
-During implementation, PRFlow creates scoped code checkpoints at major substep and verification boundaries. It stages only explicitly named paths and creates a commit when there is new work. It then checks that the pushed commit reached the tracked remote branch.
+During implementation PRFlow creates scoped checkpoints at stage boundaries. It stages **only paths it names explicitly**, creates a commit when there is new work and then confirms the pushed commit actually reached the remote branch.
 
-These checkpoints reduce the amount of work an interrupted run must repeat. They do not make every moment durable.
+Those checkpoints reduce how much an interrupted run has to repeat. They do not make every moment durable.
 
 ## What a Checkpoint Does Not Guarantee
 
-- Analysis that exists only in the active session is not durable by itself.
-- Edits made after the latest successful commit and push can still be lost with an interrupted environment.
-- A workpad update can fail during a GitHub outage, so the branch and repository state must still be inspected on resume.
-- A checkpoint cannot prove that tests are correct, that a review found every defect or that a later default-branch change will merge cleanly.
-- Local runs do not gain the cloud workflow's bounded automatic resume behavior. Run the implementation command again when a local session stops.
+- A file that is never named at any checkpoint is never committed. Staging is deliberately explicit — PRFlow never stages everything in the working tree — so a file that no checkpoint names stays uncommitted and is lost with the environment.
+- Analysis that exists only in the live session is not durable on its own.
+- Edits made after the last successful commit and push can still be lost if the environment is interrupted.
+- A workpad update can fail during a GitHub outage, so the branch and repository state still have to be inspected on resume.
+- A checkpoint cannot prove that the tests are right, that the review found every defect or that the branch will still merge cleanly later.
+- A local run does not get the cloud workflow's bounded automatic resume. Run the command again when a local session stops.
 
-Treat the workpad and remote branch as recovery evidence, not as a transaction log. Review them together before deciding what a resumed run should do.
+Treat the workpad and the remote branch as recovery evidence, not as a transaction log. Read them together before deciding what a resumed run should do.
 
 ## Terminal States
 
-- **Complete:** The run finished its configured lifecycle and recorded final verification evidence.
-- **Blocked:** A dependency, acceptance criterion, repository condition or verification requirement needs human action.
-- **Failed or Cancelled:** A cloud backstop recorded that the run did not reach a normal terminal result.
+- **Complete:** The run finished its configured lifecycle and recorded its verification evidence.
+- **Blocked:** A dependency, an acceptance criterion, a repository condition or a verification requirement needs a person.
+- **Failed** or **Cancelled:** A cloud backstop recorded that the run did not reach a normal end.
 
-The pull request remains under human control in every state.
+The pull request stays under human control in every one of those states.
+
+## Related Documentation
+
+- [The PRFlow Lifecycle](/docs/concepts/lifecycle)
+- [How PRFlow Verifies a Change](/docs/concepts/verification)
+- [Implement an Issue](/docs/workflows/implement)
+- [Cloud Run Recovery](/docs/runs/cloud/recovery)

--- a/docs/external/docs/configuration/core-settings.md
+++ b/docs/external/docs/configuration/core-settings.md
@@ -5,18 +5,39 @@ description: "Configure repository defaults, cloud authorization and shared comm
 
 Configure the repository defaults, authorization rules and shared behavior used by PRFlow's local and cloud paths.
 
+## Everyday Settings
+
 | **Setting** | **Type and accepted values** | **Fallback or scaffold** | **Tier and security note** | **Example** |
 | --- | --- | --- | --- | --- |
-| `$schema` | String path or URL | Scaffold: `./config.schema.json` | Editor only. It is ignored at runtime. | `"$schema": "./config.schema.json"` |
 | `base_branch` | String branch name | Runtime and scaffold: `main` | Review and implementation base. Confirm the branch exists. | `"base_branch": "main"` |
 | `claude_model` | String model identifier | Runtime and scaffold: `claude-opus-5` | Global model. Cloud workflows reject an empty value or one that begins with `-`. | `"claude_model": "claude-opus-5"` |
-| `prflow_version` | String tag, branch or commit SHA | Scaffold: empty; installer normally stamps a commit SHA | Thin cloud installs only. An empty runtime pin fails rather than tracking `main`. Vendored mode ignores it. | `"prflow_version": "v2.31.31"` |
 | `prflow.allowed_bots` | Comma-separated string | `claude,dependabot` | All cloud gates. List only automation identities that may incur runs. | `"allowed_bots": "claude,dependabot,my-app"` |
 | `prflow.allowed_users` | `*` or comma-separated logins | `*` | All cloud gates. Humans must also have write, maintain or admin access. | `"allowed_users": "octocat,maintainer"` |
-| `prflow.workpad_marker` | Nonempty string marker | `<!-- prflow:workpad -->` | Implementation state and self-trigger guard. Changing it can make older workpads undiscoverable. | `"workpad_marker": "<!-- prflow:workpad -->"` |
 | `prflow.effort` | `low`, `medium`, `high`, `xhigh` or `max` | Scaffold: `low`; absent runtime fallback: `high` | General cloud command workflow. Provider routes omit effort unless the provider supports it. | `"effort": "low"` |
 | `workflows.prflow` | Boolean | Scaffold: `true`; absent workflow read resolves disabled | Both fresh-install cloud workflows. Keep config committed or triggers cannot enable. | `"prflow": true` |
-| `workflows.prflow-review` | Boolean | Scaffold: `false` | **Retained legacy setting.** It enables nothing in a fresh install because the automatic-review files are not shipped. Existing installations that retained those files remain exposed to their documented defects. | `"prflow-review": false` |
+
+<Warning>
+  `prflow.allowed_users` decides who can spend money and change your repository from a comment. The default `*` allows any collaborator with write, maintain or admin access. Narrow it to named logins on a repository whose collaborator list is wider than the set of people you want triggering runs.
+
+  `prflow.allowed_bots` is separate and is not covered by `allowed_users`. Adding an automation identity there lets that automation start runs on its own.
+</Warning>
+
+<Note>
+  `prflow.effort` is the clearest case where the scaffolded file and the runtime fallback differ. `/prflow:init` writes `"effort": "low"`, but a config with no `prflow.effort` key at all resolves to `high`. Deleting the key does not restore the scaffolded value.
+</Note>
+
+<Accordion title="Settings you rarely need to change">
+  | **Setting** | **Type and accepted values** | **Fallback or scaffold** | **Tier and security note** | **Example** |
+  | --- | --- | --- | --- | --- |
+  | `$schema` | String path or URL | Scaffold: `./config.schema.json` | Editor only. It is ignored at runtime. | `"$schema": "./config.schema.json"` |
+  | `prflow_version` | String tag, branch or commit SHA | Scaffold: empty; installer normally stamps a commit SHA | Thin cloud installs only. An empty runtime pin fails rather than tracking `main`. Vendored mode ignores it. | `"prflow_version": "v2.31.31"` |
+  | `prflow.workpad_marker` | Nonempty string marker | `<!-- prflow:workpad -->` | Implementation state and self-trigger guard. Changing it can make older workpads undiscoverable. | `"workpad_marker": "<!-- prflow:workpad -->"` |
+  | `workflows.prflow-review` | Boolean | Scaffold: `false` | **Retained legacy setting.** It enables nothing in a fresh install because the automatic-review files are not shipped. Existing installations that retained those files remain exposed to their documented defects. | `"prflow-review": false` |
+
+  `prflow_version` is normally stamped by the installer. Change it by hand only to pin or roll back a cloud install deliberately. See [Cloud Updates](/docs/runs/cloud/updates).
+
+  If a warning about the retained automatic-review tier applies to your repository, see [Remove the Withdrawn Automatic-Review Tier](/docs/configuration/review#remove-the-withdrawn-automatic-review-tier).
+</Accordion>
 
 ## Valid Core Example
 
@@ -39,4 +60,6 @@ Configure the repository defaults, authorization rules and shared behavior used 
 }
 ```
 
-Use [Providers](/docs/configuration/providers) for `prflow.provider` and `prflow.claude_model`. Use [Tool Permissions](/docs/configuration/tool-permissions) for `prflow.allowed_tools`.
+Expected result: cloud runs are enabled, only `octocat` and `maintainer` may trigger one, and every run works from `main` with `claude-opus-5` at low effort.
+
+Use [Model Providers](/docs/configuration/providers) for `prflow.provider` and `prflow.claude_model`. Use [Tool Permissions](/docs/configuration/tool-permissions) for `prflow.allowed_tools`. To add house rules that no setting expresses, write a [prompt extension](/docs/configuration/prompt-extensions).

--- a/docs/external/docs/configuration/documentation-and-retrospectives.md
+++ b/docs/external/docs/configuration/documentation-and-retrospectives.md
@@ -21,23 +21,30 @@ Adapt PRFlow's documentation pass and local weekly retrospective to your reposit
 
 ## Weekly Retrospective
 
-These settings describe the locally run retrospective workflow, not the shipped GitHub Actions workflows. The table identifies settings that are currently declarative rather than enforced.
+These settings describe the locally run retrospective workflow, not the shipped GitHub Actions workflows. Every key below sits inside the `prflow_retrospective` object. The table identifies settings that are currently declarative rather than enforced.
 
 | **Setting** | **Type and accepted values** | **Fallback or scaffold** | **Security or cost note** | **Example** |
 | --- | --- | --- | --- | --- |
 | `prflow_retrospective.enabled` | Boolean | Scaffold: `true` | Declarative in the current release. Setting it to false does not prevent direct invocation of `retrospective-weekly`. | `"enabled": true` |
-| `retrospective_model` | String model identifier | Scaffold: `claude-sonnet-5` | Controls analysis cost and capability. | `"retrospective_model": "claude-sonnet-5"` |
-| `audit_model` | String model identifier | Scaffold: `claude-opus-5` | Controls audit cost and capability. | `"audit_model": "claude-opus-5"` |
-| `implementation_branch_prefix` | String | `claude/` | Helps select pull requests. Labels and linked issues can also select them. | `"implementation_branch_prefix": "claude/"` |
-| `min_occurrences` | Positive integer | `2` | Higher values require more repetition before filing. | `"min_occurrences": 2` |
-| `cooldown_days` | Nonnegative integer | `3` | Limits repeat filing for a recent open issue. | `"cooldown_days": 3` |
-| `max_issues_per_run` | Nonnegative integer | `3` | Caps new retrospective issues per run. | `"max_issues_per_run": 3` |
-| `max_open_issues` | Nonnegative integer | `10` | Limits the total number of open retrospective issues unless a previously fixed pattern has recurred. | `"max_open_issues": 10` |
-| `max_open_per_category` | Nonnegative integer | `2` | Limits the number of open retrospective issues in one category. | `"max_open_per_category": 2` |
-| `max_prs_per_run` | Positive integer | `500` | Soft cap on scanned pull requests. | `"max_prs_per_run": 500` |
-| `audit_bundle_cap` | Positive integer | `10` | Limits how many pull request records are considered for each recurring pattern. Zero and negative values are rejected. | `"audit_bundle_cap": 10` |
-| `diff_byte_cap` | Positive integer bytes | `204800` | Large diffs are omitted from the pull request information used for retrospective analysis. | `"diff_byte_cap": 204800` |
-| `watched_authors` | Array of login strings | Falls back to `prflow.allowed_bots` | Restricts the primary author population. | `"watched_authors": ["my-bot"]` |
+| `prflow_retrospective.retrospective_model` | String model identifier | Scaffold: `claude-sonnet-5` | Controls analysis cost and capability. | `"retrospective_model": "claude-sonnet-5"` |
+| `prflow_retrospective.audit_model` | String model identifier | Scaffold: `claude-opus-5` | Controls audit cost and capability. | `"audit_model": "claude-opus-5"` |
+| `prflow_retrospective.implementation_branch_prefix` | String | `claude/` | Helps select pull requests. Labels and linked issues can also select them. | `"implementation_branch_prefix": "claude/"` |
+| `prflow_retrospective.watched_authors` | Array of login strings | Falls back to `prflow.allowed_bots` | Restricts the primary author population. | `"watched_authors": ["my-bot"]` |
+
+<Accordion title="Limits on what one retrospective run may file">
+  | **Setting** | **Type and accepted values** | **Fallback or scaffold** | **Security or cost note** | **Example** |
+  | --- | --- | --- | --- | --- |
+  | `prflow_retrospective.min_occurrences` | Positive integer | `2` | Higher values require more repetition before filing. | `"min_occurrences": 2` |
+  | `prflow_retrospective.cooldown_days` | Nonnegative integer | `3` | Limits repeat filing for a recent open issue. | `"cooldown_days": 3` |
+  | `prflow_retrospective.max_issues_per_run` | Nonnegative integer | `3` | Caps new retrospective issues per run. | `"max_issues_per_run": 3` |
+  | `prflow_retrospective.max_open_issues` | Nonnegative integer | `10` | Limits the total number of open retrospective issues unless a previously fixed pattern has recurred. | `"max_open_issues": 10` |
+  | `prflow_retrospective.max_open_per_category` | Nonnegative integer | `2` | Limits the number of open retrospective issues in one category. | `"max_open_per_category": 2` |
+  | `prflow_retrospective.max_prs_per_run` | Positive integer | `500` | Soft cap on scanned pull requests. | `"max_prs_per_run": 500` |
+  | `prflow_retrospective.audit_bundle_cap` | Positive integer | `10` | Limits how many pull request records are considered for each recurring pattern. Zero and negative values are rejected. | `"audit_bundle_cap": 10` |
+  | `prflow_retrospective.diff_byte_cap` | Positive integer bytes | `204800` | Large diffs are omitted from the pull request information used for retrospective analysis. | `"diff_byte_cap": 204800` |
+
+  These limits keep one run from filing a burst of issues into your tracker. Raise them only after you have read what a run files at the default settings.
+</Accordion>
 
 ## Valid Example
 
@@ -74,3 +81,7 @@ These settings describe the locally run retrospective workflow, not the shipped 
   }
 }
 ```
+
+Expected result: the documentation pass writes developer docs under `docs/internal/`, public docs under `docs/external/` and release notes into `docs/external/release-notes.md`, labels the issue `Documented` when it finishes, files deferred work as issues labeled `PRFlow` and `Deferred`, and a weekly retrospective run files at most three issues.
+
+To change how the documentation pass writes, rather than where it writes, use a [prompt extension](/docs/configuration/prompt-extensions) for `docs`.

--- a/docs/external/docs/configuration/implementation.md
+++ b/docs/external/docs/configuration/implementation.md
@@ -5,9 +5,11 @@ description: "Configure implementation output, checkpoints, stalls and verificat
 
 Tune `/prflow:implement` behavior and coordinate verification when multiple agents share the same checkout.
 
+## Implementation Settings
+
 | **Setting** | **Type and accepted values** | **Fallback or scaffold** | **Tier and security note** | **Example** |
 | --- | --- | --- | --- | --- |
-| `prflow_implement.effort` | `low`, `medium`, `high`, `xhigh` or `max` | Scaffold: `low`; absent uses the session or workflow fallback | Local and cloud implementation. Higher values can increase cost and latency. | `"effort": "low"` |
+| `prflow_implement.effort` | `low`, `medium`, `high`, `xhigh` or `max` | Scaffold: `low`; absent runtime fallback: `high` | Local and cloud implementation. Higher values can increase cost and latency. | `"effort": "low"` |
 | `prflow_implement.implement_pr_state` | `ready_for_review` or `draft` | `ready_for_review`; invalid values also publish | Implementation. `draft` leaves the completed pull request for a human to publish. PRFlow never merges it. | `"implement_pr_state": "draft"` |
 | `prflow_implement.update_branch_checkpoints` | Boolean | `true`; only an explicit false disables | Implementation and pushed fix-loop checkpoints. Merges the configured base into the feature branch at defined boundaries. | `"update_branch_checkpoints": true` |
 | `prflow.publish_model_effort` | Boolean | `true`; only an explicit JSON false disables | Governs the provenance line for every command that emits one — the `/prflow:implement` draft pull request and the `/prflow:create-issue` issue alike: when false the line names the plugin version alone, suppressing the model and effort clause. The version is always published. Only the JSON boolean `false` disables it; the string `"false"` and the array `[false]` do not. Supersedes the former per-command key in the `prflow_implement` section, which is now read by nothing. | `"publish_model_effort": true` |
@@ -15,10 +17,27 @@ Tune `/prflow:implement` behavior and coordinate verification when multiple agen
 | `prflow_implement.stall_backstop.max_resume_attempts` | Integer zero or greater | `2`; invalid values use `2` | Cloud implementation. `0` detects and fails without resuming. Each resume can incur another run. | `"max_resume_attempts": 2` |
 | `prflow.attribute_commits_to_triggerer` | Boolean | Runtime and scaffold: `false` | Cloud writer jobs. Applies only to verified human users and changes Git metadata, not the push credential. Trigger-time and post-merge-only. | `"attribute_commits_to_triggerer": true` |
 | `verification_flight.enabled` | Boolean | `true` | Local implementation and inline review-and-fix. Disabling reuse does not turn a missing or stale record into a pass. | `"enabled": true` |
-| `verification_flight.lease_seconds` | Integer zero or greater | `900` | Reserved for future use. Changing this setting has no effect in the current release. | `"lease_seconds": 900` |
-| `verification_flight.wait_timeout_seconds` | Integer zero or greater | Scaffold: `600` | Reserved for future use. Changing this setting has no effect in the current release. | `"wait_timeout_seconds": 600` |
 
-Provider and model overrides for implementation are documented in [Providers](/docs/configuration/providers). Implementation tool grants are documented in [Tool Permissions](/docs/configuration/tool-permissions).
+<Note>
+  `prflow_implement.effort` has no default in the schema, so the scaffolded value and the fallback differ. `/prflow:init` writes `"effort": "low"`. When the key is absent, the shipped implementation workflow resolves it to `high`, the same fallback `prflow.effort` uses. Removing the key raises effort rather than lowering it.
+</Note>
+
+<Warning>
+  `prflow.attribute_commits_to_triggerer` records the person who triggered the run as the author of the commits PRFlow pushes. It changes Git metadata only. The push still uses the workflow's own credential, so this setting does not grant or transfer any access. Enable it knowing that a commit will carry a name that did not write the code.
+</Warning>
+
+<Accordion title="Settings you rarely need to change">
+  | **Setting** | **Type and accepted values** | **Fallback or scaffold** | **Tier and note** | **Example** |
+  | --- | --- | --- | --- | --- |
+  | `prflow_implement.stall_observer.enabled` | Boolean | `true`; only the exact string `false` disables | Report-only observer. It never stops or restarts a run. The workflow that reads it is not installed in a consumer repository, so the value has no effect there today. | `"enabled": true` |
+  | `prflow_implement.stall_observer.advisory_threshold_minutes` | Integer zero or greater | `90`; invalid values use `90` | Report-only observer. How long a run may go without a workpad update before an advisory notice is raised. | `"advisory_threshold_minutes": 90` |
+  | `verification_flight.lease_seconds` | Integer zero or greater | `900` | Reserved for future use. Changing this setting has no effect in the current release. | `"lease_seconds": 900` |
+  | `verification_flight.wait_timeout_seconds` | Integer zero or greater | Scaffold: `600` | Reserved for future use. Changing this setting has no effect in the current release. | `"wait_timeout_seconds": 600` |
+
+  The stall observer and the stall backstop are different things. The backstop runs after the agent step returns and can resume a run. The observer only reports that a run has been quiet for a while.
+</Accordion>
+
+Provider and model overrides for implementation are documented in [Model Providers](/docs/configuration/providers). Implementation tool grants are documented in [Tool Permissions](/docs/configuration/tool-permissions). To give implementation runs a repository-specific rule, such as the verification command they must use, write a [prompt extension](/docs/configuration/prompt-extensions).
 
 ## Valid Implementation Example
 
@@ -44,3 +63,5 @@ Provider and model overrides for implementation are documented in [Providers](/d
   }
 }
 ```
+
+Expected result: an implementation run works at low effort, keeps the feature branch current with the base branch at checkpoints, publishes the finished pull request for review and resumes at most twice if a cloud run stalls.

--- a/docs/external/docs/configuration/index.md
+++ b/docs/external/docs/configuration/index.md
@@ -1,23 +1,100 @@
 ---
 title: "Configuration"
-description: "Configure PRFlow by execution tier without editing the plugin."
+description: "Learn where PRFlow's settings live, when you need them and which page documents each family."
 ---
 
-Adapt PRFlow to your repository with shared settings in `.prflow/config.json`. Keep credentials in GitHub secrets or the local environment.
+Start here to find out what PRFlow reads from your repository and which page documents the setting you need.
 
-Running `/prflow:init` is recommended. It creates the file when absent and backfills newly scaffolded keys without replacing existing values or arrays. Local skills can use built-in defaults without a config file, but cloud workflows require the committed file.
+## Where Configuration Lives
 
-## Configuration Layers
+PRFlow reads one file: `.prflow/config.json` at the root of your repository. It is plain JSON and it is committed, so your whole team and every cloud run see the same values.
 
-- [Settings](/docs/configuration/settings) maps each setting family to its focused reference.
-- [Core Settings](/docs/configuration/core-settings) covers repository, model, authorization and workflow toggles.
-- [Implementation](/docs/configuration/implementation) covers pull-request state, checkpoints, stalls and verification coordination.
-- [Review](/docs/configuration/review) covers verdicts, fix routing and legacy automatic-review settings.
-- [Review Agents](/docs/configuration/review-agents) covers per-agent model and effort overrides.
-- [Providers](/docs/configuration/providers) covers optional cloud model routing.
-- [Runtime Setup](/docs/configuration/runtime-setup) covers languages, services and install commands.
-- [Tool Permissions](/docs/configuration/tool-permissions) covers independent command allowlists.
-- [Documentation and Retrospectives](/docs/configuration/documentation-and-retrospectives) covers docs, deferrals and the weekly retrospective.
-- [Observability and Privacy](/docs/configuration/observability-and-privacy) covers diagnostics, transcripts, denied commands and telemetry storage.
+Two other files sit beside it and are not settings:
 
-Treat configuration as code. Validate the JSON, review tool grants and install commands and commit changes through the same review process as workflow changes.
+- `.prflow/config.example.json` is the scaffolded reference copy. It shows the shape of every section.
+- `.prflow/prompt-extensions/` holds [prompt extensions](/docs/configuration/prompt-extensions), which are instructions rather than values.
+
+Run [`/prflow:init`](/docs/getting-started/initialization) to create the file. It writes the file when it is absent and adds newly scaffolded keys to an existing file without replacing values or arrays you already set.
+
+## When You Need a Config File
+
+<CardGroup cols={2}>
+  <Card title="Local Runs" icon="terminal" href="/docs/runs/local/index">
+    Work with no config file at all. Every setting falls back to a built-in default. Add the file when you want to change one.
+  </Card>
+  <Card title="Cloud Runs" icon="cloud" href="/docs/runs/cloud/index">
+    Require the file, committed to your default branch. A cloud workflow reads it to decide whether it may run at all.
+  </Card>
+</CardGroup>
+
+Cloud workflows resolve their settings from the default branch at the moment a run is triggered. A pull request that changes such a setting does not change its own run. The new value applies after the pull request merges.
+
+## A Starter Config
+
+This is a complete, valid config file. It enables the cloud workflow, names the base branch and grants one test command to the implementation path:
+
+```json
+{
+  "$schema": "./config.schema.json",
+  "base_branch": "main",
+  "claude_model": "claude-opus-5",
+  "prflow_implement": {
+    "allowed_tools": [
+      "Bash(npm test:*)"
+    ]
+  },
+  "workflows": {
+    "prflow": true
+  }
+}
+```
+
+Expected result: local commands keep working exactly as before, cloud runs are enabled for authorized users and a cloud implementation run may invoke `npm test`. Every key not listed keeps its default.
+
+## Setting Families
+
+<CardGroup cols={2}>
+  <Card title="All Settings A to Z" icon="list" href="/docs/configuration/settings">
+    Every setting name in alphabetical order with the page that documents it. Start here when you know the key.
+  </Card>
+  <Card title="Core Settings" icon="sliders" href="/docs/configuration/core-settings">
+    Base branch, model, who may trigger a cloud run and which workflows are enabled.
+  </Card>
+  <Card title="Implementation" icon="code" href="/docs/configuration/implementation">
+    Pull request state, branch checkpoints, stall handling and verification reuse.
+  </Card>
+  <Card title="Review" icon="magnifying-glass" href="/docs/configuration/review">
+    Verdict thresholds, fix routing, progress comments and retained legacy settings.
+  </Card>
+  <Card title="Review Agents" icon="users" href="/docs/configuration/review-agents">
+    Per-agent model, effort and iteration overrides inside the review engine.
+  </Card>
+  <Card title="Prompt Extensions" icon="file-pen" href="/docs/configuration/prompt-extensions">
+    Your team's own instructions, appended to a command on every run.
+  </Card>
+  <Card title="Model Providers" icon="network-wired" href="/docs/configuration/providers">
+    Route cloud execution through a gateway or Amazon Bedrock.
+  </Card>
+  <Card title="Runtime Setup" icon="server" href="/docs/configuration/runtime-setup">
+    Languages, service containers and install commands for the cloud runner.
+  </Card>
+  <Card title="Tool Permissions" icon="lock" href="/docs/configuration/tool-permissions">
+    The repository commands a cloud agent is allowed to run.
+  </Card>
+  <Card title="Documentation and Retrospectives" icon="book" href="/docs/configuration/documentation-and-retrospectives">
+    Documentation paths, deferred-issue labels and weekly retrospective limits.
+  </Card>
+  <Card title="Observability and Privacy" icon="shield-halved" href="/docs/configuration/observability-and-privacy">
+    Diagnostics, transcript artifacts, denied-command records and telemetry storage.
+  </Card>
+</CardGroup>
+
+## Treat Configuration as Code
+
+<Warning>
+  Several settings decide what a cloud agent may run and who may start it. `prflow.allowed_users`, every `allowed_tools` array and every `setup.install` line grant execution or access. Review a change to them as carefully as a change to a workflow file.
+</Warning>
+
+Validate the JSON before you commit it. Cloud config loading checks that the file is valid JSON, but it does not run a full schema check, so a misspelled key can pass unnoticed and leave the default in place.
+
+Next: find your setting in [All Settings A to Z](/docs/configuration/settings), or read [Core Settings](/docs/configuration/core-settings) first if you are setting the file up for the first time.

--- a/docs/external/docs/configuration/observability-and-privacy.md
+++ b/docs/external/docs/configuration/observability-and-privacy.md
@@ -23,10 +23,30 @@ Balance useful cloud-run diagnostics against the sensitivity of prompts, reposit
 
 The transcript and command scrubber is an incomplete blocklist. It covers common GitHub tokens, Anthropic keys and Bearer or basic Authorization headers, whose scheme keyword is matched whatever its casing. An Authorization value shorter than four characters is left alone, so a literal command such as `sed 's/AUTHORIZATION: basic //'` is not mistaken for a credential. Other credential shapes can remain. A scrub failure prevents the affected text from being uploaded or persisted.
 
-**Warning:** A successful scrub does not prove that output is secret-free.
+<Warning>
+  A successful scrub does not prove that output is secret-free. Transcript artifacts and denied-command records go through the scrubber, but Actions diagnostics can still contain truncated tool input. Treat those logs as sensitive.
+</Warning>
 
-- Transcript artifacts and denied-command records use the scrubber.
-- Actions diagnostics can still contain truncated tool input. Treat those logs as sensitive.
+## What a Run Record Contains
+
+`prflow_review_and_fix.efficiency_telemetry_enabled` is on by default, so a review-and-fix run writes one record per run to the telemetry branch. Read this before you decide whether to keep it.
+
+One record is a single JSON file. It holds:
+
+- **Which run it was.** A record format version, the repository slug and the time the record was written. The file name carries the run identifier.
+- **How the run was configured.** A hash of your review settings, so two runs can be compared, plus three values recorded in the clear: the verdict threshold, the fix threshold and the iteration limit.
+- **One entry per fix-loop iteration.** How many review agents ran. Flags describing the shape of the change, such as whether the diff was small, config only or added new types. How the verification checklist was handled and how it split between cheap direct checks and dispatched agents. How many fixes were applied, and whether the iteration applied none at all. Each agent's verdict and whether it led to a fix. The model effort each agent asked for and got.
+- **Cost figures.** Calls, token counts and wall-clock time, per phase and per iteration. A cloud run can also carry a whole-job summary: cost in dollars, tokens, usage per model, number of turns and total duration.
+
+The record holds counts, flags, identifiers and settings. It does not hold your source code, your diff, prompt text or the wording of any finding.
+
+<Warning>
+  The record is not the only thing stored. Each run also copies its workpad to the same branch, and a workpad contains the run's own written notes about the work: what it planned, what it changed and what it deferred. Scrubbed denied-command text can be stored there too. Anyone who can read the repository can read that branch.
+</Warning>
+
+A run with no readable iterations writes no record at all rather than an empty one. Set `efficiency_telemetry_enabled` to false to stop writing records entirely.
+
+## Choose Your Settings
 
 Use repository access controls and artifact retention as part of the privacy decision. Set both text-bearing options to false when even scrubbed prompt or command content is unacceptable:
 
@@ -45,5 +65,7 @@ Use repository access controls and artifact retention as part of the privacy dec
   }
 }
 ```
+
+Expected result: runs still print diagnostics to the Actions log, no transcript artifact is uploaded, no scrubbed command text is stored durably and effectiveness records keep going to the `prflow-telemetry` branch.
 
 Disabling denied-command text does not disable ordinary log diagnostics. Disable `execution_diagnostics_enabled` separately for quieter logs.

--- a/docs/external/docs/configuration/prompt-extensions.md
+++ b/docs/external/docs/configuration/prompt-extensions.md
@@ -1,0 +1,131 @@
+---
+title: "Prompt Extensions"
+description: "Add your team's own standing instructions to any PRFlow command without editing the plugin."
+---
+
+Teach a PRFlow command your repository's rules by committing a Markdown file that the command reads on every run.
+
+## What a Prompt Extension Is
+
+A prompt extension is a Markdown file in your repository whose text PRFlow adds to the end of a command's own instructions each time that command runs.
+
+The file belongs to you, not to the plugin. A plugin update never overwrites it and never conflicts with it, in the same way that your `.prflow/config.json` stays yours across updates.
+
+Settings in `.prflow/config.json` change values PRFlow already knows about. A prompt extension adds instructions PRFlow could not know about, such as the name of your verification command or a rule about code that must never change.
+
+<Warning>
+  A prompt extension has real authority over the run. Its text becomes instructions to an agent that can edit your repository, push commits, open pull requests and decide when work is finished. Anyone who can change the file can change how every later run behaves.
+
+  Review and commit extension files through the same pull request process you use for code. Never put a token, password or other secret in one, because the file is committed to your repository.
+</Warning>
+
+## Where the File Goes
+
+Put the file at `.prflow/prompt-extensions/<command>.md`. Replace `<command>` with the command name without the `/prflow:` prefix.
+
+For example, `/prflow:review` reads `.prflow/prompt-extensions/review.md`.
+
+Running [`/prflow:init`](/docs/getting-started/initialization) creates the directory and writes one commented example per command, named `<command>.md.example`. An example file is inert. It is a single Markdown comment, so it changes nothing even if you rename it by mistake. To activate it, rename it to `<command>.md` and replace the commented body with your own instructions.
+
+Commit the file. Your team shares one copy, and cloud runs read it from the committed tree.
+
+## Which Commands Read One
+
+Every PRFlow command reads its own file. These are the commands documented on this site:
+
+| Command | File it reads |
+| --- | --- |
+| [`/prflow:create-issue`](/docs/workflows/create-issue) | `.prflow/prompt-extensions/create-issue.md` |
+| [`/prflow:implement`](/docs/workflows/implement) | `.prflow/prompt-extensions/implement.md` |
+| [`/prflow:review`](/docs/workflows/review) | `.prflow/prompt-extensions/review.md` |
+| [`/prflow:review-and-fix`](/docs/workflows/review-and-fix) | `.prflow/prompt-extensions/review-and-fix.md` and `.prflow/prompt-extensions/receiving-code-review.md` |
+| [`/prflow:pr-description`](/docs/workflows/pr-description) | `.prflow/prompt-extensions/pr-description.md` |
+| [`/prflow:docs`](/docs/workflows/documentation) | `.prflow/prompt-extensions/docs.md` |
+| [`/prflow:retrospective-weekly`](/docs/workflows/retrospective-weekly) | `.prflow/prompt-extensions/retrospective-weekly.md` |
+| [`/prflow:init`](/docs/getting-started/initialization) | `.prflow/prompt-extensions/init.md` |
+
+`/prflow:review-and-fix` reads two files because its fix loop applies the code-review reception rules without running that command, so a rule you write once in `receiving-code-review.md` reaches every fix pass.
+
+The focused documentation commands read their own files under the same rule: `docs-sync-internal.md`, `docs-sync-external.md`, `docs-release-notes.md`, `docs-verify.md`, `docs-bootstrap-internal.md` and `docs-bootstrap-external.md`. The final-pass reviewer inside the review engine reads `requesting-code-review.md`.
+
+## How the Text Reaches the Run
+
+The command loads the file at the start of the run and appends its contents, word for word, to the end of its own instructions for that run only. Nothing is merged, summarized or rewritten.
+
+Long commands reload the file when they enter a new phase, so your instructions stay in effect through a run that lasts an hour. `/prflow:pr-description` is a single pass and loads it once.
+
+Write the file as instructions, not as background reading. If you want a tool called, say so, because the agent acts on what the text tells it to do.
+
+## Write One
+
+A team keeps its checks behind one command and treats shipped database migrations as immutable. They commit this file.
+
+```markdown
+<!-- .prflow/prompt-extensions/implement.md -->
+
+## Verification
+
+Run `make verify` before reporting any acceptance criterion as satisfied. It runs the unit tests, the type checker and the linter together. Do not substitute a single test file for it.
+
+## Files that must never change
+
+Never edit a file under `db/migrations/`. A migration that has shipped is immutable. If the work needs a schema change, add a new migration file instead.
+
+## Pull request description
+
+Always include a "Rollback" section that says how to undo the change in production.
+```
+
+For a cloud run, also grant the command you named. Installing a tool or naming it in an extension does not permit the agent to run it:
+
+```json
+{
+  "prflow_implement": {
+    "allowed_tools": [
+      "Bash(make verify:*)"
+    ]
+  }
+}
+```
+
+Expected result on the next `/prflow:implement` run: the run reports that the extension loaded, uses `make verify` as its verification command, opens the pull request with a "Rollback" section and refuses to edit a shipped migration, proposing a new migration file instead. See [Tool Permissions](/docs/configuration/tool-permissions) for the grant format.
+
+<Accordion title="Two headings the create-issue extension treats specially">
+  `/prflow:create-issue` reads two headings in `.prflow/prompt-extensions/create-issue.md` by name, in addition to using the whole file as instructions.
+
+  A section headed exactly `## Audit dimensions` is passed to the pass that audits the draft issue, added to its standard checklist. Use it to teach the auditor the assumptions your issues must respect.
+
+  A section headed exactly `## Evidence axes` is passed to the pass that gathers evidence before the draft is written. Use it to name the kinds of evidence a draft must cover for your repository.
+
+  A section runs from its heading line to the next line that starts with `## `. An extension without these headings changes nothing about those passes and still works as ordinary appended instructions. The scaffolded `create-issue.md.example` contains an inert sample of both headings.
+</Accordion>
+
+## Check That It Was Applied
+
+Do not assume the extension was used. Confirm it:
+
+1. Run the command.
+2. Read the command's own output. It reports the extension's resolved status: content was loaded, the file was absent or empty, or the status could not be established.
+3. For `/prflow:implement`, open the workpad comment on the issue. Its progress list carries a `prompt extension resolved` line for each extension the run loaded. The run cannot report itself complete while such a line is unresolved and unexplained.
+
+On a cloud `/prflow:implement` run, the workflow also checks arrival on its own, separately from what the run says about itself. If the repository has an extension whose text never reached the run, the job fails with an error rather than finishing quietly.
+
+## When the File Cannot Be Read
+
+| Situation | What happens |
+| --- | --- |
+| The file is absent, or present but empty | Nothing is appended. The command behaves exactly as it does without an extension. This is not an error. |
+| The file exists but cannot be delivered, such as a broken symlink, a directory in its place or a file the run cannot read | The load fails loudly with an error and the run reports it. A broken extension never disappears silently. |
+| The client refuses the command that loads the file | The run reports the state as unestablished. It never records this as "no extension", because a refused load and an absent file are different facts. |
+
+If a run reports an unestablished state, fix it before you trust the run's output. That run followed none of your house rules.
+
+<Note>
+  On cloud runs the `review`, `review-and-fix`, `pr-description`, `receiving-code-review` and `requesting-code-review` extensions are read from a copy taken from the pull request's base branch, not from the branch under review. A change to one of those files takes effect after it merges. This stops a pull request from editing the instructions its own reviewer follows. See [Security](/docs/concepts/security).
+</Note>
+
+## Keep It Short
+
+The extension's text is added to the run every time, so every line costs tokens on every run. Keep it to the rules that actually change what PRFlow does in your repository, and delete a rule once it stops being true.
+
+Related pages: [Tool Permissions](/docs/configuration/tool-permissions) for granting the commands your extension names, and [Implementation Settings](/docs/configuration/implementation) for the values that are settings rather than instructions.

--- a/docs/external/docs/configuration/providers.md
+++ b/docs/external/docs/configuration/providers.md
@@ -17,10 +17,16 @@ Each key under `providers` is a provider name.
 | `providers.<name>.effort_supported` | Boolean | `false` | Cloud only. False removes `--effort` to avoid gateway rejection. | `"effort_supported": false` |
 | `providers.<name>.env` | Object with environment-variable names and string values | Empty object | Cloud only. Values are exported into the job environment. Some names are refused outright — see *Refused `env` names* below. | `"env": {"CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1"}` |
 
-**Warning:** `.prflow/config.json` is committed repository content. Never place tokens, passwords, private keys or other secret values in `providers.<name>.env`. Store credentials in GitHub Actions secrets and reference only supported secret-backed inputs.
+<Warning>
+  `.prflow/config.json` is committed repository content. Never place tokens, passwords, private keys or other secret values in `providers.<name>.env`. Store credentials in GitHub Actions secrets and reference only supported secret-backed inputs.
+</Warning>
 
-### Refused `env` names
+### Names Checked in the `env` Map
 
+The `env` map is checked before anything is exported. Some names stop the run outright, and four others produce a warning and keep running. Open the list you need.
+
+<AccordionGroup>
+  <Accordion title="Names the job refuses outright">
 The `env` map is exported into the environment of the whole job, not just the model step, so a
 name that means something to the runner does more than add a variable. Before exporting anything,
 the job checks every key against a fixed list of names and **fails with an error naming the key**
@@ -38,9 +44,8 @@ To supply the provider credential, set the `DEVFLOW_PROVIDER_API_KEY` secret ins
 only the background model, use `ANTHROPIC_DEFAULT_HAIKU_MODEL`, which is not refused. The
 remaining names have no alternative and must be removed from the map — including `NODE_OPTIONS`
 and `PYTHONPATH`, which are refused even where your intended use is benign.
-
-### Warned `env` names
-
+  </Accordion>
+  <Accordion title="Names the job warns about and still exports">
 Separately from the refused names above — which stop the run — four names are **warned but not
 refused**. If your `env` map sets any of them, the job prints a warning naming every one it found
 and then **keeps running**; the value you set still takes effect. These are:
@@ -57,6 +62,8 @@ field or the job's own setting. The warning exists so this override is visible i
 rather than surprising you. Matching ignores case and is whole-name, the same rule the refused
 list uses: `home` warns exactly as `HOME` does, while `HOMEDIR` produces no warning. A map that
 names none of the four warned names logs nothing new.
+  </Accordion>
+</AccordionGroup>
 
 ## Section Routing Settings
 
@@ -100,6 +107,8 @@ names none of the four warned names logs nothing new.
 }
 ```
 
+Expected result: the general command path and implementation runs send their model requests to `https://gateway.example.com` using the key in `DEVFLOW_PROVIDER_API_KEY`, and neither passes an effort value, because this entry declares that the route does not support one.
+
 ## Route Through Amazon Bedrock
 
 Set `auth` to `bedrock_api_key` to reach Amazon Bedrock instead of an HTTP gateway. Store a long-lived Bedrock API key in the same `DEVFLOW_PROVIDER_API_KEY` secret — no second secret and no AWS role setup. Such an entry needs no `base_url`; instead it **must** set `AWS_REGION` in its `env` map, and its section's `claude_model` must be a Bedrock-form model identifier (the shipped Claude default is not served by Bedrock).
@@ -122,6 +131,8 @@ Set `auth` to `bedrock_api_key` to reach Amazon Bedrock instead of an HTTP gatew
   }
 }
 ```
+
+Expected result: implementation runs reach Claude through Amazon Bedrock in `us-east-1` with the Bedrock API key in `DEVFLOW_PROVIDER_API_KEY`. Every other section keeps the default Anthropic route.
 
 A `bedrock_api_key` job whose `env` map sets no `AWS_REGION` fails before the model action starts, with an error naming the section and provider. A `bedrock_api_key` entry that also carries a `base_url` runs, but the `base_url` is ignored with a warning.
 

--- a/docs/external/docs/configuration/review-agents.md
+++ b/docs/external/docs/configuration/review-agents.md
@@ -29,6 +29,10 @@ A per-agent `model` override is expressible **only** as one of the four accepted
 
 An agent-specific entry replaces the `default` entry for that agent; the default does not fill missing fields inside a specific entry. The default applies only when no specific entry exists.
 
+<Warning>
+  These overrides apply to the shared review engine, so they change every review your repository runs, including the one a human reads before merging. Moving a reviewer to a smaller model to save money lowers the quality of that merge gate. Change one agent at a time and check the findings you get afterward.
+</Warning>
+
 ## Valid Override Example
 
 ```json
@@ -51,3 +55,5 @@ An agent-specific entry replaces the `default` entry for that agent; the default
   }
 }
 ```
+
+Expected result: every review agent runs at low effort, the deduper runs on Sonnet, the project-guidelines reviewer runs on Opus and takes part only in the first fix-loop iteration, and every other agent keeps the model resolved from `claude_model`.

--- a/docs/external/docs/configuration/review.md
+++ b/docs/external/docs/configuration/review.md
@@ -14,6 +14,10 @@ Tune the shared review engine and the local review-and-fix loop to match your re
 | `prflow_review.stale_prose.enabled` | Boolean | Fallback `true`; scaffold: `false`. Anything except explicit false enables | Shared review engine. Fresh installs scaffold this off, because the check is tuned to prose idioms that are common in the PRFlow repository itself and its false-positive suppression channel only works for bot-authored review comments. Set it to true to enable the automatic check for prose that contains stale numeric claims. | `"enabled": false` |
 | `prflow_review.stale_prose.severity` | `critical`, `important` or `suggestion` | `important` | Shared review engine. The chosen severity participates in verdict computation. | `"severity": "important"` |
 
+<Note>
+  `prflow_review.stale_prose.enabled` is the second place where the scaffolded file and the fallback disagree. `/prflow:init` writes `false`, while an absent key resolves to `true`. Set the value explicitly rather than deleting the key.
+</Note>
+
 ## Review and Fix
 
 | **Setting** | **Type and accepted values** | **Fallback or scaffold** | **Tier and security note** | **Example** |
@@ -23,6 +27,33 @@ Tune the shared review engine and the local review-and-fix loop to match your re
 | `prflow_review_and_fix.efficiency_telemetry_enabled` | Boolean | `true` | Review-and-fix. False disables the effectiveness record and prevents denied-command records from being persisted on the telemetry branch. | `"efficiency_telemetry_enabled": true` |
 | `prflow_review_and_fix.efficiency_cut_candidate_min_dispatch` | Integer one or greater | `3` | Cross-run analysis. It is recorded for later analysis and does not cut an agent during the current run. | `"efficiency_cut_candidate_min_dispatch": 3` |
 | `receiving_review.fix_severity_threshold` | `critical`, `important` or `suggestion` | `critical` | Direct use of the receiving-code-review skill only. The review-and-fix loop uses its own threshold. | `"fix_severity_threshold": "critical"` |
+
+## Valid Review Example
+
+```json
+{
+  "prflow_review": {
+    "verdict_severity_threshold": "critical",
+    "live_progress_comment_enabled": true,
+    "stale_prose": {
+      "enabled": false,
+      "severity": "important"
+    }
+  },
+  "prflow_review_and_fix": {
+    "fix_severity_threshold": "important",
+    "max_iterations": 5,
+    "efficiency_telemetry_enabled": true
+  },
+  "receiving_review": {
+    "fix_severity_threshold": "critical"
+  }
+}
+```
+
+Expected result: a review rejects only on a critical finding, the fix loop corrects findings of important severity or worse and stops after at most five iterations, and each run keeps its own progress comment on the pull request.
+
+To add house review rules that no setting expresses, such as a pattern your reviewers must always flag, write a [prompt extension](/docs/configuration/prompt-extensions) for `review` and `review-and-fix`.
 
 ## Retained Legacy Automatic-Review Settings
 
@@ -34,7 +65,31 @@ Fresh installs do not include automatic pull-request-triggered review. These set
 | `prflow_review.require_ci_green` | Boolean | `true` | Withheld automatic-review caller only. No effect in fresh installs. | `"require_ci_green": true` |
 | `prflow_review.stall_backstop.enabled` | Boolean | `true` | Withheld automatic-review path and limited manual failure recovery. A resume also needs an App and allowed bot identity. | `"enabled": true` |
 | `prflow_review.stall_backstop.max_resume_attempts` | Integer zero or greater | `2` | Retained review backstop. `0` disables resume while retaining detection. | `"max_resume_attempts": 2` |
-| `prflow_runner.effort` | `low`, `medium`, `high`, `xhigh` or `max` | Scaffold: `low` | Withheld reusable runner. No effect in fresh installs. | `"effort": "low"` |
+| `prflow_runner.effort` | `low`, `medium`, `high`, `xhigh` or `max` | Scaffold: `low`; absent runtime fallback: `high` | Withheld reusable runner. No effect in fresh installs. Where that runner is still installed, an absent key resolves to `high`, the same fallback the other effort settings use. | `"effort": "low"` |
 | `prflow_runner.provision_env` | Boolean | Runtime false; scaffold: `false` | Withheld runner. Enabling runs pull-request code with provisioned tools under a privileged workflow. | `"provision_env": false` |
 
-Provider and allowed-tool settings for `prflow_runner` are listed in [Providers](/docs/configuration/providers) and [Tool Permissions](/docs/configuration/tool-permissions), with the same legacy label.
+Provider and allowed-tool settings for `prflow_runner` are listed in [Model Providers](/docs/configuration/providers) and [Tool Permissions](/docs/configuration/tool-permissions), with the same legacy label.
+
+## Remove the Withdrawn Automatic-Review Tier
+
+If your repository installed PRFlow before this tier was withdrawn, the workflow files are still there and still run. The installer leaves them alone by default and prints a notice about them on every upgrade.
+
+<Warning>
+  While those files remain and the review toggle is true, the withdrawn tier keeps running. It triggers on pull-request events, calls a reusable workflow with inherited secrets, checks out the pull request's own code and applies no check on who started the run. Remove it unless you have a specific reason to keep it.
+</Warning>
+
+To remove it, re-run the installer with the opt-in flag. An upgrade run is a preview by default, so pass `--apply` as well:
+
+```bash
+DEVFLOW_REF=<ref> bash devflow-install.sh --apply --remove-withheld-review-tier
+```
+
+For a `curl | bash` invocation that cannot pass arguments, set `DEVFLOW_REMOVE_WITHHELD_REVIEW_TIER=1` instead.
+
+Expected result: the installer deletes the withdrawn workflow files and sets the review toggle to `false` under whichever spelling your config carries.
+
+<Warning>
+  One step is yours, and no installer can do it. Remove the `Devflow Review` context from every branch protection rule or ruleset that requires it. If you leave it required, every later pull request waits forever on a check that nothing will report.
+</Warning>
+
+Do the branch-protection change in the same sitting as the removal. See [Automatic Review](/docs/runs/cloud/auto-review) for what the shipped alternative looks like, and [Human Control](/docs/concepts/human-control) for who may start a review today.

--- a/docs/external/docs/configuration/runtime-setup.md
+++ b/docs/external/docs/configuration/runtime-setup.md
@@ -17,13 +17,24 @@ Provisioning runs in this order: Python, Node.js, PHP, service containers and th
 | `setup.php_tools` | Comma-separated string | Empty uses the setup action's standard tools | Shipped cloud paths. Used only with `php_version`. | `"php_tools": "composer:v2,phpunit"` |
 | `setup.services` | Array of service objects | Empty array starts none | Shipped cloud paths. Images and options are maintainer-controlled but run code on the runner. Docker must be present. | `"services": [{"name":"redis","image":"redis:7","ports":["6379:6379"]}]` |
 | `setup.install` | Array of shell command strings | Scaffold: `["python -m pip install pyyaml"]`; absent runtime fallback: empty array | Shipped cloud paths. Commands run verbatim from the repository root. Treat edits as code execution. | `"install": ["python -m pip install pyyaml", "npm ci --prefix frontend"]` |
-| `setup.claude_code_executable` | Single-line nonblank string path | Scaffold: empty; uses action auto-install | Cloud model jobs. Primarily for a preinstalled Windows executable. Trigger-time and post-merge-only. | `"claude_code_executable": "C:\\Users\\runner\\.local\\bin\\claude.exe"` |
-| `setup.git_dir_pin` | Boolean | `false` | Cloud jobs except implementation. Can misdirect repository-root config reads; leave off unless validated. Post-merge-only. | `"git_dir_pin": false` |
-| `setup.git_work_tree_pin` | Boolean | `false` | Cloud jobs. Breaks remote marketplace cloning; use only with local-only marketplaces. Post-merge-only. | `"git_work_tree_pin": false` |
 
-**Warning:** `.prflow/config.json` is committed repository content. Never place tokens, passwords, private keys or other secret values in `setup.services[].env`. Store credentials in GitHub Actions secrets and reference only supported secret-backed inputs.
+<Warning>
+  Every string in `setup.install` runs on the runner, exactly as written, before the agent starts. A change to that array is a change to what your repository executes in CI. Review it as carefully as a workflow file.
+
+  `.prflow/config.json` is committed repository content. Never place tokens, passwords, private keys or other secret values in `setup.services[].env`. Store credentials in GitHub Actions secrets and reference only supported secret-backed inputs.
+</Warning>
 
 Each `setup.services` object requires string `name` and `image`. Optional `ports` and `options` are arrays of complete strings. Optional `env` is an object of string values. Services are reached on `127.0.0.1:<host-port>`. Use health-check options when readiness matters.
+
+<Accordion title="Settings you rarely need to change">
+  | **Setting** | **Type and accepted values** | **Fallback or scaffold** | **Tier and security note** | **Example** |
+  | --- | --- | --- | --- | --- |
+  | `setup.claude_code_executable` | Single-line nonblank string path | Scaffold: empty; uses action auto-install | Cloud model jobs. Primarily for a preinstalled Windows executable. Trigger-time and post-merge-only. | `"claude_code_executable": "C:\\Users\\runner\\.local\\bin\\claude.exe"` |
+  | `setup.git_dir_pin` | Boolean | `false` | Cloud jobs except implementation. Can misdirect repository-root config reads; leave off unless validated. Post-merge-only. | `"git_dir_pin": false` |
+  | `setup.git_work_tree_pin` | Boolean | `false` | Cloud jobs. Breaks remote marketplace cloning; use only with local-only marketplaces. Post-merge-only. | `"git_work_tree_pin": false` |
+
+  Leave all three at their defaults unless a self-hosted runner needs them. Each takes effect only after the change merges, because cloud jobs read them at trigger time from the default branch. See [Runners](/docs/runs/cloud/runners).
+</Accordion>
 
 ## Valid Runtime Example
 
@@ -53,5 +64,7 @@ Each `setup.services` object requires string `name` and `image`. Optional `ports
   }
 }
 ```
+
+Expected result: the runner installs Python 3.11 and Node.js 20, starts Redis on `127.0.0.1:6379`, installs PyYAML and the frontend dependencies, and only then starts the agent.
 
 Installing a tool does not permit the agent to invoke it. Continue with [Tool Permissions](/docs/configuration/tool-permissions).

--- a/docs/external/docs/configuration/settings.md
+++ b/docs/external/docs/configuration/settings.md
@@ -1,24 +1,142 @@
 ---
-title: "Settings"
-description: "Find the focused reference for each PRFlow configuration family."
+title: "All Settings A to Z"
+description: "Look up any PRFlow setting name and jump to the page that documents it."
 ---
 
-Use this map to find every `.prflow/config.json` setting by purpose. Each linked reference lists types, accepted values, fallbacks, execution scope, security notes and examples.
+Find any `.prflow/config.json` setting by name. Every setting PRFlow reads is listed here once, in alphabetical order, with the page that gives its type, accepted values, default and security note.
 
-| **Configuration family** | **Reference** |
-| --- | --- |
-| `$schema`, `base_branch`, `claude_model`, `prflow_version`, authorization, workpad and workflow toggles | [Core Settings](/docs/configuration/core-settings) |
-| `prflow_implement` and `verification_flight` | [Implementation](/docs/configuration/implementation) |
-| `prflow_review`, `prflow_review_and_fix` and `receiving_review` | [Review](/docs/configuration/review) |
-| `prflow_review.agent_overrides` | [Review Agents](/docs/configuration/review-agents) |
-| `providers` and per-tier provider selection | [Providers](/docs/configuration/providers) |
-| `setup` | [Runtime Setup](/docs/configuration/runtime-setup) |
-| All `allowed_tools` settings | [Tool Permissions](/docs/configuration/tool-permissions) |
-| `docs`, `deferred`, `create_issue` and `prflow_retrospective` | [Documentation and Retrospectives](/docs/configuration/documentation-and-retrospectives) |
-| Execution diagnostics, transcript artifacts, denial records and `telemetry` | [Observability and Privacy](/docs/configuration/observability-and-privacy) |
+Search this page for the key you have. If you are choosing settings rather than looking one up, start at [Configuration](/docs/configuration/index).
+
+## How to Read a Setting Name
+
+A name such as `prflow_implement.stall_backstop.max_resume_attempts` is a path through the JSON file. Each dot is one level deeper. Written out, that setting is:
+
+```json
+{
+  "prflow_implement": {
+    "stall_backstop": {
+      "max_resume_attempts": 2
+    }
+  }
+}
+```
+
+Expected result: a stalled cloud implementation run is resumed at most twice. Every other setting keeps its default, because a key you leave out is a key PRFlow falls back on.
+
+A name containing `<name>`, such as `providers.<name>.auth`, means you choose that part yourself. It is the name you give your own provider entry.
+
+## Index
+
+| Setting | Documented on | What it controls |
+| --- | --- | --- |
+| `$schema` | [Core Settings](/docs/configuration/core-settings) | Editor validation only. Ignored at runtime. |
+| `base_branch` | [Core Settings](/docs/configuration/core-settings) | The branch reviews and implementation work from. |
+| `claude_model` | [Core Settings](/docs/configuration/core-settings) | The model every section uses unless it overrides it. |
+| `create_issue.investigation_record_enabled` | [Documentation and Retrospectives](/docs/configuration/documentation-and-retrospectives) | Whether the investigation record is posted with a new issue. |
+| `deferred.labels` | [Documentation and Retrospectives](/docs/configuration/documentation-and-retrospectives) | Labels applied to follow-up issues for deferred work. |
+| `docs.changelog_file` | [Documentation and Retrospectives](/docs/configuration/documentation-and-retrospectives) | The changelog the release-note pass reconciles against. |
+| `docs.external` | [Documentation and Retrospectives](/docs/configuration/documentation-and-retrospectives) | Where public documentation lives. |
+| `docs.external_enabled` | [Documentation and Retrospectives](/docs/configuration/documentation-and-retrospectives) | Whether the combined docs pass covers public docs. |
+| `docs.internal` | [Documentation and Retrospectives](/docs/configuration/documentation-and-retrospectives) | Where developer documentation lives. |
+| `docs.internal_enabled` | [Documentation and Retrospectives](/docs/configuration/documentation-and-retrospectives) | Whether the combined docs pass covers developer docs. |
+| `docs.labels` | [Documentation and Retrospectives](/docs/configuration/documentation-and-retrospectives) | Labels applied after the documentation pass. |
+| `docs.release_notes_file` | [Documentation and Retrospectives](/docs/configuration/documentation-and-retrospectives) | The customer-facing release-notes file. |
+| `prflow.allowed_bots` | [Core Settings](/docs/configuration/core-settings) | Which automation identities may trigger a cloud run. |
+| `prflow.allowed_tools` | [Tool Permissions](/docs/configuration/tool-permissions) | Extra commands granted to the general cloud command path. |
+| `prflow.allowed_users` | [Core Settings](/docs/configuration/core-settings) | Which people may trigger a cloud run. |
+| `prflow.attribute_commits_to_triggerer` | [Implementation](/docs/configuration/implementation) | Whose name appears as the author of cloud commits. |
+| `prflow.claude_model` | [Model Providers](/docs/configuration/providers) | Model override for the general cloud command path. |
+| `prflow.effort` | [Core Settings](/docs/configuration/core-settings) | Reasoning effort for the general cloud command path. |
+| `prflow.execution_denial_commands_enabled` | [Observability and Privacy](/docs/configuration/observability-and-privacy) | Whether denied command text is recorded. |
+| `prflow.execution_diagnostics_enabled` | [Observability and Privacy](/docs/configuration/observability-and-privacy) | Whether run diagnostics are printed to the logs. |
+| `prflow.execution_transcript_artifact_enabled` | [Observability and Privacy](/docs/configuration/observability-and-privacy) | Whether a scrubbed transcript is uploaded as an artifact. |
+| `prflow.provider` | [Model Providers](/docs/configuration/providers) | Provider route for the general cloud command path. |
+| `prflow.publish_model_effort` | [Implementation](/docs/configuration/implementation) | Whether the provenance line names the model and effort. |
+| `prflow.workpad_marker` | [Core Settings](/docs/configuration/core-settings) | The marker that identifies a workpad comment. |
+| `prflow_implement.allowed_tools` | [Tool Permissions](/docs/configuration/tool-permissions) | Extra commands granted to implementation runs. |
+| `prflow_implement.claude_model` | [Model Providers](/docs/configuration/providers) | Model override for implementation runs. |
+| `prflow_implement.effort` | [Implementation](/docs/configuration/implementation) | Reasoning effort for implementation runs. |
+| `prflow_implement.implement_pr_state` | [Implementation](/docs/configuration/implementation) | Whether the finished pull request is published or left as a draft. |
+| `prflow_implement.provider` | [Model Providers](/docs/configuration/providers) | Provider route for implementation runs. |
+| `prflow_implement.stall_backstop.enabled` | [Implementation](/docs/configuration/implementation) | Whether a stalled cloud run is detected after the agent step. |
+| `prflow_implement.stall_backstop.max_resume_attempts` | [Implementation](/docs/configuration/implementation) | How many times a stalled run may be resumed. |
+| `prflow_implement.stall_observer.advisory_threshold_minutes` | [Implementation](/docs/configuration/implementation) | How long a run may go quiet before an advisory is raised. |
+| `prflow_implement.stall_observer.enabled` | [Implementation](/docs/configuration/implementation) | Whether the report-only stall observer runs. |
+| `prflow_implement.update_branch_checkpoints` | [Implementation](/docs/configuration/implementation) | Whether the base branch is merged in at checkpoints. |
+| `prflow_retrospective.audit_bundle_cap` | [Documentation and Retrospectives](/docs/configuration/documentation-and-retrospectives) | How many pull request records inform one pattern. |
+| `prflow_retrospective.audit_model` | [Documentation and Retrospectives](/docs/configuration/documentation-and-retrospectives) | The model used for the audit stage. |
+| `prflow_retrospective.cooldown_days` | [Documentation and Retrospectives](/docs/configuration/documentation-and-retrospectives) | How long before a recent pattern may be filed again. |
+| `prflow_retrospective.diff_byte_cap` | [Documentation and Retrospectives](/docs/configuration/documentation-and-retrospectives) | The size above which a diff is left out of analysis. |
+| `prflow_retrospective.enabled` | [Documentation and Retrospectives](/docs/configuration/documentation-and-retrospectives) | Declares whether the weekly loop is in use. |
+| `prflow_retrospective.implementation_branch_prefix` | [Documentation and Retrospectives](/docs/configuration/documentation-and-retrospectives) | A branch prefix that helps select pull requests. |
+| `prflow_retrospective.max_issues_per_run` | [Documentation and Retrospectives](/docs/configuration/documentation-and-retrospectives) | How many issues one retrospective run may file. |
+| `prflow_retrospective.max_open_issues` | [Documentation and Retrospectives](/docs/configuration/documentation-and-retrospectives) | How many retrospective issues may be open at once. |
+| `prflow_retrospective.max_open_per_category` | [Documentation and Retrospectives](/docs/configuration/documentation-and-retrospectives) | How many may be open in one category. |
+| `prflow_retrospective.max_prs_per_run` | [Documentation and Retrospectives](/docs/configuration/documentation-and-retrospectives) | A soft cap on scanned pull requests. |
+| `prflow_retrospective.min_occurrences` | [Documentation and Retrospectives](/docs/configuration/documentation-and-retrospectives) | How often a pattern must recur before it is filed. |
+| `prflow_retrospective.retrospective_model` | [Documentation and Retrospectives](/docs/configuration/documentation-and-retrospectives) | The model used for the analysis stage. |
+| `prflow_retrospective.watched_authors` | [Documentation and Retrospectives](/docs/configuration/documentation-and-retrospectives) | Whose pull requests the weekly loop scans. |
+| `prflow_review.agent_overrides` | [Review Agents](/docs/configuration/review-agents) | Per-agent `model`, `effort` and `iterations` overrides, plus a `default` entry. |
+| `prflow_review.live_progress_comment_enabled` | [Review](/docs/configuration/review) | Whether a run keeps a live progress comment. |
+| `prflow_review.require_ci_green` | [Review](/docs/configuration/review) | Retained legacy setting for the withdrawn automatic-review tier. |
+| `prflow_review.require_up_to_date` | [Review](/docs/configuration/review) | Retained legacy setting for the withdrawn automatic-review tier. |
+| `prflow_review.stale_prose.enabled` | [Review](/docs/configuration/review) | Whether the stale-prose check runs. |
+| `prflow_review.stale_prose.severity` | [Review](/docs/configuration/review) | The severity a stale-prose finding carries. |
+| `prflow_review.stall_backstop.enabled` | [Review](/docs/configuration/review) | Retained legacy setting for the withdrawn automatic-review tier. |
+| `prflow_review.stall_backstop.max_resume_attempts` | [Review](/docs/configuration/review) | How many times a stalled review may be resumed. |
+| `prflow_review.verdict_severity_threshold` | [Review](/docs/configuration/review) | The severity at which findings turn the verdict into a rejection. |
+| `prflow_review_and_fix.efficiency_cut_candidate_min_dispatch` | [Review](/docs/configuration/review) | A threshold recorded for later cross-run analysis. |
+| `prflow_review_and_fix.efficiency_telemetry_enabled` | [Review](/docs/configuration/review) and [Observability and Privacy](/docs/configuration/observability-and-privacy) | Whether the effectiveness record is written. |
+| `prflow_review_and_fix.fix_severity_threshold` | [Review](/docs/configuration/review) | The severity at which a finding is eligible for a fix. |
+| `prflow_review_and_fix.max_iterations` | [Review](/docs/configuration/review) | How many fix-loop iterations may run. |
+| `prflow_runner.allowed_tools` | [Tool Permissions](/docs/configuration/tool-permissions) | Retained legacy setting for the withdrawn automatic-review tier. |
+| `prflow_runner.claude_model` | [Model Providers](/docs/configuration/providers) | Retained legacy setting for the withdrawn automatic-review tier. |
+| `prflow_runner.effort` | [Review](/docs/configuration/review) | Retained legacy setting for the withdrawn automatic-review tier. |
+| `prflow_runner.provider` | [Model Providers](/docs/configuration/providers) | Retained legacy setting for the withdrawn automatic-review tier. |
+| `prflow_runner.provision_env` | [Review](/docs/configuration/review) | Retained legacy setting for the withdrawn automatic-review tier. |
+| `prflow_version` | [Core Settings](/docs/configuration/core-settings) | The plugin version a thin cloud install fetches. |
+| `providers.<name>.auth` | [Model Providers](/docs/configuration/providers) | How the route authenticates. |
+| `providers.<name>.base_url` | [Model Providers](/docs/configuration/providers) | The endpoint that receives model requests. |
+| `providers.<name>.effort_supported` | [Model Providers](/docs/configuration/providers) | Whether the route accepts an effort value. |
+| `providers.<name>.env` | [Model Providers](/docs/configuration/providers) | Environment variables exported for the job. |
+| `providers.<name>.timeout_ms` | [Model Providers](/docs/configuration/providers) | The request timeout for the route. |
+| `receiving_review.fix_severity_threshold` | [Review](/docs/configuration/review) | The fix threshold for direct use of the review-reception command. |
+| `setup.claude_code_executable` | [Runtime Setup](/docs/configuration/runtime-setup) | A preinstalled client path to use instead of auto-install. |
+| `setup.git_dir_pin` | [Runtime Setup](/docs/configuration/runtime-setup) | Pins the Git directory for cloud jobs. |
+| `setup.git_work_tree_pin` | [Runtime Setup](/docs/configuration/runtime-setup) | Pins the Git work tree for cloud jobs. |
+| `setup.install` | [Runtime Setup](/docs/configuration/runtime-setup) | Shell commands run on the runner before the agent starts. |
+| `setup.node_version` | [Runtime Setup](/docs/configuration/runtime-setup) | The Node.js version to install. |
+| `setup.node_working_directory` | [Runtime Setup](/docs/configuration/runtime-setup) | Where Node.js detection and caching look. |
+| `setup.php_extensions` | [Runtime Setup](/docs/configuration/runtime-setup) | Extra PHP extensions to install. |
+| `setup.php_tools` | [Runtime Setup](/docs/configuration/runtime-setup) | Extra PHP tools to install. |
+| `setup.php_version` | [Runtime Setup](/docs/configuration/runtime-setup) | The PHP version to install. |
+| `setup.python_version` | [Runtime Setup](/docs/configuration/runtime-setup) | The Python version to install. |
+| `setup.services` | [Runtime Setup](/docs/configuration/runtime-setup) | Service containers started for the job. Each entry takes `name`, `image`, `ports`, `env` and `options`. |
+| `telemetry.branch` | [Observability and Privacy](/docs/configuration/observability-and-privacy) | The branch that stores run records. |
+| `verification_flight.enabled` | [Implementation](/docs/configuration/implementation) | Whether a clean verification result may be reused. |
+| `verification_flight.lease_seconds` | [Implementation](/docs/configuration/implementation) | Reserved for future use. |
+| `verification_flight.wait_timeout_seconds` | [Implementation](/docs/configuration/implementation) | Reserved for future use. |
+| `workflows.prflow` | [Core Settings](/docs/configuration/core-settings) | Whether the shipped cloud workflows may run. |
+| `workflows.prflow-review` | [Core Settings](/docs/configuration/core-settings) | Retained legacy setting for the withdrawn automatic-review tier. |
+
+## Not on This Page
+
+Prompt extensions are files, not settings. They live under `.prflow/prompt-extensions/` and are documented on [Prompt Extensions](/docs/configuration/prompt-extensions).
+
+Credentials are never settings. Store them as GitHub Actions secrets, described in [Cloud Setup](/docs/runs/cloud/setup).
 
 ## Read Defaults Correctly
 
-The scaffold and runtime fallback can differ. For example, the current scaffold writes `prflow.effort: "low"`, while an absent key falls back to `high`. The focused pages label both when they differ.
+<Note>
+  The value the scaffold writes and the value an absent key falls back to can differ. `/prflow:init` writes `prflow.effort: "low"`, while an absent `prflow.effort` falls back to `high`. Each family page names both whenever they differ, so read the fallback column rather than assuming the scaffolded file shows the default.
+</Note>
 
-Unknown top-level keys are tolerated by the schema for forward compatibility. Nested objects with closed schemas can reject unknown entries in editor validation. Cloud config loading validates JSON syntax but does not automatically run a full JSON Schema validator.
+Unknown top-level keys are tolerated so that an older config keeps working after an update. Nested sections have closed schemas, so an editor flags an unknown key inside one. Cloud config loading checks that the file is valid JSON, but it does not run a full schema check.
+
+## A Setting Is Only Half the Answer
+
+Some behavior is not configurable by a value at all:
+
+- To make PRFlow follow a house rule, write a [prompt extension](/docs/configuration/prompt-extensions).
+- To let a cloud agent run one of your commands, grant it under [Tool Permissions](/docs/configuration/tool-permissions).
+- To change who may start a run, see [Core Settings](/docs/configuration/core-settings) and [Human Control](/docs/concepts/human-control).

--- a/docs/external/docs/configuration/tool-permissions.md
+++ b/docs/external/docs/configuration/tool-permissions.md
@@ -7,6 +7,10 @@ Grant cloud agents only the repository-specific test, lint, build or deployment 
 
 Installation and runtime provisioning do not grant command execution. PRFlow appends configured entries to a built-in allowlist; configured arrays do not replace the base profile.
 
+<Warning>
+  Every entry you add lets an agent run that command against your repository, with whatever the runner environment can reach. A broad pattern such as `Bash(npm run:*)` grants every script in `package.json`, including one added later by a pull request. Grant the narrowest command that does the job, and review a change to these arrays as carefully as a change to a workflow file.
+</Warning>
+
 | **Setting** | **Type and accepted values** | **Fallback** | **Tier and security note** | **Example** |
 | --- | --- | --- | --- | --- |
 | `prflow.allowed_tools` | Array of claude-code-action tool strings | Empty array adds nothing | General cloud command workflow. It does not apply to implementation. | `["Bash(npm test:*)"]` |
@@ -34,12 +38,18 @@ List the leading command and arguments directly. Add the same entry under every 
 }
 ```
 
+Expected result: a cloud implementation run and a cloud command run may each invoke `npm test` and `npm run lint`. Any other command stays denied.
+
 The two shipped allowlists are independent. Neither inherits from the other. A command provisioned by `setup.install` can still be denied if it is absent from the active tier's list.
 
 Use the narrowest leading command that performs the needed check. PRFlow's built-in restrictions can deny compound shell wrappers and raw `bash`, `sh`, `zsh`, `eval`, `exec`, `source` or `sudo` commands even when a broader entry appears in the configuration.
 
 ## Plan Grants Before the Work
 
-Cloud workflows resolve grants at trigger time from the default branch. A pull request that adds its own permission cannot use that permission during the same run. The grant becomes effective after merge.
+<Note>
+  Cloud workflows resolve grants at trigger time from the default branch. A pull request that adds its own permission cannot use that permission during the same run. The grant becomes effective after merge.
+</Note>
 
 If a required verification command is not granted, implementation marks that verification blocked. It does not treat CI as an in-run substitute. Merge the narrow grant first, then retry the work that needs it.
+
+Naming a command in a [prompt extension](/docs/configuration/prompt-extensions) does not grant it. If your extension tells a run to use `make verify`, add `Bash(make verify:*)` here as well.

--- a/docs/external/docs/getting-started/first-run.md
+++ b/docs/external/docs/getting-started/first-run.md
@@ -1,60 +1,152 @@
 ---
 title: "First Run"
-description: "Turn a user story, feature request or existing issue into a review-ready pull request."
+description: "Walk through one PRFlow run, from a GitHub issue to a review-ready pull request."
 ---
 
-Start with a user story, feature request or existing GitHub issue. PRFlow helps you create an approved issue when needed, then turns it into a pull request for human review.
+Follow one complete run and learn to read the progress workpad PRFlow writes while it works.
 
 ## Before You Start
 
-Confirm that:
+Confirm all of the following:
 
-- The current directory is inside the Git repository you want to change.
-- The intended GitHub repository is available as the `origin` remote.
+- Your current directory is inside the Git repository you want to change.
+- The GitHub repository you want to work in is the `origin` remote.
 - `gh auth status` succeeds for an identity that can read the issue and create issue comments, branches and pull requests.
-- The repository's tests and linters can run from the local environment.
-- The issue has a clear outcome and verifiable acceptance criteria.
+- The repository's tests and linters run from your local environment.
+- The issue you plan to use has a clear outcome and acceptance criteria someone could check.
 
-Initialization is not a prerequisite. Local defaults work without `.prflow/config.json`.
+[Initialization](/docs/getting-started/initialization) is not a prerequisite. Local runs work on built-in defaults with no `.prflow/config.json`.
 
-## 1. Create or Select an Issue
+## The Walkthrough
 
-Skip this step when a suitable issue already exists. Otherwise, use the syntax for your client:
+<Steps>
+  <Step title="Create or Pick an Issue">
+    Skip this step if a suitable issue already exists. Otherwise describe the change in one sentence:
 
-| **Client** | **Create-Issue Command** |
-| --- | --- |
-| Claude Code | `/prflow:create-issue Add an option to retain completed run logs for 30 days` |
-| GitHub Copilot CLI | `/prflow/create-issue Add an option to retain completed run logs for 30 days` |
-| Codex CLI | `$prflow:create-issue Add an option to retain completed run logs for 30 days` |
+    ```text
+    /prflow:create-issue Add an option to retain completed run logs for 30 days
+    ```
 
-PRFlow clarifies unresolved decisions, displays the complete issue draft and creates the issue only after you explicitly approve that draft.
+    PRFlow asks about anything the description leaves undecided, shows you the complete issue draft and creates the issue only after you approve that draft. Note the issue number it reports.
 
-## 2. Implement the Issue
+    See [Create Issue](/docs/workflows/create-issue) for the full workflow.
+  </Step>
 
-Replace `123` with the issue number:
+  <Step title="Run Implementation">
+    Pass the issue number:
 
-| **Client** | **Implement Command** |
-| --- | --- |
-| Claude Code | `/prflow:implement 123` |
-| GitHub Copilot CLI | `/prflow/implement 123` |
-| Codex CLI | `$prflow:implement 123` |
+    ```text
+    /prflow:implement 123
+    ```
 
-PRFlow fetches the issue, mirrors its acceptance criteria into a workpad, plans the change, implements it, runs repository verification, reviews the diff and updates relevant documentation.
+    PRFlow reads the issue, creates a feature branch, posts a workpad comment on the issue, plans the change, writes it, runs your repository's verification commands, reviews the diff and updates documentation.
 
-## What to Expect
+    Expect this to take a while. Every step reports into the workpad as it happens, so you can follow along on the issue page.
+  </Step>
 
-A fresh run normally produces these visible artifacts:
+  <Step title="Read the Workpad on the Issue">
+    Open the issue in GitHub. PRFlow keeps one comment there and edits it in place for the whole run, so it always shows the current state rather than a history you have to scroll.
 
-- **Branch:** A branch named `issue-<number>-<title-slug>`. PRFlow adds a date suffix when the unsuffixed name already exists. A resumed run can adopt the head branch of an existing open pull request instead.
-- **Workpad:** One dedicated progress comment on the GitHub issue. It records status, branch, plan, acceptance criteria, progress and notable limitations. The same comment is updated throughout the run.
-- **Pull request:** A draft pull request is opened during review. By default, PRFlow publishes it as ready for review only after verification, review and documentation finish. A repository can configure implementation runs to leave it as a draft.
+    It looks like this, abridged:
 
-PRFlow can stop with a `Blocked` status when a dependency, acceptance criterion, verification command or repository state needs human action. Resolve the recorded cause, then run implementation again. PRFlow can resume from the latest workpad and pushed branch checkpoint. Work after that checkpoint may need to be repeated.
+    ```markdown
+    # PRFlow Workpad — Issue #123
 
-## 3. Review and Merge
+    **Status:** 🚀 Reviewing
+    **Branch:** `issue-123-add-an-option-to-retain-completed-run-logs-for-30`
+    **Run:** _(local run)_
+    **PR:** https://github.com/your-org/your-repo/pull/456
+    **Last updated:** 2026-08-26 14:07 UTC
 
-Review the code, tests, documentation, acceptance-criteria evidence and any workpad reflections. Run an additional [standalone review](/docs/workflows/review) when you want an independent verdict.
+    ## Progress
+    - [x] **Setup** — branch & workpad
+      - 13:42:11 — /prflow:implement run started
+    - [x] **Implement**
+      - [x] code + sweeps
+    - [ ] **Review**
+      - [x] `/simplify`
+      - [ ] `review-and-fix`
+      - [ ] acceptance-criteria gate
+    - [ ] **Documentation**
+    - [ ] **PR marked ready**
 
-PRFlow never merges the pull request. Merge it through your repository's normal human review and branch-protection process.
+    ## Plan
+    - [x] Add the retention setting and its default
+    - [ ] Expire logs past the retention window
+    - [ ] Cover both in tests
 
-Learn the complete sequence in [The PRFlow Lifecycle](/docs/concepts/lifecycle).
+    ## Acceptance Criteria
+    - [x] The retention window is configurable
+    - [ ] Logs older than the window are removed
+
+    ## Devflow Reflection
+    ```
+
+    The header fields tell you where the work lives. **Status** is the current phase. **Branch** is the branch PRFlow created or adopted. **Run** links to the cloud run, or reads `_(local run)_` when you started it yourself. **PR** reads `_not yet created_` until the pull request exists, then holds its link. **Last updated** is the time of the most recent edit, in UTC.
+
+    The **Progress** checklist has one top-level row per phase, with sub-rows beneath. Notes are timestamped and nest under the phase they belong to. **Plan** and **Acceptance Criteria** start as placeholders and fill in once PRFlow has read the issue and planned the work.
+
+    **Devflow Reflection** collects anything PRFlow wants a human to know: a limitation it hit, work it deferred, an assumption it had to make. It keeps the older `Devflow` spelling. Read it before you review the code.
+  </Step>
+
+  <Step title="Review and Merge">
+    Read the code, the tests, the documentation changes and the acceptance-criteria evidence, plus any reflections. Run a [standalone review](/docs/workflows/review) when you want a second, independent verdict.
+
+    Then merge the pull request through your repository's normal human review and branch-protection process.
+  </Step>
+</Steps>
+
+<Warning>
+  PRFlow never merges the pull request and never approves its own work. The merge decision is always yours.
+</Warning>
+
+## Reading the Status Glyph
+
+Every status word carries a glyph, so you can tell the state of a run at a glance without reading the word.
+
+| **Glyph** | **Meaning** | **Status Words** |
+| --- | --- | --- |
+| 🚀 | Running | Setup, Discovering, Reproducing, Planning, Implementing, Reviewing, Documenting |
+| 🎉 | Finished | Complete |
+| 👎 | Stopped and waiting for you | Blocked |
+| 💥 | A cloud run died | Failed |
+| 🛑 | A cloud run was cancelled | Cancelled |
+
+A local run you start yourself never writes `Failed` or `Cancelled`. Those two are written for cloud runs that ended without reaching a decision of their own.
+
+## What a Run Produces
+
+- **A branch** named `issue-<number>-<title-slug>`. PRFlow adds a date suffix when the plain name is already taken. A resumed run can adopt the head branch of an existing open pull request instead of creating one.
+- **A workpad**, which is the single issue comment shown above.
+- **A pull request**, opened as a draft during review. By default PRFlow publishes it as ready for review once verification, review and documentation finish. A repository can set `implement_pr_state` to `draft` to leave it unpublished. See [Implementation Settings](/docs/configuration/implementation).
+
+## When a Run Reports Blocked
+
+`👎 Blocked` means PRFlow stopped on purpose because something needs a human. It is not a crash. Common causes are a dependency that is missing, an acceptance criterion the change cannot satisfy, a verification command that fails or will not run and a repository state PRFlow refuses to work around, such as an unpushed branch tip.
+
+Do this:
+
+1. Read the `Devflow Reflection` section. The reason is recorded there, along with what PRFlow observed.
+2. Fix that specific cause. Install the tool, correct the acceptance criterion, repair the failing test or resolve the repository state.
+3. Run `/prflow:implement 123` again with the same issue number.
+
+PRFlow resumes from the latest workpad and the last pushed commit on the branch. Anything it did after that last push may be repeated. A re-run on a blocked workpad surfaces the recorded reason and pauses for your confirmation before it continues, so an automated retry cannot run straight past the gate that stopped the previous run.
+
+See [Workpads and Resume](/docs/concepts/workpads-and-resume) for how resume decides what to redo, and [Implementation Troubleshooting](/docs/troubleshooting/implementation) for specific blocked causes.
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="The PRFlow Lifecycle" icon="timeline" href="/docs/concepts/lifecycle">
+    The complete sequence a run follows, phase by phase.
+  </Card>
+  <Card title="Review Workflow" icon="magnifying-glass" href="/docs/workflows/review">
+    Ask for an independent verdict on a pull request or branch.
+  </Card>
+  <Card title="Human Control" icon="user-shield" href="/docs/concepts/human-control">
+    Where you approve, and what PRFlow will never decide for you.
+  </Card>
+  <Card title="Configuration" icon="sliders" href="/docs/configuration/index">
+    Adjust verification, review and documentation behavior.
+  </Card>
+</CardGroup>

--- a/docs/external/docs/getting-started/index.md
+++ b/docs/external/docs/getting-started/index.md
@@ -1,26 +1,46 @@
 ---
 title: "Getting Started"
-description: "Install PRFlow and carry a request from user story and specification to a review-ready pull request."
+description: "Install PRFlow, set up a repository and turn your first issue into a review-ready pull request."
 ---
 
-Start with a user story, feature request or existing GitHub issue. PRFlow can shape the request into an approved issue, then carry it through implementation, verification, review and documentation. You keep final review and merge control.
+This section takes you from an empty machine to your first PRFlow pull request.
 
-PRFlow works especially well in established repositories where a change must follow existing architecture, tests and documentation conventions. You can run it locally from Claude Code, GitHub Copilot CLI or Codex CLI. Cloud automation is optional.
+PRFlow is a plugin for [Claude Code](https://code.claude.com). It takes a GitHub issue and carries it through planning, implementation, verification, review and documentation, then leaves you a pull request. You keep final review and merge control. PRFlow never merges the pull request for you.
 
-## The Shortest Route to Your First Pull Request
+PRFlow works best in an established repository, where a change has to follow architecture, tests and documentation conventions that already exist.
 
-1. [Check the requirements](/docs/getting-started/requirements). Install Git, GitHub CLI, `jq`, Python 3.11 or newer and a POSIX Bash shell.
-2. [Install the plugin](/docs/getting-started/installation) for your coding client.
-3. Run [initialization](/docs/getting-started/initialization) if you want repository configuration, detected tool permissions and update settings. This step is recommended, not required for local defaults.
-4. Follow the [first-run guide](/docs/getting-started/first-run) with an existing GitHub issue or create one with PRFlow.
+<Tip>
+  If you want the shortest possible path, read the [Quickstart](/docs/quickstart) first. It covers install and first run on one page. Come back here when you want the detail behind each step.
+</Tip>
 
-The first run creates or adopts a feature branch, maintains a progress workpad on the issue and opens a pull request. PRFlow verifies and reviews the change before handing it back to you.
+## Follow the Steps in Order
+
+<CardGroup cols={2}>
+  <Card title="Requirements" icon="list-check" href="/docs/getting-started/requirements">
+    The tools PRFlow needs on your machine and the GitHub access it needs on your account.
+  </Card>
+  <Card title="Installation" icon="download" href="/docs/getting-started/installation">
+    Add the marketplace and install the plugin in Claude Code.
+  </Card>
+  <Card title="Initialization" icon="sliders" href="/docs/getting-started/initialization">
+    Run `/prflow:init` to scaffold repository configuration and detected tool permissions.
+  </Card>
+  <Card title="First Run" icon="rocket" href="/docs/getting-started/first-run">
+    Run `/prflow:implement` on a real issue and read the progress workpad it writes.
+  </Card>
+  <Card title="Updates" icon="arrows-rotate" href="/docs/getting-started/updates">
+    Move an existing installation to a newer release, locally and in the cloud.
+  </Card>
+  <Card title="Migrate from DevFlow" icon="right-left" href="/docs/getting-started/migrate-from-devflow">
+    Move a repository that was set up before the PRFlow rename.
+  </Card>
+</CardGroup>
 
 ## Choose Where Runs Execute
 
-[Local runs](/docs/runs/local/index) use the tools, credentials and permission system already available in your coding client. They are the fastest way to start.
+[Local runs](/docs/runs/local/index) use the tools, credentials and permission system already present in Claude Code. They are the fastest way to start, and nothing else is required.
 
-[Cloud runs](/docs/runs/cloud/index) use GitHub Actions and repository credentials. Add them after the local workflow fits your team.
+[Cloud runs](/docs/runs/cloud/index) use GitHub Actions and repository credentials, so a run can start from a comment on an issue. Add them after the local workflow fits your team.
 
 ## Related Documentation
 

--- a/docs/external/docs/getting-started/initialization.md
+++ b/docs/external/docs/getting-started/initialization.md
@@ -1,58 +1,137 @@
 ---
 title: "Initialization"
-description: "Scaffold and refresh repository-specific PRFlow configuration."
+description: "Scaffold and refresh the PRFlow configuration for one repository."
 ---
 
-Create repository-specific PRFlow configuration with the initialization workflow. Run it after installation and updates when you want detected permissions and explicit settings; local runs can use built-in defaults without it.
+Create repository-specific PRFlow configuration by running the `init` skill once in each repository.
 
-Initialization is separate from plugin installation. Run it from anywhere inside the target Git repository with the syntax for your client:
+Initialization is separate from plugin installation. Run it after you install PRFlow and again after each update, so new configuration keys and new prompt-extension examples reach the repository. Local runs work on built-in defaults without it, so treat it as recommended rather than required.
 
-| **Client** | **Command** |
-| --- | --- |
-| Claude Code | `/prflow:init` |
-| GitHub Copilot CLI | `/prflow/init` |
-| Codex CLI | `$prflow:init` |
+## Run It
+
+Open Claude Code anywhere inside the repository and enter:
+
+```text
+/prflow:init
+```
+
+The skill resolves the repository root itself, so the subdirectory you happen to be in does not matter.
+
+### What You See
+
+The skill runs a scaffolder and then a dependency preflight, and relays their output. A first run in a repository that has no PRFlow configuration prints lines like these:
+
+```
+devflow-scaffold: scaffolded /path/to/repo/.prflow/config.json — every value has a working default; edit it only to customize
+devflow-scaffold: wrote /path/to/repo/.prflow/.gitignore (ignores ephemeral .prflow/tmp/ scratch)
+devflow-scaffold: created/backfilled 18 prompt-extension example(s) in /path/to/repo/.prflow/prompt-extensions/ (rename <skill>.md.example to <skill>.md to activate)
+devflow preflight: all dependencies present.
+```
+
+The paths are your repository's, and the number of examples matches the number of skills in the release you installed. A repository that already has a config prints `keeping existing …` instead, followed by a backfill line when the release added new keys.
+
+### Files That Appear
+
+```
+.prflow/
+  config.json                       your settings — every value has a working default
+  config.schema.json                the schema your editor validates config.json against
+  .gitignore                        ignores the ephemeral .prflow/tmp/ scratch directory
+  prompt-extensions/
+    implement.md.example            one inert example per skill
+    review.md.example
+    …
+.claude/
+  settings.json                     the project marketplace registration
+```
+
+Nothing here is committed for you. Initialization creates no Git commit on any path.
 
 ## What Initialization Writes
 
-The initializer resolves the Git repository root. It then applies these idempotent changes:
+<Accordion title="Configuration and schema">
+  - Creates `.prflow/config.json` from the shipped example when the file is absent.
+  - Backfills newly added keys at any nesting depth when the file already exists. Your values always win, and arrays you tuned, such as tool allowlists, are left alone.
+  - Refreshes `.prflow/config.schema.json` to the schema of the release you installed, so your editor validates against the current field set.
+</Accordion>
 
-- It creates `.prflow/config.json` from the shipped example when the file is absent.
-- It backfills newly added configuration keys at any nesting depth when the file already exists.
-- Existing values win. Customized arrays such as tool allowlists remain unchanged.
-- It refreshes `.prflow/config.schema.json` to the current schema.
-- It adds a commented, inert `.md.example` prompt-extension file for each skill when that example is absent.
-- It does not overwrite existing examples or live prompt extensions.
-- It detects Node, Go, Rust, Java, Ruby, PHP, .NET, Make and Docker markers.
-- It merges matching build, test and lint tools into the three relevant allowlists. It also adds known setup commands.
-- It inspects the repository for additional services, runtime requirements and project-specific build or verification commands that deterministic language detection cannot infer.
-- It deep-merges the PRFlow marketplace registration into the project `.claude/settings.json`. The registration enables `prflow@devflow-marketplace` and tracks the marketplace repository's default branch with `autoUpdate: true`.
+<Accordion title="Prompt-extension examples">
+  - Adds a commented `<skill>.md.example` file for each skill when that example is absent, so you can see which skills accept a consumer extension.
+  - The `.example` suffix keeps every scaffolded file inert. Rename it to `<skill>.md` to activate it.
+  - Never overwrites an existing example or a live extension you wrote.
 
-The language and tool merge is additive. Re-running initialization can discover newly added project tooling without removing custom entries or creating duplicates.
+  See [Prompt Extensions](/docs/configuration/prompt-extensions) for what these files do.
+</Accordion>
 
-## Other Checks and Side Effects
+<Accordion title="Detected tools and setup commands">
+  - Detects Node, Go, Rust, Java, Ruby, PHP, .NET, Make and Docker markers.
+  - Merges the matching build, test and lint tools into the three tool allowlists, and adds the install commands that go with the lockfiles it finds.
+  - Reads the repository for services, runtime versions and project-specific build or verification commands that marker detection cannot infer, and proposes those as well.
 
-Initialization also:
+  The merge is additive and idempotent. Re-running picks up tooling you added since the last run without removing custom entries and without creating duplicates. See [Tool Permissions](/docs/configuration/tool-permissions).
+</Accordion>
 
-- Runs a preflight for Git, a runnable GitHub CLI, `jq`, Python 3.11 or newer and PyYAML. Authentication is a separate `gh auth status` check.
-- Creates the reserved `PRFlow` GitHub label on a best-effort basis.
-- Checks the documentation tree. It reads the internal and external documentation locations from configuration and, when internal documentation is missing or empty, explains what internal and external documentation are and offers to create the internal documentation for you by running `/prflow:docs-bootstrap-internal`. On your explicit consent it dispatches a single agent that writes only under the internal documentation location and runs no version-control command; otherwise it just prints the command to run yourself. It never runs the external bootstrap and commits nothing — review and commit whatever it writes.
-- Checks for shared project-memory files such as `CLAUDE.md` and reports suggestions without editing them.
-- On supported third-party Claude Code providers, offers to make `auto` permission mode selectable by editing the user-global `~/.claude/settings.json`. This write requires explicit consent and is not a repository file.
+<Accordion title="The project marketplace registration">
+  Initialization deep-merges the PRFlow marketplace registration into the project `.claude/settings.json`. The registration enables `prflow@devflow-marketplace` and tracks the marketplace repository's default branch with `autoUpdate: true`.
 
-**Important:** The repository scaffold is written before the dependency preflight. A missing hard prerequisite is reported, but it does not roll back `.prflow/` or other successful setup changes. Install the missing tool before running implementation or review.
+  This write happens immediately, with no separate confirmation. It lands in a committed project file, so anyone who clones the repository inherits it, and because the registration is unpinned a change on the marketplace's default branch changes what runs in the editor. Review it before you commit.
+</Accordion>
+
+<Accordion title="Other checks">
+  - Runs the dependency preflight for Git, a runnable GitHub CLI, `jq`, Python 3.11 or newer and PyYAML. Authentication is a separate `gh auth status` check.
+  - Creates the reserved `PRFlow` GitHub label, on a best-effort basis.
+  - Looks for shared project-memory files such as `CLAUDE.md` and reports suggestions. It never edits them.
+</Accordion>
+
+<Warning>
+  The repository scaffold is written before the dependency preflight runs. A missing tool is reported, but it does not roll back `.prflow/` or any other change that already succeeded. Install the missing tool before you run implementation or review.
+</Warning>
+
+## Older Repositories Are Migrated First
+
+Initialization is also where a repository that predates the PRFlow rename is moved to the current layout. Before it scaffolds anything, the skill checks whether the repository still keeps its state in `.devflow/` and, if so, runs the migration.
+
+The migration moves the state directory, the vendored plugin path, the configuration keys and the workflow bodies that name them. All of those move together or not at all. If any precondition fails, the migration refuses and leaves the repository byte-for-byte unchanged, then reports what blocked it. Initialization continues either way.
+
+Read [Migrate from DevFlow](/docs/getting-started/migrate-from-devflow) before you review that larger diff.
+
+## Optional Guided Setup
+
+Initialization can offer to do more than scaffold files. Every offer below asks first, and declining changes nothing that already succeeded.
+
+- **Create internal documentation.** If the repository has no developer documentation, the skill explains what internal and external documentation are, why written documentation makes later runs cheaper, and offers to create the internal set for you. On your explicit consent it dispatches one agent that writes only under the internal documentation location and runs no version-control command. If you decline, it prints the command so you can run it yourself. It never runs the external bootstrap, and it commits nothing.
+- **Make `auto` permission mode selectable.** On a supported third-party model provider, the skill offers to add one setting to your user-global `~/.claude/settings.json`. That file affects every project you work on, so the write needs explicit consent. It makes `auto` mode selectable. It never turns it on, and plan, model and admin gates still apply. Decline and the skill prints the one-line setting for you to add yourself.
+- **Sweep remaining product-name references.** After a successful rename migration, the skill can offer to update remaining `DevFlow` product-name mentions in your own files. See the privacy note in [Migrate from DevFlow](/docs/getting-started/migrate-from-devflow) before accepting.
 
 ## Review and Commit the Result
 
-Review the complete diff before committing. Pay particular attention to:
+<Steps>
+  <Step title="Read the Full Diff">
+    Initialization writes files but never commits them. Look at every change before you decide what to keep.
+  </Step>
+  <Step title="Check the Four Paths That Matter">
+    | **Path** | **What to Review** |
+    | --- | --- |
+    | `.prflow/config.json` | Detected setup commands, service configuration and tool permissions. |
+    | `.prflow/config.schema.json` | The refreshed schema from the release you installed. |
+    | `.prflow/prompt-extensions/*.md.example` | Newly added examples. They stay inert until you rename them. |
+    | `.claude/settings.json` | The unpinned, auto-updating marketplace registration that your collaborators inherit. |
+  </Step>
+  <Step title="Tighten the Tool Allowlists">
+    Grant enough access for PRFlow to run your real build and test commands, and prefer narrow patterns over broad ones. A reviewer that cannot run your test command will decline to judge anything that depends on it. See [Tool Permissions](/docs/configuration/tool-permissions).
+  </Step>
+  <Step title="Commit What Your Team Should Share">
+    Commit the repository files through your normal review process. Do not commit a change to your user-global `~/.claude/settings.json`, which is personal and lives outside the repository.
+  </Step>
+</Steps>
 
-| **Path** | **What to Review** |
-| --- | --- |
-| `.prflow/config.json` | Detected setup commands, service configuration and tool permissions. |
-| `.prflow/config.schema.json` | The refreshed schema shipped with the installed release. |
-| `.prflow/prompt-extensions/*.md.example` | Newly added examples. They remain inert until renamed. |
-| `.claude/settings.json` | The unpinned, auto-updating project marketplace registration that collaborators inherit. |
+## Next Steps
 
-Commit the repository files your team wants to share. Do not commit a user-global `~/.claude/settings.json` change.
-
-If the repository predates the PRFlow rename, initialization first follows the protected migration path. Read [Migrate From DevFlow](/docs/getting-started/migrate-from-devflow) before reviewing that larger diff.
+<CardGroup cols={2}>
+  <Card title="First Run" icon="rocket" href="/docs/getting-started/first-run">
+    Turn a real issue into a review-ready pull request.
+  </Card>
+  <Card title="Settings Reference" icon="sliders" href="/docs/configuration/settings">
+    Every key in `.prflow/config.json`, with its default.
+  </Card>
+</CardGroup>

--- a/docs/external/docs/getting-started/installation.md
+++ b/docs/external/docs/getting-started/installation.md
@@ -1,51 +1,64 @@
 ---
 title: "Installation"
-description: "Install the PRFlow plugin in Claude Code, GitHub Copilot CLI or Codex CLI."
+description: "Install the PRFlow plugin in Claude Code."
 ---
 
-Install the PRFlow plugin to make its skills available in your coding client. Repository initialization is a separate, recommended step.
+Install the PRFlow plugin so its skills are available in Claude Code.
 
-The plugin is named `prflow`. Its marketplace intentionally keeps the `devflow-marketplace` name. PRFlow has no companion-plugin dependencies.
+The plugin is named `prflow`. Its marketplace keeps the name `devflow-marketplace` on purpose, so do not rename it. PRFlow depends on no companion plugin.
 
-If you previously installed DevFlow, follow [Migrate From DevFlow](/docs/getting-started/migrate-from-devflow) instead.
+If you already installed DevFlow, follow [Migrate from DevFlow](/docs/getting-started/migrate-from-devflow) instead of this page.
 
-## Install in Your Client
+## Install the Plugin
 
-Add the marketplace, then install PRFlow:
+<Steps>
+  <Step title="Add the Marketplace">
+    Run this in your terminal:
 
-<Tabs>
-  <Tab title="Claude Code">
     ```bash
     claude plugin marketplace add The01Geek/prflow
+    ```
+  </Step>
+  <Step title="Install PRFlow">
+    ```bash
     claude plugin install prflow@devflow-marketplace
     ```
 
-    The interactive `/plugin` manager provides equivalent marketplace and installation actions. Start a new Claude Code session if the PRFlow skills do not appear immediately.
-  </Tab>
-  <Tab title="GitHub Copilot CLI">
-    ```bash
-    copilot plugin marketplace add The01Geek/prflow
-    copilot plugin install prflow@devflow-marketplace
-    ```
+    The plugin name and the marketplace name are different on purpose. Enter both exactly as shown.
+  </Step>
+  <Step title="Confirm the Skills Are Loaded">
+    Start a new Claude Code session, then enter `/` and look for the `prflow` skills, such as `/prflow:init` and `/prflow:implement`.
 
-    Start a new GitHub Copilot CLI session after installation.
-  </Tab>
-  <Tab title="Codex CLI">
-    ```bash
-    codex plugin marketplace add The01Geek/prflow
-    codex plugin add prflow@devflow-marketplace
-    ```
+    If they do not appear, the session was started before the install finished. Start another session.
+  </Step>
+</Steps>
 
-    Start a new Codex CLI session after installation.
-  </Tab>
-</Tabs>
+The interactive `/plugin` manager offers the same marketplace and install actions if you prefer to work in a menu.
 
-## Continue Setup
+<Note>
+  **Other agent clients.** Claude Code plugins are largely compatible with other agent clients, and PRFlow has been verified to work in GitHub Copilot CLI, Codex CLI, Codex Desktop and VS Code agent modes. Each client installs and names plugins differently, so follow that client's own plugin-installation instructions. PRFlow's documented commands and syntax describe Claude Code.
+</Note>
 
-Plugin installation does not create repository configuration or install system packages. Before the first run:
+## What Installation Does Not Do
 
-1. Confirm the [local requirements](/docs/getting-started/requirements).
-2. Run [initialization](/docs/getting-started/initialization) if you want a configurable repository scaffold and detected tools.
-3. Follow the [first-run guide](/docs/getting-started/first-run).
+Installing the plugin does not create repository configuration and does not install system packages. Two things are still yours to do:
 
-See [Updates](/docs/getting-started/updates) when you need a newer plugin release.
+- Install the [local requirements](/docs/getting-started/requirements) yourself. The plugin manager never runs `pip`, `brew` or `apt`.
+- Run [initialization](/docs/getting-started/initialization) in each repository you want PRFlow to work in. This step is recommended. Local runs still work on built-in defaults without it.
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Requirements" icon="list-check" href="/docs/getting-started/requirements">
+    Confirm Git, the GitHub CLI, `jq`, Python and a POSIX bash shell are ready.
+  </Card>
+  <Card title="Initialization" icon="sliders" href="/docs/getting-started/initialization">
+    Scaffold `.prflow/` configuration for the repository.
+  </Card>
+  <Card title="First Run" icon="rocket" href="/docs/getting-started/first-run">
+    Turn a real issue into a pull request.
+  </Card>
+  <Card title="Updates" icon="arrows-rotate" href="/docs/getting-started/updates">
+    Move to a newer PRFlow release later.
+  </Card>
+</CardGroup>

--- a/docs/external/docs/getting-started/migrate-from-devflow.md
+++ b/docs/external/docs/getting-started/migrate-from-devflow.md
@@ -1,176 +1,132 @@
 ---
 title: "Migrate from DevFlow"
-description: "Update the renamed PRFlow plugin and migrate existing local and cloud repositories safely."
+description: "Move a repository that was set up before the DevFlow-to-PRFlow rename."
 ---
 
-PRFlow is the new name for the DevFlow plugin. After updating the plugin, migrate each existing repository once. The marketplace keeps its original `devflow-marketplace` name, so do not remove or rename it.
+PRFlow is the new name for the DevFlow plugin. Update the plugin once, then migrate each existing repository once.
 
-If you are installing the plugin for the first time, follow [Installation](/docs/getting-started/installation) instead.
+The marketplace keeps its original `devflow-marketplace` name, so do not remove or rename it.
 
-## Claude Code: Quick Migration
+If you are installing for the first time, follow [Installation](/docs/getting-started/installation) instead. Nothing on this page applies to you.
 
-Choose one method. Option 1 is shorter and recommended.
+## Update the Plugin
 
-### Option 1: Run the Complete Command Sequence
+<Steps>
+  <Step title="Refresh the Marketplace">
+    ```bash
+    claude plugin marketplace update devflow-marketplace
+    ```
+  </Step>
+  <Step title="Install PRFlow">
+    ```bash
+    claude plugin install prflow@devflow-marketplace
+    ```
+  </Step>
+  <Step title="Start a New Session">
+    Start a new Claude Code session so the renamed skills load. The interactive `/plugin` manager offers the same marketplace and install actions if you prefer a menu.
+  </Step>
+</Steps>
 
-Open Claude Code in a repository that uses DevFlow, then run each command in order:
+<Warning>
+  The `/devflow:*` skill names do not survive the rename in your editor. Use `/prflow:*` for every local PRFlow skill from now on.
+</Warning>
+
+Claude Code's CLI and its VS Code extension share plugin configuration, so updating in one updates the other. If PRFlow does not appear in VS Code, run the two commands above in VS Code's integrated terminal and restart Claude Code.
+
+## Migrate Each Repository
+
+Run this once in every repository that was configured before the rename, including repositories that use GitHub Actions:
 
 ```text
-/plugin marketplace update devflow-marketplace
-/plugin install prflow@devflow-marketplace
-/reload-plugins
 /prflow:init
 ```
 
-Follow the agent's instructions until initialization is complete. Then review the repository diff before committing it.
-
-### Option 2: Use the Plugin Manager
-
-1. Open Claude Code in a repository that uses DevFlow.
-2. Enter `/plugin` and select **Marketplaces**.
-3. Select `devflow-marketplace` and update it.
-4. Run `/reload-plugins` or restart Claude Code.
-5. Run the repository migration and follow the agent's instructions:
-
-   ```text
-   /prflow:init
-   ```
-
-   The agent may ask questions, request permission to make changes or give you additional setup steps. Continue until the agent confirms initialization is complete.
-
-6. Review the repository diff before committing it.
-
-**Important:** Local `/devflow:*` commands do not remain after the plugin rename. Use `/prflow:*` for every local PRFlow skill.
-
-## Claude Code in VS Code
-
-Claude Code CLI and the VS Code extension share plugin configuration.
-
-1. Open the Claude Code panel in VS Code.
-2. Enter `/plugins` to open **Manage plugins**.
-3. Select **Marketplaces** and click the refresh icon for `devflow-marketplace`.
-4. Restart Claude Code when the extension prompts you.
-5. Run `/prflow:init` from the repository you want to migrate. Follow the agent's instructions until initialization is complete.
-
-If PRFlow does not appear, use [option 1](#option-1-run-the-complete-command-sequence) in VS Code's integrated terminal.
-
-## GitHub Copilot CLI
-
-Copilot does not rename the installed plugin automatically, so replace DevFlow with PRFlow.
-
-Run:
-
-```bash
-copilot plugin marketplace update devflow-marketplace
-copilot plugin uninstall devflow
-copilot plugin install prflow@devflow-marketplace
-```
-
-Start a new Copilot CLI session in each repository that needs migration and run:
-
-```text
-/prflow/init
-```
-
-Follow the agent's instructions until initialization is complete.
-
-Copilot CLI separates the plugin and skill names with `/`. Claude Code uses the equivalent `/prflow:init` spelling with `:`.
-
-## GitHub Copilot in VS Code
-
-Agent Plugins in VS Code are a preview feature. The simplest path is to migrate with Copilot CLI first; VS Code discovers CLI-installed plugins automatically.
-
-After completing the [Copilot CLI migration](#github-copilot-cli):
-
-1. Open the VS Code **Extensions** view.
-2. Enter `@agentPlugins` in the search field.
-3. Find PRFlow under installed Agent Plugins and make sure it is enabled.
-4. In Copilot Chat, enter `/` and select PRFlow's `init` skill.
-5. Follow the agent's instructions until initialization is complete.
-
-To manage PRFlow entirely in VS Code, add `The01Geek/prflow` to `chat.plugins.marketplaces`, run **Extensions: Check for Extension Updates**, then replace DevFlow with PRFlow in the `@agentPlugins` view.
-
-If PRFlow does not appear, check that your organization allows Agent Plugins and `chat.plugins.enabled` is on. As a fallback, run `/prflow/init` from Copilot CLI in the integrated terminal.
-
-## Codex CLI
-
-Codex CLI does not rename the installed plugin automatically, so replace DevFlow with PRFlow. Update the marketplace and install PRFlow with the same commands the [installation guide](/docs/getting-started/installation) uses:
-
-```bash
-codex plugin marketplace add The01Geek/prflow
-codex plugin add prflow@devflow-marketplace
-```
-
-If a DevFlow-named plugin is still installed, remove it with your Codex CLI version's plugin-management command; see the Codex CLI plugin documentation for the exact syntax.
-
-Start a new Codex CLI session in each repository that needs migration and run the `init` skill (Codex CLI spells it `$prflow:init`). Follow the agent's instructions until initialization is complete.
-
-## What `init` Changes
-
-Run `init` once in every repository configured before the rename, including repositories that use GitHub Actions. It first applies these rename changes together:
+Initialization performs the rename first, before it scaffolds anything. It changes these five things:
 
 - Moves `.devflow/` to `.prflow/` and updates the vendored plugin path.
-- Renames supported top-level configuration keys.
-- Updates workflow contents that refer to the old state directory, vendored path or configuration keys.
+- Renames the supported top-level configuration keys.
+- Updates workflow contents that name the old state directory, vendored path or configuration keys.
 - Updates the repository's local marketplace reference.
 - Updates the plugin name and version pin.
 
-PRFlow applies these changes together or not at all. If it reports a blocker, the rename changes nothing. Follow the reported fix instead of moving files or rewriting workflow paths by hand.
+<Note>
+  These changes are applied together or not at all. If any precondition fails, the migration changes nothing and the repository stays byte-for-byte as it was. Follow the reported fix rather than moving files or rewriting workflow paths by hand — a half-migrated repository fails silently instead of loudly.
+</Note>
 
-After the rename attempt, `init` continues with normal setup and may update other files. Always review the final diff, even if the rename was refused.
+After the rename attempt, initialization continues with its normal setup and may change other files. Review the final diff either way, including when the rename was refused.
 
-After a successful migration:
+## Messages You May See
 
-1. Review `git status` and the complete diff.
-2. Confirm that your custom settings were preserved.
-3. Commit the repository migration through your normal review process.
-4. For cloud repositories, merge the migration before expecting GitHub Actions to use the new paths and configuration keys.
+| **Message** | **What It Means** |
+| --- | --- |
+| `APPLIED` | Every part of the rename landed together. The diff is large but mechanical. |
+| `ALREADY MIGRATED` | The repository is already on the current layout. Nothing changed. |
+| `REFUSED` | The rename changed nothing. Initialization may still perform other setup. Resolve the reported blockers, then run it again. |
+| `NOTHING TO MIGRATE` | No PRFlow or DevFlow state directory was found. This is a first-time install, not a migration. |
+| `could not migrate …` | A specific file the migration does not own, usually a workflow the installer does not ship. Update or remove it by hand. |
+
+## After a Successful Migration
+
+<Steps>
+  <Step title="Read the Full Diff">
+    Check `git status` and every changed file.
+  </Step>
+  <Step title="Confirm Your Settings Survived">
+    Your configuration values, tuned arrays and custom workflow content should all still be there.
+  </Step>
+  <Step title="Commit Through Your Normal Process">
+    The migration is an ordinary commit and should get an ordinary review.
+  </Step>
+  <Step title="Merge Before Expecting Cloud Runs to Change">
+    GitHub Actions uses the new paths and configuration keys only once the migration reaches your default branch.
+  </Step>
+</Steps>
 
 ## Optional Product-Name Sweep
 
-After the rename succeeds, `/prflow:init` may offer to update remaining DevFlow product-name references. This step is optional.
+After the rename succeeds, `/prflow:init` may offer to update remaining `DevFlow` product-name mentions in your own files. This step is optional and is separate from the migration.
 
-**Privacy note:** The sweep reads tracked, untracked and git-ignored files, which may contain secrets or private data. Their contents may enter the model's context. Declining the sweep does not affect the completed migration.
+<Warning>
+  **Privacy note.** The sweep reads tracked, untracked and ignored files, which may hold secrets or private data, and their contents may enter the model's context. Declining the sweep does not affect the migration, which is already complete.
+</Warning>
 
-## Cloud Tier Checks
+## Cloud Repositories
 
-Cloud users should also review:
+If your repository uses the cloud tier, also review:
 
-- Any workflow files PRFlow reports as rewritten.
-- Any warning about a retained custom workflow that the PRFlow installer does not maintain.
+- Any workflow file the migration reports as rewritten.
+- Any warning about a retained workflow the PRFlow installer does not maintain.
 - The migrated `workflows.prflow` and `workflows.prflow-review` configuration toggles.
-- The repository's PRFlow version pin and vendored path, if the committed-vendor installation mode is used.
+- The version pin and vendored path, if you use the committed-vendor installation mode.
 
-Existing cloud automation may keep using `/devflow:implement` or `/devflow:review`. Use `/prflow:implement` and `/prflow:review` for new comments.
+Existing automation may still post `/devflow:implement` or `/devflow:review` comments. Those keep working. Use `/prflow:implement` and `/prflow:review` in new comments.
 
 ## Names That Intentionally Stay the Same
 
-Do not perform a repository-wide search-and-replace. These names deliberately retain the DevFlow spelling:
+<Warning>
+  Do not run a repository-wide search and replace. Several names keep the DevFlow spelling on purpose, and renaming one of them removes a setting rather than moving it — usually without any error.
+</Warning>
 
-- **Marketplace:** `devflow-marketplace` remains the marketplace identifier. The installed plugin is `prflow@devflow-marketplace`.
-- **Environment variables and secrets:** Keep every documented `DEVFLOW_*` name. PRFlow does not read a corresponding `PRFLOW_*` name.
-- **Workflow file names:** Existing files such as `devflow.yml` and `devflow-implement.yml` keep their names. Their contents are migrated.
-- **Cloud command compatibility:** Supported GitHub comment commands accept both the `/devflow:` and `/prflow:` namespaces.
+| **Name** | **Why It Stays** |
+| --- | --- |
+| `devflow-marketplace` | The marketplace identifier. The installed plugin is `prflow@devflow-marketplace`. |
+| `DEVFLOW_*` environment variables and secrets | PRFlow reads no `PRFLOW_*` equivalent. An unresolvable variable looks exactly like one you never set. |
+| Workflow file names such as `devflow.yml` | The file names stay. Their contents are migrated. |
+| The `/devflow:` comment namespace | Cloud comment commands accept both `/devflow:` and `/prflow:`. |
 
 ## Verify the Migration
 
-The migration is complete when:
+The migration is complete when all of the following are true:
 
-- The client lists `prflow` as the installed plugin.
-- The PRFlow `init` skill is available under the spelling used by your client.
+- Claude Code lists `prflow` as the installed plugin.
+- `/prflow:init` is available in a new session.
 - The repository contains `.prflow/` and no `.devflow/` directory remains.
-- The migration diff contains the expected moves and rewrites, with your custom values intact.
+- The diff holds the expected moves and rewrites, with your custom values intact.
 - Cloud workflow checks pass after the migration reaches the default branch.
-
-Messages you may see:
-
-- **`ALREADY MIGRATED`:** `.prflow/` exists and `.devflow/` does not. No rename changes were made on this run.
-- **`REFUSED`:** The rename changed nothing, but `init` may still perform other setup. Review the final diff and resolve reported blockers before retrying.
 
 ## Related Documentation
 
 - [Installation](/docs/getting-started/installation)
-- [Cloud setup](/docs/runs/cloud/setup)
-- [Claude Code plugin management](https://code.claude.com/docs/en/discover-plugins)
-- [GitHub Copilot CLI plugins](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/plugins-finding-installing)
-- [Agent Plugins in VS Code](https://code.visualstudio.com/docs/agent-customization/agent-plugins)
+- [Initialization](/docs/getting-started/initialization)
+- [Cloud Setup](/docs/runs/cloud/setup)
+- [Updates](/docs/getting-started/updates)

--- a/docs/external/docs/getting-started/requirements.md
+++ b/docs/external/docs/getting-started/requirements.md
@@ -3,35 +3,89 @@ title: "Requirements"
 description: "Prepare the local tools and GitHub access that PRFlow needs."
 ---
 
-Prepare your workstation with the tools required for local PRFlow runs. Cloud runs use a separate [environment and runner setup path](/docs/runs/cloud/setup).
+Get your workstation ready for local PRFlow runs. Cloud runs use a separate [environment and runner setup path](/docs/runs/cloud/setup).
 
 ## Required Local Tools
 
-Install one supported coding client and make these tools available on `PATH`:
+Install Claude Code, then make these tools available on `PATH`:
 
 | **Requirement** | **Why PRFlow Needs It** |
 | --- | --- |
-| Claude Code, GitHub Copilot CLI or Codex CLI | Loads and runs the PRFlow plugin skills. |
+| Claude Code | Loads and runs the PRFlow plugin skills. |
 | Git | Reads repository history and manages the feature branch. |
 | GitHub CLI (`gh`) | Reads and writes issues, pull requests and reviews. Authenticate it with `gh auth login`. |
-| `jq` | Processes JSON used by PRFlow helpers. |
-| Python 3.11 or newer, available as `python3` | Runs configuration, workpad and verification helpers. |
-| POSIX Bash | Runs PRFlow's shell helpers. `sh`, Dash and PowerShell alone are not substitutes. |
+| `jq` | Processes the JSON that PRFlow's helpers pass between steps. |
+| Python 3.11 or newer, available as `python3` | Runs the configuration, workpad and verification helpers. |
+| POSIX bash | Runs PRFlow's shell helpers. `sh`, Dash and PowerShell alone are not substitutes. |
 
-The repository must be a Git repository connected to GitHub. Your GitHub identity needs enough access to read the issue and create branches, issue comments and pull requests.
+<Note>
+  Claude Code is the client PRFlow documents. Other agent clients can load the plugin as well. See the compatibility note on the [installation page](/docs/getting-started/installation).
+</Note>
 
-You can inspect the main versions and authentication state with:
+The repository must be a Git repository connected to GitHub. Your GitHub identity needs enough access to read the issue and to create branches, issue comments and pull requests.
+
+PRFlow avoids GNU-only command flags, so the standard macOS and BSD command-line tools work.
+
+## Check Your Machine
+
+Run these commands and read the versions they print:
 
 ```bash
 git --version
 gh --version
-gh auth status
 jq --version
 python3 --version
 bash --version
+gh auth status
 ```
 
-PRFlow avoids GNU-only command flags, so the standard macOS and BSD command-line tools are supported.
+On a macOS workstation with everything installed, the first four print something like this:
+
+```
+git version 2.50.1 (Apple Git-155)
+gh version 2.96.0 (2026-07-02)
+jq-1.7.1-apple
+Python 3.14.6
+```
+
+Your exact version numbers will differ. What matters is that every command prints a version instead of `command not found`, that Python reports 3.11 or newer and that `gh auth status` reports a logged-in account.
+
+PRFlow also ships a preflight check, which [initialization](/docs/getting-started/initialization) runs for you. When every dependency is present it prints one line:
+
+```
+devflow preflight: all dependencies present.
+```
+
+If Python cannot import PyYAML but everything else is present, it prints a different line and still succeeds:
+
+```
+devflow preflight: required dependencies present; PyYAML advisory (see above).
+```
+
+<Note>
+  The preflight tool keeps the older `devflow` spelling in its own output. That is expected and is not a sign of a stale install.
+</Note>
+
+## macOS Ships an Older Python
+
+macOS includes `python3` at `/usr/bin/python3`, and on current releases that interpreter is Python 3.9. PRFlow needs 3.11 or newer. If a newer Python is installed but `/usr/bin/python3` comes first on `PATH`, PRFlow's preflight reports the version failure even though a suitable Python exists on the machine.
+
+Check which interpreter actually answers, and what else is available:
+
+```bash
+python3 -VV
+which -a python3
+```
+
+On a machine where a newer Python is installed and correctly ordered, the result looks like this:
+
+```
+Python 3.14.6 (main, Jun 10 2026, 10:03:53) [Clang 21.0.0 (clang-2100.0.123.102)]
+/opt/homebrew/bin/python3
+/usr/bin/python3
+```
+
+The first line is the version that will run. The list shows every `python3` on `PATH` in the order the shell searches them. If `/usr/bin/python3` is first and reports 3.9, install a newer Python and put it ahead of `/usr/bin` on `PATH`.
 
 ## PyYAML Is Advisory for Local Runs
 
@@ -41,26 +95,32 @@ PyYAML is recommended but is not a hard local prerequisite. Install it with:
 python3 -m pip install PyYAML
 ```
 
-Without PyYAML, one helper cannot apply severity demotions from deferred-findings blocks in pull-request bodies. The review continues with the findings intact. This can surface and fix more findings than intended, so installing PyYAML avoids unnecessary churn.
+Name the package rather than pointing `pip` at a requirements file. A requirements file resolves against your current working directory, so in a Python project you would install that project's dependencies by mistake.
 
-The local preflight reports missing PyYAML as an advisory and still succeeds. PyYAML remains required by PRFlow's own test suite, continuous integration and cloud tiers.
+Without PyYAML, one helper cannot apply severity demotions from deferred-findings blocks in pull-request bodies. The review continues with the findings intact. That can surface and fix more findings than you intended, so installing PyYAML avoids unnecessary churn.
+
+PyYAML stays required for PRFlow's own test suite, its continuous integration and the cloud tiers.
 
 ## Windows Bash Choices
 
-On Windows, use any one of these POSIX Bash environments:
+On Windows, use any one of these POSIX bash environments:
 
-- Windows Subsystem for Linux (WSL) Bash.
-- Git Bash.
-- MSYS2 Bash.
+- Windows Subsystem for Linux (WSL) bash
+- Git Bash
+- MSYS2 bash
 
-PRFlow does not require one specific choice. Set the frozen `DEVFLOW_BASH` environment variable when you need to select the Bash executable explicitly:
+PRFlow does not require one specific choice. Set the `DEVFLOW_BASH` environment variable when you need to select the bash executable explicitly:
 
 ```bash
 export DEVFLOW_BASH=/path/to/bash
 ```
 
-A PowerShell-only host with none of these Bash environments cannot run PRFlow's shell helpers. Windows may also expose Python as `python` or `py -3` without a `python3` command. Follow [installation troubleshooting](/docs/troubleshooting/installation) if preflight reports that case.
+<Warning>
+  `DEVFLOW_BASH` keeps the `DEVFLOW_` prefix on purpose. PRFlow reads no `PRFLOW_BASH` equivalent, so renaming the variable removes the setting instead of moving it, and it does so silently.
+</Warning>
+
+A PowerShell-only host with none of these bash environments cannot run PRFlow's shell helpers. Windows may also expose Python as `python` or `py -3` with no `python3` command at all. Follow [installation troubleshooting](/docs/troubleshooting/installation) if the preflight reports that case.
 
 ## Let Initialization Check the Environment
 
-The recommended [`init` skill](/docs/getting-started/initialization) runs the bundled preflight after it scaffolds repository files. Missing tools are reported with remedies. They do not undo the scaffold that was already written.
+The recommended [`init` skill](/docs/getting-started/initialization) runs the bundled preflight after it scaffolds the repository files. A missing tool is reported with a remedy, and the scaffold that was already written stays in place.

--- a/docs/external/docs/getting-started/updates.md
+++ b/docs/external/docs/getting-started/updates.md
@@ -1,60 +1,95 @@
 ---
 title: "Updates"
-description: "Update local plugins and cloud repository automation without mixing the two paths."
+description: "Move an existing PRFlow installation to a newer release, locally and in the cloud."
 ---
 
-Keep an existing PRFlow installation current by updating the local plugin and cloud repository files separately.
+Update the plugin on your machine and the cloud files in your repository. They are two separate paths, and you update them separately.
 
-## Update a Local Plugin
+## Update the Local Plugin
 
-Refresh the marketplace and plugin with the commands supported by your client.
+<Steps>
+  <Step title="Refresh the Marketplace">
+    ```bash
+    claude plugin marketplace update devflow-marketplace
+    ```
+  </Step>
+  <Step title="Update the Plugin">
+    ```bash
+    claude plugin update prflow@devflow-marketplace
+    ```
 
-### Claude Code
+    The interactive `/plugin` manager offers the same actions in a menu.
+  </Step>
+  <Step title="Start a New Session">
+    Start a new Claude Code session if the updated skills do not appear.
+  </Step>
+  <Step title="Re-Run Initialization">
+    In each repository, enter:
 
-```bash
-claude plugin marketplace update devflow-marketplace
-claude plugin update prflow@devflow-marketplace
-```
+    ```text
+    /prflow:init
+    ```
 
-The interactive `/plugin` manager provides equivalent update actions.
+    This backfills configuration keys the new release added, refreshes `.prflow/config.schema.json` and adds any newly shipped prompt-extension examples. Your existing values and arrays are kept. Review the diff before you commit it.
+  </Step>
+</Steps>
 
-### GitHub Copilot CLI
+## Update the Cloud Files
 
-```bash
-copilot plugin marketplace update devflow-marketplace
-copilot plugin update prflow
-```
+A default cloud installation has two parts that update independently:
 
-### Codex CLI
+- The workflows and composite actions committed in your repository.
+- The plugin content fetched at the `prflow_version` ref recorded in `.prflow/config.json`.
 
-```bash
-codex plugin marketplace upgrade devflow-marketplace
-```
+Update both together by re-running the installer.
 
-Start a new client session if the updated skills do not appear. Then run the client-specific form of the [`init` skill](/docs/getting-started/initialization) to backfill new configuration keys, refresh the schema and add any newly shipped prompt-extension examples.
+### Preview, Then Apply
 
-## Update Cloud Repository Files
-
-The default thin cloud installation uses two independently updated artifacts:
-
-- The workflows and composite actions committed in the repository.
-- The plugin content fetched at the `prflow_version` ref in `.prflow/config.json`.
-
-Update both sides together. With the installer saved as `devflow-install.sh`, preview the upgrade first, then apply it:
+Download the installer at the ref you want, read it, then run the copy you read. With the file saved as `devflow-install.sh`:
 
 ```bash
 DEVFLOW_REF=<newer-ref> bash devflow-install.sh
 DEVFLOW_REF=<newer-ref> bash devflow-install.sh --apply
 ```
 
-An upgrade is a dry run by default. The installer does not intentionally change the target repository in this mode. It creates a sandbox copy and can create temporary files. It also executes the downloaded installer, so inspect and verify that file before running it. The preview displays the planned repository diff.
+<Note>
+  **An upgrade is a dry run by default.** The first command writes nothing to your repository. It prints the full plan and a unified diff of every byte the upgrade would change, working against a sandbox copy. Nothing reaches the repository until you re-run with `--apply`.
 
-The installer refreshes the workflows and actions. It re-stamps `prflow_version` when the existing value is empty or looks like a commit SHA. A deliberately set tag or branch name is preserved, so advance that value yourself when needed.
+  A first-time install is different. With no PRFlow files present, the installer applies immediately. Pass `--dry-run` to force a preview there too.
+</Note>
 
-A committed-vendor installation created with `DEVFLOW_VENDOR=1` stores the plugin tree in the repository and ignores `prflow_version`. Re-run the installer with the same vendor mode to refresh that tree.
+The installer executes the file you downloaded, so read it before you run it, and fetch it at a pinned tag or commit rather than a moving branch.
 
-Review and commit the resulting diff. If the installer preserves a modified artifact as a `.prflow-new` sidecar, compare and reconcile it instead of assuming the workflow was updated in place.
+### Your Edits Are Never Overwritten
 
-Fresh cloud installations maintain `devflow.yml` and `devflow-implement.yml`. Older repositories can retain withdrawn review-tier files; the updater reports them but does not remove them without explicit direction.
+The installer records the exact bytes it wrote for each file it owns. On the next run it compares:
 
-See [Cloud Runs](/docs/runs/cloud/index) for the complete setup and update path.
+- **Unchanged since the installer wrote it.** The file is updated in place.
+- **You edited it.** The file is preserved exactly as you left it, and the new version is written beside it as `<path>.prflow-new` for you to merge by hand. The installer reports each file it preserved.
+- **The installer cannot tell.** A file with no recorded fingerprint, or one it could not read, is preserved the same way and reported with the reason.
+- **You deleted it.** The file is recreated.
+
+<Warning>
+  A `.prflow-new` file is a real file sitting inside your `.github/` directory, and it is not merged for you. If you leave it there, treat the workflow beside it as still carrying your old version. The installer adds an ignore rule so a later `git add -A` cannot commit the sidecar by accident.
+</Warning>
+
+`.prflow/config.json` is never rewritten by this mechanism at all. Only newly added keys are backfilled into it.
+
+### The Version Pin
+
+The installer re-stamps `prflow_version` when the existing value is empty or looks like a commit SHA. A tag or branch name you set deliberately is preserved, so move that value yourself when you want a newer one.
+
+A committed-vendor installation, created with `DEVFLOW_VENDOR=1`, stores the plugin tree in the repository and ignores `prflow_version`. Re-run the installer with the same vendor mode to refresh that tree.
+
+### After the Upgrade
+
+Review and commit the resulting diff. A fresh cloud installation maintains `devflow.yml` and `devflow-implement.yml`. An older repository can still hold a workflow the installer no longer ships. The installer reports such a file by name and never removes it without explicit direction, because no future installer run can refresh it either.
+
+See [Cloud Runs](/docs/runs/cloud/updates) for the complete cloud update path.
+
+## Related Documentation
+
+- [Initialization](/docs/getting-started/initialization)
+- [Cloud Installation](/docs/runs/cloud/installation)
+- [Migrate from DevFlow](/docs/getting-started/migrate-from-devflow)
+- [Release Notes](/release-notes)

--- a/docs/external/docs/index.md
+++ b/docs/external/docs/index.md
@@ -1,23 +1,112 @@
 ---
-title: "PRFlow Documentation"
-description: "Install, configure and use PRFlow."
+title: "Introduction"
+description: "What PRFlow is, the problem it solves and how a request becomes a review-ready pull request."
 ---
 
-Use these guides to take PRFlow from installation to a review-ready pull request. Start with a task below, or use the reference pages when you need an exact command or setting.
+PRFlow is a [Claude Code](https://code.claude.com) plugin that takes one request and hands back a pull request that is ready for your review.
 
-## Start Using PRFlow
+Not a snippet. Not a first draft. A branch with the code, the tests the change needed, the documentation it affected, a record of what was verified and a review that already found and fixed its own problems. You do the final review and the merge.
 
-- [Getting Started](/docs/getting-started/index): Check requirements, install the plugin, initialize a repository and complete a first run.
-- [Workflows](/docs/workflows/index): Choose the command that matches the work you want PRFlow to do.
-- [How PRFlow Works](/docs/concepts/index): Understand branches, workpads, review passes, recovery and human control.
+## The Problem PRFlow Solves
 
-## Operate and Configure PRFlow
+Coding agents are impressive on a fresh repository and disappointing on a real ticket.
 
-- [Runs](/docs/runs/index): Choose local execution or optional GitHub Actions automation.
-- [Configuration](/docs/configuration/index): Set repository defaults, models, tools, cloud runtimes, documentation paths and privacy controls.
-- [Reference](/docs/reference/index): Find client-specific command syntax and definitions of PRFlow terms.
-- [Troubleshooting](/docs/troubleshooting/index): Start from a symptom and follow a concrete recovery path.
+Point one at a change in a large production codebase and it usually comes back with part of the work: code that ignores an existing pattern, no tests, documentation left stale and acceptance criteria that were never checked. The agent saved you an hour of typing and cost you two hours of review and cleanup.
 
-New users should begin with [Requirements](/docs/getting-started/requirements), continue to [Installation](/docs/getting-started/installation) and then follow [First Run](/docs/getting-started/first-run).
+The bottleneck moved. Writing code got cheap. Everything around it — planning against architecture that already exists, verifying the change, reviewing it seriously, keeping documentation true — did not. That is the work PRFlow does.
 
-**Need help reporting a problem?** Include your PRFlow version, operating system, coding client, command and the smallest relevant error excerpt. Remove credentials and private repository content before sharing logs.
+## What You Actually Get
+
+| | A raw coding agent | PRFlow |
+| --- | --- | --- |
+| **Starting point** | A prompt | A GitHub issue with acceptance criteria |
+| **Scope** | What fits in one response | A whole ticket, across as many steps as it takes |
+| **Tests** | If you ask | Written and run as part of the change |
+| **Review** | You do it | Independent review passes that find issues and fix them, then re-review |
+| **Documentation** | Rarely | Internal docs, public docs and release notes updated in the same run |
+| **Evidence** | The chat log | A progress record on the issue naming what was verified and what was not |
+| **Result** | A diff to clean up | A pull request to review and merge |
+
+## How It Works
+
+Three commands cover the common path.
+
+<Steps>
+  <Step title="Describe the work">
+    `/prflow:create-issue` turns a rough idea into a GitHub issue. It reads your repository first, asks the questions it genuinely cannot answer and creates nothing until you approve the exact draft.
+  </Step>
+  <Step title="Let PRFlow build it">
+    `/prflow:implement 123` creates a branch, plans the change against your existing code, implements it, runs your tests, reviews the diff, fixes what the review found, updates the documentation and opens a pull request. It writes its progress to a comment on the issue as it goes, so you can watch or walk away.
+  </Step>
+  <Step title="Review and merge">
+    You read the pull request. PRFlow never merges it. Your branch protection and your normal approval process are untouched.
+  </Step>
+</Steps>
+
+A run on a real ticket takes minutes, not seconds. It is doing the whole round, not a single completion.
+
+```mermaid
+flowchart LR
+    accTitle: What one PRFlow run does between your request and your review
+    accDescr: A request becomes an issue you approve. PRFlow then plans the change, implements it, verifies it against your tests and reviews it. Findings from the review go back into another fix pass until the review is clean. PRFlow then updates documentation and opens a pull request. A person reviews and merges it.
+    req["Your request"] --> issue["Issue<br/>you approve it"]
+    issue --> plan["Plan and implement"]
+    plan --> verify["Run your tests<br/>and linters"]
+    verify --> review["Review the diff"]
+    review -- "findings" --> fix["Fix them"]
+    fix --> review
+    review -- "clean" --> docs["Update the docs"]
+    docs --> pr["Pull request"]
+    pr --> human["You review<br/>and merge"]
+```
+
+## What Makes the Review Trustworthy
+
+Any single pass from a language model is variable. PRFlow is built around not trusting one.
+
+<CardGroup cols={2}>
+  <Card title="Independent reviewers" icon="users">
+    Several reviewers with different jobs look at the same change without seeing each other's conclusions. When more than one raises the same defect, that agreement counts for something.
+  </Card>
+  <Card title="Verification before opinion" icon="list-check">
+    PRFlow builds a checklist of the specific claims a change makes and checks them against the code. A check that fails, or that cannot be settled, blocks a clean approval.
+  </Card>
+  <Card title="A review of the review" icon="eye">
+    Before an approval stands, a separate pass re-examines the change without the first review's conclusions, looking for what it missed.
+  </Card>
+  <Card title="It improves itself" icon="arrows-rotate">
+    A weekly retrospective reads PRFlow's own track record and proposes the smallest change that would prevent a repeating mistake. A person approves or rejects each one.
+  </Card>
+</CardGroup>
+
+## What PRFlow Does Not Do
+
+Honesty here is worth more than a stronger claim.
+
+- **It does not merge.** PRFlow prepares a pull request. Every merge decision stays with a person and with your repository's protections.
+- **A clean review is evidence, not proof.** The extra review passes narrow the chance of a bad change getting through. They never close it. Reviewers can share the same blind spot, and a test can encode the same wrong assumption as the code it covers.
+- **It does not invent your requirements.** If an issue leaves a decision open, PRFlow stops and asks rather than guessing. A run can end Blocked, which is a result, not a failure.
+- **It does not run without permission.** Locally it uses your session's tools and permission prompts. In the cloud it runs only when an authorized person asks it to.
+
+## Start Here
+
+<CardGroup cols={2}>
+  <Card title="Quickstart" icon="bolt" href="/docs/quickstart">
+    Install PRFlow and get your first pull request on one page.
+  </Card>
+  <Card title="Getting Started" icon="book-open" href="/docs/getting-started/index">
+    Requirements, installation, repository setup and a guided first run.
+  </Card>
+  <Card title="Workflows" icon="route" href="/docs/workflows/index">
+    Every command, what it changes and when to reach for it.
+  </Card>
+  <Card title="How PRFlow Works" icon="diagram-project" href="/docs/concepts/index">
+    The lifecycle, the review system, verification and the security boundaries.
+  </Card>
+</CardGroup>
+
+## Getting Help
+
+When something goes wrong, start from the symptom in [Troubleshooting](/docs/troubleshooting/index).
+
+When reporting a problem, include your PRFlow version, your operating system, the command you ran, whether it was a local or a cloud run and the smallest excerpt of the error. Remove credentials and private repository content before sharing any log.

--- a/docs/external/docs/quickstart.md
+++ b/docs/external/docs/quickstart.md
@@ -1,0 +1,154 @@
+---
+title: "Quickstart"
+description: "Install PRFlow and turn your first issue into a review-ready pull request."
+---
+
+Go from nothing installed to a pull request you can review. Allow about 10 minutes, plus the time PRFlow spends on the change itself.
+
+For the longer explanation behind each step, follow [Getting Started](/docs/getting-started/index) instead.
+
+## Before You Start
+
+You need a GitHub repository you can push to, Claude Code and five tools on your `PATH`.
+
+```bash
+git --version
+gh --version
+jq --version
+python3 --version
+bash --version
+gh auth status
+```
+
+Python must be 3.11 or newer, and `bash` must be a POSIX Bash. On macOS, `/usr/bin/python3` is often 3.9 — check with `python3 -VV` and install a newer Python if needed. On Windows, use WSL Bash, Git Bash or MSYS2 Bash.
+
+`gh auth status` must report an account that can read issues and create branches, comments and pull requests in the repository you plan to change.
+
+<Note>
+  PRFlow does not need a configuration file to run locally. Every setting has a built-in default.
+</Note>
+
+## 1. Install the Plugin
+
+```bash
+claude plugin marketplace add The01Geek/prflow
+claude plugin install prflow@devflow-marketplace
+```
+
+The marketplace is named `devflow-marketplace` on purpose. The plugin is named `prflow`.
+
+Start a new Claude Code session, then confirm the commands are available by entering `/prflow:` in the prompt. You should see the PRFlow commands offered as completions.
+
+## 2. Set Up Your Repository
+
+From anywhere inside the repository you want to change:
+
+```text
+/prflow:init
+```
+
+This step is recommended, not required. It writes `.prflow/config.json`, detects the build, test and lint tools your project already uses, grants them to PRFlow and checks your prerequisites. It finishes by reporting the dependency check:
+
+```text
+devflow preflight: all dependencies present.
+```
+
+If a tool is missing, initialization tells you which one and what to install. The configuration it already wrote is kept, so you install the tool and continue.
+
+Review the diff before you commit it. `/prflow:init` does not commit anything for you.
+
+## 3. Create an Issue
+
+Skip this if you already have an issue with clear acceptance criteria.
+
+```text
+/prflow:create-issue Add a --retain-days option so completed run logs can be kept for 30 days
+```
+
+PRFlow reads your repository, asks the questions it cannot answer from the code, then shows you the complete issue draft. Nothing is created until you approve that exact draft.
+
+Approve it, and PRFlow creates the issue and tells you its number.
+
+<Tip>
+  Acceptance criteria are what PRFlow checks its own work against later. An issue with none still runs, but there is nothing for that check to test. Keep them in the draft.
+</Tip>
+
+## 4. Implement It
+
+Replace `123` with your issue number.
+
+```text
+/prflow:implement 123
+```
+
+PRFlow creates a branch named `issue-123-<title-slug>`, then posts a single progress comment to the issue and keeps it updated for the whole run. That comment is the workpad. Abridged, it looks like this:
+
+```markdown
+# PRFlow Workpad — Issue #123
+
+**Status:** 🚀 Implementing
+**Branch:** `issue-123-add-retain-days-option`
+**Run:** _(local run)_
+**PR:** _not yet created_
+**Last updated:** 2026-08-26 09:41 UTC
+
+## Progress
+- [x] **Setup** — branch & workpad
+- [ ] **Implement**
+  - [x] code + sweeps
+- [ ] **Review**
+  - [ ] `/simplify`
+  - [ ] `review-and-fix`
+  - [ ] acceptance-criteria gate
+- [ ] **Documentation**
+- [ ] **PR marked ready**
+```
+
+The status glyph tells you where the run stands at a glance:
+
+| Glyph | Meaning |
+| --- | --- |
+| 🚀 | Running. The word beside it names the current stage. |
+| 🎉 | Complete. The run finished its lifecycle and recorded its evidence. |
+| 👎 | Blocked. Something needs a person. The reason is recorded in the workpad. |
+| 💥 | Failed. A cloud run ended without a normal result. |
+| 🛑 | Cancelled. |
+
+When the run finishes, you have a branch, a pull request that closes the issue and a workpad recording what was verified and anything PRFlow could not settle.
+
+## 5. Review and Merge
+
+Read the pull request the way you would read a colleague's: the code, the tests, the documentation and the acceptance-criteria evidence in the workpad.
+
+For a second opinion from a fresh review with no memory of building the change:
+
+```text
+/prflow:review 123
+```
+
+That returns findings and a verdict. Then merge it yourself. PRFlow never merges.
+
+## If a Run Stops
+
+A run that ends with 👎 **Blocked** is telling you something specific. Common causes are an issue that depends on another open issue, a bug PRFlow could not reproduce, an acceptance criterion that does not pass, or a verification command it is not permitted to run.
+
+Read the reason in the workpad, resolve it and run the same command again. PRFlow picks up from the last recorded checkpoint.
+
+[Troubleshooting](/docs/troubleshooting/implementation) covers each cause and its fix.
+
+## What to Read Next
+
+<CardGroup cols={2}>
+  <Card title="Workflows" icon="route" href="/docs/workflows/index">
+    Every command, what it is allowed to change and when to use it.
+  </Card>
+  <Card title="How PRFlow Works" icon="diagram-project" href="/docs/concepts/index">
+    The lifecycle, the review system and where your control points are.
+  </Card>
+  <Card title="Configuration" icon="sliders" href="/docs/configuration/index">
+    Set the base branch, tool permissions, review thresholds and documentation paths.
+  </Card>
+  <Card title="Cloud Runs" icon="cloud" href="/docs/runs/cloud/index">
+    Start PRFlow from a GitHub comment instead of your terminal.
+  </Card>
+</CardGroup>

--- a/docs/external/docs/reference/command-reference.md
+++ b/docs/external/docs/reference/command-reference.md
@@ -1,54 +1,75 @@
 ---
 title: "Command Reference"
-description: "Look up every public PRFlow command, argument, supported client and result."
+description: "Look up every PRFlow command, its arguments, where it runs, what it can change and what it returns."
 ---
 
-Find the canonical syntax and client availability for every public PRFlow command. A command is the text you enter. It invokes a PRFlow skill, whose documented behavior is called a workflow in these guides.
+Find the exact syntax for every PRFlow command you can invoke yourself.
 
-This reference lists the commands you invoke yourself. PRFlow also ships internal skills (such as the retrospective analysis stages that `retrospective-weekly` dispatches) that are marked not directly invocable; they are intentionally absent from this matrix.
+A command is the text you enter. It runs a PRFlow skill, whose behavior these guides call a workflow.
 
-## Client Syntax
+## Syntax
 
-Replace `<skill>` with the command name from the matrix.
+Every PRFlow command uses the `prflow` namespace:
 
-| **Client or Surface** | **Syntax** |
-| --- | --- |
-| Claude Code | `/prflow:<skill> [arguments]` |
-| GitHub Copilot CLI | `/prflow/<skill> [arguments]` |
-| Codex CLI | `$prflow:<skill> [arguments]` |
-| GitHub comment | `/prflow:<skill> [arguments]` |
+```text
+/prflow:<command> [arguments]
+```
 
-All public commands support the three local clients above. GitHub-comment availability is limited to the rows marked Supported.
+For example, to implement issue 123 and then ask for an independent review of the resulting pull request 456:
+
+```text
+/prflow:implement 123
+/prflow:review 456
+```
+
+<Warning>
+  Always include the `prflow` namespace. Names such as `review` and `init` collide with commands built into coding clients, and a bare name can run something else entirely.
+</Warning>
+
+The same `/prflow:` spelling works in a GitHub comment for the commands marked below. Comments also still accept the older `/devflow:` spelling, which is normalized to the current one. Use `/prflow:` in anything you write today.
+
+PRFlow also ships internal skills that it dispatches on its own, such as the stages behind the weekly retrospective. They are not invocable and are deliberately absent from this table.
 
 ## Commands
 
-| **Command and Arguments** | **Purpose** | **Supported Clients** | **Local / Cloud** | **Mutation Authority** | **Expected Result** |
-| --- | --- | --- | --- | --- | --- |
-| `init` | Scaffold or update PRFlow repository configuration and check prerequisites. | Claude Code, GitHub Copilot CLI, Codex CLI | Local only | Writes configuration and approved setup files. | Updated repository configuration with existing values preserved, plus any reported prerequisite gaps. |
-| `create-issue <user story>` | Turn a rough request into an approved GitHub issue. | Claude Code, GitHub Copilot CLI, Codex CLI | Local only | Creates one issue after explicit draft approval. | An approved issue. It is implementation-ready only when its Blocked section has no unresolved decision. |
-| `implement <issue number>` | Complete the four-phase issue-to-pull-request lifecycle. | Claude Code, GitHub Copilot CLI, Codex CLI, GitHub comment | Local: Yes. Cloud: Supported comment. | Creates or adopts a branch, commits, pushes and creates or updates a pull request. | A review-ready or draft pull request with recorded verification evidence, or a Blocked result naming the required human action. |
-| `review [pull request number] [--issue N]` | Assess a pull request or the current branch. | Claude Code, GitHub Copilot CLI, Codex CLI, GitHub comment | Local: Yes. Cloud: Supported comment. | Does not edit the reviewed tree. Pull request mode can post comments and attempts a formal review. | Findings and a review verdict, with any incomplete checks or missing formal signal reported. |
-| `review-and-fix [pull request number] [--push-each-iteration] [--issue N]` | Assess changes and commit authorized corrections. | Claude Code, GitHub Copilot CLI, Codex CLI | Local only | Commits corrections. Pushes only with `--push-each-iteration`. | Corrections followed by recorded verification, or a report naming unresolved findings. Run `review` separately to attempt a formal signal. |
-| `receiving-code-review [pull request number or feedback]` | Verify received feedback and address findings that meet the direct-use correction threshold. | Claude Code, GitHub Copilot CLI, Codex CLI | Local only | Can update the active branch, edit files and run tests. It applies corrections only after verifying the subject and feedback. | Verified dispositions, authorized corrections and verification evidence, or a report naming degraded context or blockers. |
-| `requesting-code-review` | Request an assessment of the current work from an independent reviewer. | Claude Code, GitHub Copilot CLI, Codex CLI | Local only | Dispatches an assessment-only reviewer. The reviewer does not edit the assessed tree. | Review findings and an assessment returned to the active session. |
-| `pr-description [issue number]` | Generate or update the current branch's pull request body. | Claude Code, GitHub Copilot CLI, Codex CLI | Local only | Updates an existing pull request body. Makes no branch file edits. | A structured description or plain text when no pull request exists. |
-| `docs` | Run the internal, external and release-note documentation sequence. | Claude Code, GitHub Copilot CLI, Codex CLI | Local only | Edits documentation files. Does not commit. | A branch-wide documentation pass and summary. |
-| `docs-sync-internal` | Align developer docs with changed code. | Claude Code, GitHub Copilot CLI, Codex CLI | Local only | Edits internal documentation. | Internal docs that match the branch's behavior changes. |
-| `docs-sync-external` | Align existing public docs with internal sources and shipped behavior. | Claude Code, GitHub Copilot CLI, Codex CLI | Local only | Edits customer-facing documentation. | Updated public guidance with internal-only detail removed. |
-| `docs-bootstrap-internal` | Create or comprehensively reorganize developer docs. | Claude Code, GitHub Copilot CLI, Codex CLI | Local only | Creates and edits internal documentation. | A domain-based internal documentation set. |
-| `docs-bootstrap-external` | Create or comprehensively rebuild public docs from internal docs. | Claude Code, GitHub Copilot CLI, Codex CLI | Local only | Creates, edits and can remove customer-facing documentation. | A structured public documentation set. |
-| `docs-verify [--report-only] [--search-space <pathspec>] <topic>` | Verify one documentation topic against code. | Claude Code, GitHub Copilot CLI, Codex CLI | Local only | Default mode edits internal docs. `--report-only` makes no changes. | Corrected topic docs or a structured findings report. |
-| `docs-release-notes` | Add an applicable release note and reconcile the changelog. | Claude Code, GitHub Copilot CLI, Codex CLI | Local only | Edits the configured release-note and applicable changelog files. | A customer-facing note for visible changes or an explicit skip. |
-| `retrospective-weekly` | Analyze recent merged work and file bounded improvements for human triage. | Claude Code, GitHub Copilot CLI, Codex CLI | Local only | Changes the local checkout, updates learning records, opens or updates a state pull request and files selected issues. | A retrospective report, state pull request, filed issues and explicit blockers. |
+| Command and Arguments | Purpose | Where It Runs | What It Can Change | Expected Result |
+| --- | --- | --- | --- | --- |
+| `init` | Scaffold or refresh repository configuration and check prerequisites. | Local | Writes configuration and approved setup files. | Updated configuration with your existing values preserved, plus any prerequisite gaps it found. |
+| `create-issue <user story>` | Turn a rough request into an approved GitHub issue. | Local | Creates one issue, only after you approve the draft. | An approved issue. It is ready to implement when its Blocked section holds no unresolved decision. |
+| `implement <issue number>` | Carry an issue through to a pull request. | Local, and a comment on an **issue** | Creates or adopts a branch, commits, pushes and creates or updates a pull request. | A review-ready or draft pull request with recorded verification evidence, or a Blocked result naming what a person must do. |
+| `review [pull request number] [--issue N]` | Assess a pull request or the current branch. | Local, and a comment on a **pull request** | Nothing in the reviewed tree. In pull-request mode it can post comments and a formal review. | Findings and a verdict, with any incomplete check reported. |
+| `review-and-fix [pull request number] [--push-each-iteration] [--issue N]` | Assess changes and commit authorized corrections. | Local, and a comment on a **pull request** | Commits corrections. A local run pushes only with `--push-each-iteration`; a comment-triggered run pushes to the pull request branch. | Corrections followed by recorded verification, or a report naming unresolved findings. |
+| `pr-description [issue number]` | Generate or refresh the current branch's pull request body. | Local, and a comment on a **pull request** | Updates an existing pull request body. Makes no file edits. | A structured description, or plain text when no pull request exists. |
+| `receiving-code-review [pull request number or feedback]` | Verify review feedback you received and address what meets the correction threshold. | Local | Can edit files on the active branch and run tests, after verifying the feedback. | Verified dispositions, authorized corrections and verification evidence, or a report naming blockers. |
+| `requesting-code-review` | Ask an independent reviewer to assess the current work. | Local | Nothing. The reviewer does not edit the tree. | Review findings returned to your session. |
+| `docs` | Run the internal, external and release-note documentation sequence. | Local | Edits documentation files. Does not commit. | A branch-wide documentation pass and a summary. |
+| `docs-sync-internal` | Bring developer docs in line with changed code. | Local | Edits internal documentation. | Internal docs matching the branch's behavior changes. |
+| `docs-sync-external` | Bring public docs in line with internal sources and shipped behavior. | Local | Edits customer-facing documentation. | Updated public guidance with internal-only detail removed. |
+| `docs-bootstrap-internal` | Create or comprehensively reorganize developer docs. | Local | Creates and edits internal documentation. | A structured internal documentation set. |
+| `docs-bootstrap-external` | Create or comprehensively rebuild public docs from internal docs. | Local | Creates, edits and can remove customer-facing documentation. | A structured public documentation set. |
+| `docs-verify [--report-only] [--search-space <pathspec>] <topic>` | Check one documentation topic against the code. | Local | Corrects internal docs by default. `--report-only` changes nothing. | Corrected topic docs, or a findings report. |
+| `docs-release-notes` | Add a release note where one applies and reconcile the changelog. | Local | Edits the configured release-note and changelog files. | A customer-facing note, or an explicit decision to skip. |
+| `retrospective-weekly` | Analyze recently merged work and file bounded improvements for human triage. | Local | Updates learning records, opens or updates a state pull request and files selected issues. | A report, a state pull request, filed issues and any blockers. |
 
-## GitHub Comment Boundary
+## What Runs From a GitHub Comment
 
-Fresh installations ship comment automation for `implement` and manual `review`. A repository collaborator must issue the command on the relevant issue or pull request. Automatic pull-request-triggered review is not included in fresh installations.
+A fresh cloud installation answers four commands posted as a comment by an authorized person:
 
-PRFlow prepares review-ready work. No command merges a pull request.
+- `/prflow:implement <issue number>` — on a comment on an **issue**, not on a pull request.
+- `/prflow:review` — on a comment on a **pull request's Conversation tab**.
+- `/prflow:review-and-fix` — same surface.
+- `/prflow:pr-description` — same surface.
+
+Every one of them requires a repository collaborator with write, maintain or admin access who also matches the allowed-users setting, or a listed bot identity. Someone commenting from a fork cannot start a privileged run.
+
+Automatic review triggered by pull-request events is not included in a fresh installation. To get review without typing a command, see [Request a Review Automatically on Green CI](/docs/runs/cloud/auto-review).
+
+<Note>
+  No command merges a pull request. PRFlow prepares review-ready work and stops there.
+</Note>
 
 ## Related Articles
 
-- [Workflows](/docs/workflows/index)
-- [Cloud Triggers](/docs/runs/cloud/triggers)
-- [Glossary](/docs/reference/glossary)
+- [Workflows](/docs/workflows/index) — which command to reach for
+- [Cloud Triggers](/docs/runs/cloud/triggers) — the comment surface in detail
+- [Glossary](/docs/reference/glossary) — the terms these commands use

--- a/docs/external/docs/reference/glossary.md
+++ b/docs/external/docs/reference/glossary.md
@@ -1,13 +1,27 @@
 ---
 title: "Glossary"
-description: "Understand the terms PRFlow uses for issues, branches, reviews and human control."
+description: "Look up any term PRFlow prints in its output, in plain language."
 ---
 
-Use this glossary to understand PRFlow terms without needing to know the product's internal implementation.
+Use this glossary to read PRFlow's own output without knowing how the product is built.
 
-**Acceptance criteria**: Testable statements in an issue that define when the requested outcome is complete.
+**Acceptance criteria**: Testable statements in an issue that define when the requested outcome is complete. PRFlow reads a criterion only when it is written as a markdown checkbox row.
+
+**APPROVE**: The clean verdict. The review found nothing that blocks the merge and verified its own coverage.
+
+**APPROVE with notes**: Nothing blocked the merge, and the review still reported findings that sat below the line where a finding causes a rejection.
+
+**APPROVE WITH ADVISORY NOTES**: The review-and-fix loop approved the change and parked one or more findings for a person to judge instead of fixing them.
+
+**APPROVE WITH CAVEAT**: The review approved the change and could not confirm how much of its own checking actually ran. Read it as approved with unknown coverage.
+
+**APPROVE WITH UNRESOLVED SHADOW FINDINGS**: The review-and-fix loop converged, and its final independent pass then surfaced findings it had no iterations left to address. Read it as approved with known, unaddressed work, listed in the report.
 
 **Base branch**: The repository branch a feature branch or pull request is compared with, such as `main`.
+
+**Blocked**: This word means two different things. In an issue, a `🚫 Blocked` section lists unresolved decisions that must be settled before anyone implements the issue. As a run outcome, Blocked means the run stopped on purpose without finishing and recorded why.
+
+**Checkpoint**: A commit and push a run makes at a step boundary so that an interrupted run loses only the work done since the last one.
 
 **Cloud run**: A supported PRFlow command executed by repository automation after an authorized GitHub comment.
 
@@ -15,25 +29,57 @@ Use this glossary to understand PRFlow terms without needing to know the product
 
 **Draft pull request**: A pull request that is open but not yet published as ready for review.
 
+**Effort**: How much reasoning the model is asked to spend on a run. The accepted values are `low`, `medium`, `high`, `xhigh` and `max`, set per configuration section.
+
 **Feature branch**: The branch that holds the commits for one issue or pull request.
 
-**Formal review**: A GitHub pull request review that records an approval, comment or request for changes. A comment review is a durable report but does not create an approval or request-changes merge signal.
+**Finding severity**: The grade a review agent gives a finding: Critical, Important, Suggestion or Informational. Only Informational never affects the verdict.
 
-**Human merge boundary**: The rule that PRFlow prepares and reviews pull requests but a person owns the final merge decision.
+**Formal review**: A GitHub pull request review that records an approval, comment or request for changes. A comment review is a durable report but creates no approval or request-changes merge signal.
 
-**Local run**: A PRFlow skill executed in the user's active Claude Code, GitHub Copilot CLI or Codex CLI session.
+**Human merge boundary**: The rule that PRFlow prepares and reviews pull requests, and a person owns the final merge decision.
 
-**Post-merge verification**: An acceptance check that requires a deployed or other genuinely live environment and must run after merge.
+**Investigation record**: A separate comment PRFlow posts on an issue it creates, holding the investigation behind the issue — rejected designs, confirmatory evidence and deliberation — so the issue body carries only what an implementer needs.
+
+**Iteration**: One pass of the review-and-fix loop: review, fix what qualifies, then review again.
+
+**Local run**: A PRFlow skill executed in the user's active Claude Code session.
+
+**Post-merge verification**: An acceptance check that requires a deployed or otherwise genuinely live environment, and so must run after merge.
+
+**Preflight**: The dependency check that confirms working `git`, `gh`, `jq` and Python 3.11 or newer. Initialization runs it for you, and its output keeps the older `devflow` spelling.
 
 **PRFlow**: A plugin that prepares documented pull requests with verification and review evidence for human evaluation.
 
+**Progress comment**: The comment a review keeps up to date on the pull request while it works. It is edited in place, so a superseded verdict disappears from it. It is the review's equivalent of the workpad.
+
+**Prompt extension**: A markdown file under `.prflow/prompt-extensions/` that adds your repository's own policy to one skill's instructions. See [Prompt Extensions](/docs/configuration/prompt-extensions).
+
+**Provenance label**: The label `PRFlow`, applied to every issue and pull request PRFlow creates so later runs can recognize their own work. The older `DevFlow` spelling is still recognized.
+
 **Ready for review**: A pull request state that tells reviewers the authoring workflow is complete. It does not mean the pull request has been approved or merged.
 
-**Review-and-fix loop**: A bounded cycle that reviews a candidate, verifies findings, commits authorized fixes and reviews the result again.
+**Reflection**: A short durable note a run writes on the workpad about friction it hit, a stop it made or a problem with the issue itself. The workpad heading keeps the older `Devflow Reflection` spelling on purpose, so records written before the rename stay readable.
 
-**Shadow review**: A separate review pass that looks for significant findings missed by the primary review-and-fix loop. It reports which planned reviewers completed and any known coverage gaps, but it cannot prove that every defect was found.
+**REJECT**: The blocking verdict. At least one checklist item failed or was inconclusive, or a finding reached the severity that blocks a merge, or the change's own diff added a line that is untrue.
 
-**State pull request**: A pull request containing retrospective learning records instead of product-code changes. A human reviews and merges it.
+**Review agent**: One of the nine subagents the review engine dispatches, each looking for a different class of problem — project guidelines, comment accuracy, test coverage, silent failures and type design among them.
+
+**Review-and-fix loop**: A bounded cycle that reviews a candidate, verifies findings, commits authorized fixes and reviews the result again. It stops after five iterations by default, and reports its latest verdict when it does.
+
+**Run status**: The single word on a workpad saying where a run is. In order: Setup, Discovering, Reproducing, Planning, Implementing, Reviewing, Documenting, then Complete. Blocked, Failed and Cancelled are the ways a run ends early. Each word carries a glyph — 🚀 for any status still running, 🎉 Complete, 👎 Blocked, 💥 Failed and 🛑 Cancelled.
+
+**Scope-acknowledged finding**: A review finding deliberately left unfixed in this pull request and recorded in the pull-request body with a follow-up issue, so the next review reports it as informational instead of rejecting the change again.
+
+**Shadow review**: A separate review pass that looks for significant findings the primary review-and-fix loop missed. It reports whether its coverage was verified, and it cannot prove that every defect was found. When it raises findings the loop cannot resolve within its iteration cap, the verdict says so.
+
+**State pull request**: A pull request containing retrospective learning records instead of product-code changes. A person reviews and merges it.
+
+**Telemetry branch**: A long-lived branch, `prflow-telemetry` by default, that holds per-run efficiency records rather than product code. A fresh cloud installation does not receive the workflow that pushes to it.
+
+**Verdict**: The review's overall answer about a pull request, and the thing that decides whether a merge is blocked. It is one of the APPROVE forms above, or REJECT.
+
+**Verification checklist**: The list of checkable claims the review engine derives from the diff before it dispatches its agents. Each item resolves to PASS, FAIL or INCONCLUSIVE, and anything other than PASS causes a REJECT.
 
 **Workpad**: The single GitHub issue comment that records an implementation run's branch, status, plan, progress, acceptance criteria and important recovery notes.
 
@@ -41,3 +87,5 @@ Use this glossary to understand PRFlow terms without needing to know the product
 
 - [Command Reference](/docs/reference/command-reference)
 - [Workflows](/docs/workflows/index)
+- [Review System](/docs/concepts/review-system)
+- [Troubleshooting](/docs/troubleshooting/index)

--- a/docs/external/docs/reference/index.md
+++ b/docs/external/docs/reference/index.md
@@ -1,11 +1,23 @@
 ---
 title: "Reference"
-description: "Find PRFlow command availability, arguments, mutation authority and product terms."
+description: "Look up PRFlow command syntax, product terminology and past release notes."
 ---
 
-Find exact command syntax, client availability and definitions for PRFlow terminology.
+Use these pages when you know what you want and need the exact wording.
 
-- [Command Reference](/docs/reference/command-reference) lists every public command, its arguments, supported clients, run availability, mutation authority and expected result.
-- [Glossary](/docs/reference/glossary) defines the product terms used across the documentation.
+<CardGroup cols={2}>
+  <Card title="Command Reference" icon="terminal" href="/docs/reference/command-reference">
+    Every command you can invoke, its arguments, where it runs, what it may change and what it returns.
+  </Card>
+  <Card title="Glossary" icon="book" href="/docs/reference/glossary">
+    The terms PRFlow uses in its own output, defined in plain language.
+  </Card>
+  <Card title="Release Notes" icon="sparkles" href="/release-notes">
+    User-visible changes, fixes and upgrade notes for recent releases.
+  </Card>
+  <Card title="2026 Archive" icon="box-archive" href="/docs/reference/release-notes-archive-2026">
+    Earlier 2026 release notes, kept for reference.
+  </Card>
+</CardGroup>
 
-For task-selection guidance, start with [Workflows](/docs/workflows/index).
+If you are choosing which command fits a task rather than looking one up, start with [Workflows](/docs/workflows/index).

--- a/docs/external/docs/runs/cloud/auto-review.md
+++ b/docs/external/docs/runs/cloud/auto-review.md
@@ -1,0 +1,162 @@
+---
+title: "Request a Review Automatically on Green CI"
+description: "Add a workflow that posts a PRFlow review request as soon as your own CI passes on a pull request."
+---
+
+Get a PRFlow review without anyone typing a comment, by letting your own CI request it once it goes green.
+
+A fresh installation does not review pull requests automatically. The supported way to make review hands-free is a small workflow you add to your repository. When your CI succeeds on a pull request, that workflow posts a `/prflow:review` comment on it, and the PRFlow workflow you already installed handles the rest.
+
+## Before You Start
+
+<Warning>
+  **This workflow is safe only under the `pull_request` event. Never move it to `pull_request_target`.**
+
+  `pull_request_target` makes your repository secrets available to runs started by pull requests from forks. Under that trigger, the same-repository check inside the workflow would be the only thing stopping a fork from minting your GitHub App token. Under `pull_request`, GitHub withholds secrets from fork runs no matter what, so the same-repository check is a second line of defense rather than the only one.
+</Warning>
+
+Three preconditions must be true before the workflow can request anything:
+
+<AccordionGroup>
+  <Accordion title="A GitHub App Must Be Configured">
+    The workflow mints a downscoped token from the App you configured as `DEVFLOW_APP_ID` and `DEVFLOW_APP_PRIVATE_KEY`. Without those, the job's own condition is false and nothing is requested. See [Cloud Setup](/docs/runs/cloud/setup).
+  </Accordion>
+  <Accordion title="The App's Bot Login Must Be Allowed">
+    The comment is posted by your App, so PRFlow sees a bot as the requester. Add that App's bot login, such as `your-app[bot]`, to `prflow.allowed_bots` in `.prflow/config.json`. The shipped default is `claude,dependabot`, which names no App, so a fresh install does not authorize yours.
+
+    **Merge the `allowed_bots` change first.** PRFlow reads that setting from your default branch at the moment a comment arrives. Adding your App's login in the same pull request that adds this workflow has no effect on that pull request.
+  </Accordion>
+  <Accordion title="Your Installed Version Must Be Recent Enough">
+    The helper this workflow calls first ships in `prflow_version` `2.30.18`. Pin at or above it. Below that version the workflow warns and requests no review rather than failing.
+  </Accordion>
+</AccordionGroup>
+
+## Add the Workflow
+
+<Steps>
+  <Step title="Create the File">
+    Add a new file at `.github/workflows/prflow-auto-review.yml` in your repository. Do not put this content into an existing PRFlow workflow file, because the installer manages those.
+  </Step>
+  <Step title="Paste the Workflow">
+    Copy the file below exactly as it is.
+  </Step>
+  <Step title="Name Your Own CI Job">
+    Change `needs: [ci]` to the name of the job, or jobs, that must pass first. This is the only line you are expected to edit.
+  </Step>
+  <Step title="Commit and Open a Pull Request">
+    Commit the file, then open a pull request and let your CI run.
+  </Step>
+</Steps>
+
+```yaml
+# .github/workflows/prflow-auto-review.yml
+# Requests a PRFlow /prflow:review automatically once your CI is green on a
+# non-draft, same-repository pull request. Safe ONLY under `pull_request`
+# (see the hard precondition above — never `pull_request_target`).
+name: PRFlow auto-review request
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+permissions:
+  contents: read
+jobs:
+  request-review:
+    # Replace `ci` with YOUR own CI job(s). This `needs:` IS the success gate:
+    # because the `if:` below uses no status function (`always()`, `!cancelled()`,
+    # `success()`, `failure()`), GitHub skips this job unless every `needs:` job
+    # succeeded. Adding one of those functions REMOVES that implicit gate — if you
+    # do, add your own `needs.<job>.result == 'success'` clauses to the steps that
+    # mint the token and post, or a red CI run will request a review.
+    needs: [ci]
+    # These five eligibility clauses are the safety gate. Do not edit them.
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]' &&
+      vars.DEVFLOW_APP_ID != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      # The helper lives under .prflow/vendor/prflow/, where the installer put
+      # the plugin, and the vendor-plugin action re-materializes it at run time.
+      # The sparse checkout names both scripts/ and lib/ because the helper reads
+      # files from both.
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          sparse-checkout: |
+            .github/actions/vendor-plugin
+            .prflow/vendor/prflow/scripts
+            .prflow/vendor/prflow/lib
+      - name: Materialize the vendored PRFlow helper tree
+        uses: ./.github/actions/vendor-plugin
+      - name: Mint downscoped comment token
+        id: app_token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.DEVFLOW_APP_ID }}
+          private-key: ${{ secrets.DEVFLOW_APP_PRIVATE_KEY }}
+          permission-pull-requests: write
+      - name: Request a PRFlow review for this head
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          PR: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          EXPECTED_AUTHOR: ${{ steps.app_token.outputs.app-slug }}
+        run: |
+          HELPER=.prflow/vendor/prflow/scripts/post-ci-review-trigger.sh
+          # Absent-file breadcrumb: a consumer pinned below the version that
+          # carries the helper gets a NAMED warning rather than an rc-127 red step.
+          if [ ! -x "$HELPER" ]; then
+            echo "::warning::PRFlow auto-review: helper not found at $HELPER — is prflow_version >= 2.30.18? Skipping (no review requested)."
+            exit 0
+          fi
+          "$HELPER"
+```
+
+## What You Should See
+
+Once your CI job finishes successfully on the pull request, the `PRFlow auto-review request` workflow runs. It posts a `/prflow:review` comment on the pull request, authored by your GitHub App. That comment then starts a normal PRFlow review, exactly as if a collaborator had typed it, and the review posts its progress comment on the same pull request.
+
+Three outcomes tell you something went wrong instead:
+
+- **The job was skipped.** One of the five conditions was false: the pull request is a draft, it comes from a fork, its author is `dependabot[bot]`, `DEVFLOW_APP_ID` is not set or your CI job did not succeed.
+- **The step logged a warning about a missing helper.** Your installed `prflow_version` is below `2.30.18`. Update the installation. See [Cloud Updates](/docs/runs/cloud/updates).
+- **The comment was posted but no review started.** The App's bot login is not in `prflow.allowed_bots` on your default branch. See [Cloud Triggers](/docs/runs/cloud/triggers).
+
+## Where This Does Not Reach
+
+<Warning>
+  This mechanism can only wait on GitHub Actions jobs in the same workflow run. It does not reach CI that reports from outside Actions, such as CircleCI, Buildkite or a classic Jenkins commit status. A `needs:` entry cannot name those.
+</Warning>
+
+If your CI runs outside GitHub Actions, keep the manual path: a repository collaborator comments `/prflow:review` on the pull request.
+
+## Two Refinements You May Want
+
+PRFlow's own repository runs a slightly richer version of this job. Both additions are optional, and neither is in the file above:
+
+- **Serialize concurrent runs at the same commit**, so two green CI runs on one head cannot request two reviews.
+- **Supersede stale CI runs**, by adding a workflow-level `concurrency:` key to your own CI so an older run for a superseded head stops.
+
+Add either one to your own workflow if you want it.
+
+## Related Pages
+
+<CardGroup cols={2}>
+  <Card title="Cloud Setup" icon="key" href="/docs/runs/cloud/setup">
+    Configure the GitHub App this workflow mints its token from.
+  </Card>
+  <Card title="Cloud Triggers" icon="comment" href="/docs/runs/cloud/triggers">
+    The comment format and authorization rules the posted comment must satisfy.
+  </Card>
+  <Card title="Review System" icon="magnifying-glass" href="/docs/concepts/review-system">
+    What the review itself does once it starts.
+  </Card>
+  <Card title="Security" icon="shield" href="/docs/concepts/security">
+    The wider trust boundaries around cloud runs.
+  </Card>
+</CardGroup>

--- a/docs/external/docs/runs/cloud/index.md
+++ b/docs/external/docs/runs/cloud/index.md
@@ -3,25 +3,58 @@ title: "Cloud Runs"
 description: "Run PRFlow from authorized GitHub comments through repository automation."
 ---
 
-Cloud runs are for teams that want authorized collaborators to start PRFlow from GitHub. They run in GitHub Actions without an open local Claude Code session.
+Let authorized collaborators start PRFlow from a GitHub comment, with no local Claude Code session open.
 
-Cloud commands pass through an authorization gate before the agent job starts. The gate uses narrow GitHub permissions. The agent job then receives model credentials and its configured repository permissions. Maintainer-controlled workflows and configuration define both jobs. The run writes its work to a branch, workpad, pull request or review; it does not merge the change.
+A cloud command passes through an authorization gate before the agent job starts. The gate holds narrow GitHub permissions. The agent job then receives the model credentials and the repository permissions you configured. Maintainer-controlled workflow files and `.prflow/config.json` define both jobs. The run writes its work to a branch, a workpad, a pull request or a review.
 
 ![A cloud command moves from a GitHub comment through an authorization gate with narrow GitHub permissions, then into an agent job with model credentials and configured repository permissions. The agent job produces a branch, workpad, pull request or review for a person to review and merge.](/images/cloud-run-trust-boundary.svg)
 
-Fresh installations support two public cloud commands:
+## What a Fresh Installation Ships
 
-- `/prflow:implement` turns an issue into a pull request.
-- `/prflow:review` reviews a pull request without changing it.
+A fresh installation adds two workflow files, and they answer four comment commands:
 
-Automatic review on pull-request events is not included in fresh installations. PRFlow prepares review-ready pull requests but never merges them.
+| **Comment Command** | **Where You Post It** | **What It Produces** |
+| --- | --- | --- |
+| `/prflow:implement 123` | A comment on the issue. | A feature branch and a pull request that resolves the issue. |
+| `/prflow:review` | A comment on a pull request's **Conversation** tab. | A review verdict. It changes no code. |
+| `/prflow:review-and-fix` | A comment on a pull request's **Conversation** tab. | Review findings plus fixes pushed to the pull-request branch. |
+| `/prflow:pr-description` | A comment on a pull request's **Conversation** tab. | A written or updated pull-request description. |
+
+<Warning>
+  No cloud run merges a pull request. Every command ends with work a person still has to read, approve and merge.
+</Warning>
+
+<Note>
+  Automatic pull-request-triggered review is not included in a fresh installation. If you want a review to be requested without anyone typing a comment, add the workflow on [Request a Review Automatically on Green CI](/docs/runs/cloud/auto-review).
+</Note>
 
 ## Set Up Cloud Runs
 
-1. [Install the cloud tier](/docs/runs/cloud/installation).
-2. [Add authentication and project setup](/docs/runs/cloud/setup).
-3. [Choose and provision a runner](/docs/runs/cloud/runners).
-4. [Learn the comment triggers](/docs/runs/cloud/triggers).
-5. Run a low-stakes implementation or review before relying on the automation.
+<Steps>
+  <Step title="Install the Cloud Tier">
+    Run the installer from the repository root. See [Cloud Installation](/docs/runs/cloud/installation).
+  </Step>
+  <Step title="Add Authentication and Project Setup">
+    Add the model credential, review `.prflow/config.json` and declare how the runner is provisioned. See [Cloud Setup](/docs/runs/cloud/setup).
+  </Step>
+  <Step title="Choose a Runner">
+    Keep the default GitHub-hosted Linux runner, or point the workflows at your own. See [Cloud Runners](/docs/runs/cloud/runners).
+  </Step>
+  <Step title="Learn the Comment Triggers">
+    Learn the exact comment format and who is allowed to use it. See [Cloud Triggers](/docs/runs/cloud/triggers).
+  </Step>
+  <Step title="Try a Low-Stakes Run">
+    Use a throwaway pull request or a small issue before you rely on the automation.
+  </Step>
+</Steps>
 
-Use [Updates](/docs/runs/cloud/updates) when moving to a newer release. Use [Recovery](/docs/runs/cloud/recovery) when a run stops or reports a blocker.
+## Keep It Running
+
+<CardGroup cols={2}>
+  <Card title="Updates" icon="arrow-up" href="/docs/runs/cloud/updates">
+    Move an existing installation to a newer release without losing your configuration.
+  </Card>
+  <Card title="Recovery" icon="life-ring" href="/docs/runs/cloud/recovery">
+    Read a workpad status and resume a run that stopped before it finished.
+  </Card>
+</CardGroup>

--- a/docs/external/docs/runs/cloud/installation.md
+++ b/docs/external/docs/runs/cloud/installation.md
@@ -1,59 +1,90 @@
 ---
 title: "Cloud Installation"
-description: "Install PRFlow's GitHub Actions workflows from matching version references."
+description: "Install PRFlow's GitHub Actions workflows from a matching version reference."
 ---
 
-Add PRFlow's optional GitHub Actions tier to a repository when your team needs cloud runs. Local plugin users do not need this installer.
+Add PRFlow's optional GitHub Actions tier to a repository. Skip this page if you only run PRFlow locally.
 
-## Prerequisites
+## Before You Start
 
-Use a Git repository and run the installer from its root. Install `git` before starting. A working Python 3.11 or newer is strongly recommended because the installer uses it to compare managed files and record their provenance.
+- Work in a Git repository and run the installer from its root.
+- Install `git`.
+- Install Python 3.11 or newer. The installer uses Python to compare managed files and record their provenance. Without it, it preserves existing files rather than risk overwriting your work.
 
 ## Install From a Release Tag
 
-1. Download the installer from the current release tag.
+<Note>
+  The examples below pin `v2.34.50`. Replace it with the tag you want to install, from the [releases page](https://github.com/The01Geek/prflow/releases). Pin a tag rather than a branch, so the bytes you read are the bytes that run.
+</Note>
 
-   ```bash
-   curl -fsSL https://raw.githubusercontent.com/The01Geek/prflow/v2.34.50/install.sh -o devflow-install.sh
-   ```
+<Steps>
+  <Step title="Download the Installer">
+    ```bash
+    curl -fsSL https://raw.githubusercontent.com/The01Geek/prflow/v2.34.50/install.sh -o devflow-install.sh
+    ```
+  </Step>
+  <Step title="Read the File Before Running It">
+    This script writes workflow files and configuration into your repository. Open `devflow-install.sh` and read it first.
+  </Step>
+  <Step title="Run It With the Same Tag">
+    The URL selects the installer. `DEVFLOW_REF` selects the payload it installs. Use the same value in both places.
 
-2. Read `devflow-install.sh` before running it.
-3. Run the downloaded file with the same tag in `DEVFLOW_REF`.
+    ```bash
+    DEVFLOW_REF=v2.34.50 bash devflow-install.sh
+    ```
 
-   ```bash
-   DEVFLOW_REF=v2.34.50 bash devflow-install.sh
-   ```
+    A first installation applies immediately. Add `--dry-run`, or set `DEVFLOW_DRY_RUN=1`, to preview instead.
+  </Step>
+  <Step title="Review the Result">
+    ```bash
+    git status
+    git diff
+    ```
 
-4. Review the result with `git status` and `git diff`.
-5. Commit only after the generated files and permissions match your repository policy.
+    You should see new files under `.github/workflows/`, `.github/actions/` and `.prflow/`, listed in the next section. Commit only after the files and permissions match your repository policy.
+  </Step>
+</Steps>
 
-The URL and `DEVFLOW_REF` select the same release tag. A tag is not an immutable byte pin. Use the same verified commit SHA in both places when immutability is required. Leaving `DEVFLOW_REF` unset selects the moving `main` branch.
+<Warning>
+  A tag is not an immutable byte pin. Use the same verified commit SHA in both the URL and `DEVFLOW_REF` when you need immutability. Leaving `DEVFLOW_REF` unset selects the moving `main` branch.
+</Warning>
 
-## Understand First-Install Behavior
+## What a First Install Creates
 
-A first installation applies immediately unless you pass `--dry-run` or set `DEVFLOW_DRY_RUN=1`. It creates or updates these public installation surfaces:
-
-- `.github/workflows/devflow.yml` for authorized comment commands.
-- `.github/workflows/devflow-implement.yml` for issue implementation.
+- `.github/workflows/devflow.yml` for the comment commands `/prflow:review`, `/prflow:review-and-fix` and `/prflow:pr-description`.
+- `.github/workflows/devflow-implement.yml` for `/prflow:implement`.
 - `.github/actions/read-project-config`, `.github/actions/setup-project-env` and `.github/actions/vendor-plugin`.
 - `.claude-plugin/marketplace.json`.
 - `.prflow/config.json`, `.prflow/config.schema.json`, `.prflow/.gitignore` and prompt-extension examples.
 - `.prflow/install-manifest.json`, when Python can record managed-artifact digests.
-- `.prflow/lint-manifest.json` and `.prflow/install-state.json`, which let issue-implementation runs provision their lint tools from a verified, digest-bound set before the agent starts.
-- Repository ignore rules for installer sidecars.
+- `.prflow/lint-manifest.json` and `.prflow/install-state.json`, which let implementation runs provision their lint tools from a verified, digest-bound set before the agent starts.
+- Repository ignore rules for installer sidecar files.
 
-Fresh installations do not receive `devflow-review.yml`, `devflow-runner.yml` or `telemetry-push.yml`. Automatic pull-request-triggered review is withdrawn from new installs. Use a collaborator's `/prflow:review` comment instead.
+<Note>
+  A fresh installation does not receive an automatic pull-request review workflow. That tier is withdrawn from new installs. Use a collaborator's `/prflow:review` comment, or add the workflow described in [Request a Review Automatically on Green CI](/docs/runs/cloud/auto-review).
+</Note>
 
 ## Choose an Install Mode
 
-The default is a thin install. The workflows fetch the plugin at runtime into `.prflow/vendor/prflow/` using the pinned `prflow_version`. The fetched tree is ignored and is not committed.
+<Tabs>
+  <Tab title="Thin Install (Default)">
+    The workflows fetch the plugin at run time into `.prflow/vendor/prflow/`, using the `prflow_version` pin in `.prflow/config.json`. The fetched tree is ignored and is not committed.
 
-Set `DEVFLOW_VENDOR=1` to commit the plugin tree instead:
+    ```bash
+    DEVFLOW_REF=v2.34.50 bash devflow-install.sh
+    ```
 
-```bash
-DEVFLOW_VENDOR=1 DEVFLOW_REF=v2.34.50 bash devflow-install.sh
-```
+    Choose this for a small install diff and a small update diff.
+  </Tab>
+  <Tab title="Vendored Install">
+    The plugin tree is committed to your repository instead.
 
-Vendored mode avoids a runtime fetch and makes the plugin bytes auditable in the repository. It also creates a much larger install and update diff.
+    ```bash
+    DEVFLOW_VENDOR=1 DEVFLOW_REF=v2.34.50 bash devflow-install.sh
+    ```
+
+    Choose this when you want no run-time fetch and want the plugin bytes auditable in your own history. Expect a much larger install and update diff.
+  </Tab>
+</Tabs>
 
 Continue with [Cloud Setup](/docs/runs/cloud/setup).

--- a/docs/external/docs/runs/cloud/recovery.md
+++ b/docs/external/docs/runs/cloud/recovery.md
@@ -1,31 +1,87 @@
 ---
 title: "Cloud Recovery"
-description: "Resume or recover a blocked, failed or interrupted PRFlow cloud run."
+description: "Read a stopped PRFlow cloud run's recorded state and decide how to resume it."
 ---
 
-Resume an implementation or review when a cloud run stops making progress or ends before completing the handoff.
+Work out what a stopped cloud run had finished, and restart it without losing that work.
 
-## Start With Recorded State
+## Start With the Recorded State
 
-Start with the workpad or review-progress comment. Cross-check its status against the linked Actions run, current pull-request head and remote branch. For implementation, the workpad is the primary progress record, not a transaction log.
+Every implementation run keeps one workpad comment on the issue. Every review keeps one progress comment on the pull request. Read that comment first, then cross-check it against the linked Actions run, the current pull-request head and the remote branch.
 
-Interpret an implementation workpad status as follows:
+<Note>
+  The workpad is a progress record, not a transaction log. It tells you the run's last known state, not every action the run took.
+</Note>
 
-- An interim 🚀 status means the lifecycle did not reach a terminal state.
-- 🎉 Complete means PRFlow finished its lifecycle. It does not mean the pull request was merged.
-- 👎 Blocked names a prerequisite or verification that needs human action.
-- 💥 Failed or 🛑 Cancelled means the run stopped terminally.
+## Read the Status Glyph
 
-## Recover From a Stopped Run
+The workpad's `Status` line starts with one glyph. The glyph is the authoritative signal. PRFlow also mirrors 🚀, 🎉 and 👎 as a reaction on the comment that started the run, but that reaction is best effort, so trust the `Status` line over it.
 
-1. Read the last workpad note and the matching Actions step.
-2. Check authentication, runner prerequisites and `.prflow/config.json` before changing code.
-3. Fix the named blocker or confirm that the failure was transient.
-4. Reissue the original standalone command.
-5. Confirm that the new run adopts the existing workpad or current pull-request head.
+| **Glyph** | **Status** | **What It Means** | **Can It Be Resumed?** |
+| --- | --- | --- | --- |
+| 🚀 | Running | The run is in some phase and never reached an ending. This is the state a stalled or interrupted run is left in. | Yes. This is the one state a resume is for. |
+| 🎉 | Complete | PRFlow finished its own lifecycle. | No, and it does not need to be. |
+| 👎 | Blocked | A prerequisite or a verification needs a person. The run ended on purpose. | Only after you clear the named blocker. |
+| 💥 | Failed | The run dead-ended and the workflow recorded it. | Yes, after you fix the cause. |
+| 🛑 | Cancelled | Someone or something cancelled the run. | Yes, but only if you start it again yourself. |
 
-Implementation pushes progress at branch checkpoints. A later run can adopt the existing branch and pull request. Work after the last pushed checkpoint can still be lost. A run interrupted before its first checkpoint may have no branch changes to recover.
+<Warning>
+  🎉 Complete does not mean the pull request was merged, and it is not a promise that the change is correct. Read the diff and the review before you merge.
+</Warning>
 
-Configured stall backstops can post bounded resume requests for interim runs. They do not resume cancelled runs. When the cap is exhausted, authentication is unavailable or state cannot be read, the workflow reports the failure instead of looping indefinitely.
+<Warning>
+  **A cancelled run is a decided ending, not a stall.** PRFlow's stall backstops deliberately do not resume it. They flip the workpad to 🛑 Cancelled, post no comment and consume no resume attempt. If you want the work to continue, post the original command again yourself.
+</Warning>
 
-Do not repeatedly retry an unchanged deterministic failure. Use [Cloud-Run Problems](/docs/troubleshooting/cloud-runs) to match the symptom to a correction first.
+## Recover a Stopped Run
+
+<Steps>
+  <Step title="Read the Last Workpad Note and the Matching Actions Step">
+    The workpad names the phase it stopped in. Open the linked Actions run and read the step that failed or was still running.
+  </Step>
+  <Step title="Check the Environment Before You Change Code">
+    Most stopped runs are environment problems, not code problems. Check model authentication, runner prerequisites and `.prflow/config.json` first. See [Cloud Setup](/docs/runs/cloud/setup) and [Cloud Runners](/docs/runs/cloud/runners).
+  </Step>
+  <Step title="Fix the Named Blocker, or Confirm the Failure Was Transient">
+    A 👎 Blocked workpad names what it needs. A 💥 Failed run needs a cause you can point at in the log.
+  </Step>
+  <Step title="Post the Original Command Again">
+    Add the same standalone comment on the same thread. For example, on the issue:
+
+    ```text
+    /prflow:implement 123
+    ```
+  </Step>
+  <Step title="Confirm the New Run Adopted the Existing Work">
+    The new run should reuse the same workpad comment on the issue and record whether it resumed unfinished work or started from a terminal state. For a review, confirm the progress comment names the current pull-request head.
+  </Step>
+</Steps>
+
+## What Survives an Interruption
+
+Implementation pushes its progress at branch checkpoints, so a later run can adopt the existing branch and pull request.
+
+- Work committed at a checkpoint survives.
+- Work done after the last pushed checkpoint can still be lost.
+- A run interrupted before its first checkpoint may have left no branch changes at all.
+
+## When PRFlow Retries by Itself
+
+A configured stall backstop can post a bounded resume request for a run still showing 🚀. It is limited on purpose, by `prflow_implement.stall_backstop.max_resume_attempts`, which defaults to `2`.
+
+It stops rather than looping when the attempt cap is exhausted, when authentication is unavailable or when it cannot read the run's state. In each of those cases the workflow reports the failure.
+
+<Warning>
+  Do not repeatedly retry a failure that reproduces exactly. A deterministic failure will fail again and each attempt costs a full run. Match the symptom to a cause in [Cloud-Run Problems](/docs/troubleshooting/cloud-runs) first.
+</Warning>
+
+## Related Pages
+
+<CardGroup cols={2}>
+  <Card title="Workpads and Resume" icon="clipboard" href="/docs/concepts/workpads-and-resume">
+    How a workpad records progress and how a later run adopts it.
+  </Card>
+  <Card title="Cloud-Run Problems" icon="triangle-exclamation" href="/docs/troubleshooting/cloud-runs">
+    Symptom-by-symptom fixes for cloud runs that do not start or do not finish.
+  </Card>
+</CardGroup>

--- a/docs/external/docs/runs/cloud/runners.md
+++ b/docs/external/docs/runs/cloud/runners.md
@@ -1,40 +1,74 @@
 ---
 title: "Cloud Runners"
-description: "Select and provision GitHub-hosted or self-hosted runners for PRFlow."
+description: "Select and provision GitHub-hosted or self-hosted runners for PRFlow cloud jobs."
 ---
 
-Move PRFlow jobs from the default GitHub-hosted Linux runner to a compatible self-hosted or custom runner.
+Keep PRFlow on the default GitHub-hosted Linux runner, or move every job to a runner you control.
 
 ## Select a Runner
 
-Every job in the two shipped workflows uses `ubuntu-latest` by default. Set the GitHub Actions variable `DEVFLOW_RUNNER` to select another runner for all of them.
+Every job in the two shipped workflows runs on `ubuntu-latest` by default. One GitHub Actions variable, `DEVFLOW_RUNNER`, changes all of them at once.
+
+Set it under **Settings → Secrets and variables → Actions → Variables**.
 
 | **Value** | **Result** |
 | --- | --- |
-| Unset or empty | `ubuntu-latest` |
-| `windows-latest` | One runner label |
-| `["self-hosted","windows","PRFlow"]` | A runner matching every label in the JSON array |
-| A value beginning with `[` that is invalid JSON | Workflow evaluation fails with a `fromJSON` error |
+| Unset or empty | `ubuntu-latest`, the standard GitHub-hosted Linux runner. |
+| `windows-latest` | The single runner label you named. |
+| `["self-hosted","windows","PRFlow"]` | A runner matching every label in the JSON array. |
+| A value starting with `[` that is not valid JSON | Workflow evaluation fails with a `fromJSON` error. |
 
-Set it under **Settings → Secrets and variables → Actions → Variables**. Keep the `DEVFLOW_` name. No `PRFLOW_RUNNER` alias exists.
+Keep the `DEVFLOW_` prefix exactly as written. There is no `PRFLOW_RUNNER` alias.
+
+<Warning>
+  A label set that no registered runner matches does not fail. GitHub leaves the job queued forever with no error message. If a run never starts and the **Actions** tab shows it as queued, compare your label array against your runner's registered labels first.
+</Warning>
+
+<Warning>
+  If the variable name is misspelled or deleted, the expression falls back to `ubuntu-latest` and every job silently moves to a GitHub-hosted runner. That job carries your GitHub App private key and your model-provider API key in its environment. If you self-host for network isolation or compliance, check the runner label on a run after any change to this variable.
+</Warning>
 
 ## Provision a Self-Hosted Runner
 
-Install these prerequisites before selecting the runner:
+Install these before you point PRFlow at the runner:
 
 - `git`.
 - GitHub CLI (`gh`).
 - `jq`.
 - Python 3.11 or newer, available as `python3`.
 - A POSIX bash on `PATH`.
-- `openssl`, `curl`, and `nohup` — the long-run credential refresher hard-requires all three.
-- Docker when `setup.services` or repository checks need it.
+- `openssl`, `curl` and `nohup`. The long-run credential refresher needs all three.
+- Docker, when `setup.services` or your own checks need it.
 
-The workflows force `bash` for `run:` steps. On Windows, install Git Bash or an equivalent POSIX bash. If Python is available only as `python` or `py -3`, run the shipped `scripts/provision-python3-shim.sh --apply` once on the runner. Use `DEVFLOW_GH`, `DEVFLOW_JQ` or `DEVFLOW_BASH` only when the working executables are in nonstandard locations.
+Confirm the set in one pass on the runner:
+
+```bash
+for t in git gh jq python3 bash openssl curl nohup; do
+  command -v "$t" >/dev/null && echo "ok   $t" || echo "MISSING $t"
+done
+python3 --version
+```
+
+Every line should read `ok`, and the version should be 3.11 or higher. Fix each `MISSING` line before you continue.
+
+<AccordionGroup>
+  <Accordion title="Windows Runners">
+    The workflows force `bash` for their `run:` steps, so install Git Bash or an equivalent POSIX bash. If Python is available only as `python` or `py -3`, run the shipped shim provisioner once on the runner, from a checkout that has the plugin tree:
+
+    ```bash
+    bash .prflow/vendor/prflow/scripts/provision-python3-shim.sh --apply
+    ```
+
+    It refuses to create a shim when no compatible interpreter is present, so a clean exit means the runner is ready.
+  </Accordion>
+  <Accordion title="Executables in Nonstandard Locations">
+    Set `DEVFLOW_GH`, `DEVFLOW_JQ` or `DEVFLOW_BASH` only when the working executable is somewhere the normal search path does not reach. A correct `PATH` is simpler and less likely to drift.
+  </Accordion>
+</AccordionGroup>
 
 ## Use Claude Code on Windows
 
-The action's bundled Claude Code installer is Unix-only. Preinstall Claude Code on a self-hosted Windows runner and set `setup.claude_code_executable` to the single-line path of `claude.exe`.
+The action's bundled Claude Code installer is Unix-only. On a self-hosted Windows runner, install Claude Code yourself and point `.prflow/config.json` at it:
 
 ```json
 {
@@ -44,12 +78,21 @@ The action's bundled Claude Code installer is Unix-only. Preinstall Claude Code 
 }
 ```
 
-An absent or empty value uses automatic installation. A rejected value warns and falls back to automatic installation. This trigger-time setting takes effect after its configuration change merges.
+Use a single-line path, with the backslashes escaped as shown. An absent or empty value uses automatic installation. A value PRFlow rejects produces a warning in the run log and falls back to automatic installation.
 
-## Avoid Runner Selection Traps
+<Note>
+  This is a trigger-time setting. It takes effect only after the configuration change is merged into your default branch, not while it sits in a pull request.
+</Note>
 
-A self-hosted label array must match a registered runner's labels. GitHub leaves an unmatched job queued rather than failing it.
+## Avoid Two Configuration Traps
 
-Leave `setup.git_dir_pin` and `setup.git_work_tree_pin` at `false` unless you have validated their documented constraints. `git_dir_pin` is not honored by implementation and can misdirect repository-root config reads. `git_work_tree_pin` breaks remote marketplace cloning and is appropriate only for a local-only marketplace list.
+Leave `setup.git_dir_pin` and `setup.git_work_tree_pin` at `false` unless you have validated their constraints:
 
-PRFlow can send jobs to the configured runner, but it is not certified for every non-Linux environment. Run one complete shipped workflow on the target runner before treating it as production-ready.
+- `git_dir_pin` is not honored by implementation runs and can misdirect repository-root configuration reads.
+- `git_work_tree_pin` breaks remote marketplace cloning. It suits a local-only marketplace list and nothing else.
+
+<Warning>
+  PRFlow can send jobs to any runner you configure, but it is not certified for every non-Linux environment. Run one complete workflow end to end on the target runner before you treat it as production-ready.
+</Warning>
+
+Continue with [Cloud Triggers](/docs/runs/cloud/triggers).

--- a/docs/external/docs/runs/cloud/setup.md
+++ b/docs/external/docs/runs/cloud/setup.md
@@ -3,7 +3,7 @@ title: "Cloud Setup"
 description: "Configure cloud authentication, repository settings and runtime provisioning."
 ---
 
-Complete the repository settings, secrets and permissions required for the first PRFlow cloud run.
+Complete the secrets, variables and repository settings a first PRFlow cloud run needs.
 
 ## Add Model Authentication
 
@@ -13,23 +13,25 @@ The default Anthropic route needs one repository or environment secret:
 CLAUDE_CODE_OAUTH_TOKEN
 ```
 
-Add it under **Settings → Secrets and variables → Actions → Secrets**. The built-in `GITHUB_TOKEN` handles GitHub operations and needs no setup.
+Add it under **Settings → Secrets and variables → Actions → Secrets**. GitHub's built-in `GITHUB_TOKEN` handles GitHub operations and needs no setup.
 
-A fully provider-routed installation can use `DEVFLOW_PROVIDER_API_KEY` instead of the OAuth token. Route every active section before removing `CLAUDE_CODE_OAUTH_TOKEN`. A partially routed installation may need both secrets because each section chooses its route independently. See [Providers](/docs/configuration/providers).
+<Note>
+  A fully provider-routed installation can use `DEVFLOW_PROVIDER_API_KEY` instead. Route every active section before you remove `CLAUDE_CODE_OAUTH_TOKEN`. A partly routed installation may need both secrets, because each section chooses its route independently. See [Providers](/docs/configuration/providers).
+</Note>
 
 ## Review Repository Configuration
 
-The installer creates `.prflow/config.json`. Commit this file because the workflows read it from the repository.
+The installer creates `.prflow/config.json`. Commit it, because the workflows read it from the repository, not from your machine.
 
 At minimum, review:
 
 - `base_branch` and `claude_model`.
-- `prflow.allowed_users` and `prflow.allowed_bots`.
-- The `setup` block for runtimes and install commands.
-- `prflow.allowed_tools` and `prflow_implement.allowed_tools` for repository-specific commands.
+- `prflow.allowed_users` and `prflow.allowed_bots`, which decide who may start a run.
+- The `setup` block, for runtimes and install commands.
+- `prflow.allowed_tools` and `prflow_implement.allowed_tools`, for repository-specific commands.
 - `workflows.prflow`, which enables the shipped command and implementation paths.
 
-Running `/prflow:init` is recommended after installation or an upgrade. It backfills new settings without replacing existing values and detects common project tools.
+Running `/prflow:init` after an installation or an upgrade is recommended. It adds newly scaffolded settings without replacing values you already set, and it detects common project tools.
 
 ## Provision the Runtime
 
@@ -38,30 +40,62 @@ PRFlow prepares the runner in this order:
 1. Set up Python.
 2. Set up Node.js.
 3. Set up PHP.
-4. Start configured service containers with Docker.
+4. Start the service containers named in `setup.services`, using Docker.
 5. Run each `setup.install` line from the repository root.
 
-Keep Python 3.11 or newer and PyYAML available even in non-Python projects because PRFlow's cloud helpers use them. Provisioning a command does not grant the agent permission to run it. Add the command to the correct allowlist separately. See [Runtime Setup](/docs/configuration/runtime-setup) and [Tool Permissions](/docs/configuration/tool-permissions).
+Keep Python 3.11 or newer and PyYAML available even in a project that is not written in Python, because PRFlow's own cloud helpers need them.
+
+<Warning>
+  Provisioning a command does not grant the agent permission to run it. Add the command to the correct allowlist as a separate step. See [Runtime Setup](/docs/configuration/runtime-setup) and [Tool Permissions](/docs/configuration/tool-permissions).
+</Warning>
 
 ## Optional GitHub App
 
-The default path needs no GitHub App. Add one when cloud implementation must push changes under `.github/workflows/`, when you need a dedicated automation identity or when a configured stall backstop must post a workflow-triggering resume comment.
-
-Configure the App with:
+The default path needs no GitHub App. Add one when a cloud implementation run has to push changes under `.github/workflows/`, when you want a dedicated automation identity or when a configured stall backstop has to post a resume comment that starts another run.
 
 | **Kind** | **Name** |
 | --- | --- |
 | Repository or organization variable | `DEVFLOW_APP_ID` |
 | Repository or organization secret | `DEVFLOW_APP_PRIVATE_KEY` |
 
-Install the App on the repository with `Contents: write`, `Workflows: write`, `Pull requests: write`, `Issues: write` and `Actions: read`. A configured but invalid App fails at token creation. An unset App falls back to `GITHUB_TOKEN`.
+Install the App on the repository with `Contents: write`, `Workflows: write`, `Pull requests: write`, `Issues: write` and `Actions: read`.
+
+An unset App falls back to `GITHUB_TOKEN`. A configured but invalid App fails loudly at the token-creation step.
+
+## Optional Reviewer App
+
+This is a second, separate GitHub App, used only by the `/prflow:review` comment command.
+
+| **Kind** | **Name** |
+| --- | --- |
+| Repository variable | `DEVFLOW_REVIEWER_APP_ID` |
+| Repository secret | `DEVFLOW_REVIEWER_PRIVATE_KEY` |
+
+Install it on the repository with a narrower permission set than the primary App: `Contents: read`, `Issues: read`, `Pull requests: write` and `Actions: read`. It reads the repository, the issue and CI results, and it posts comments and formal reviews. It cannot push.
+
+Why a second App exists: GitHub does not let an identity approve or request changes on its own pull request. When the same identity both authors a pull request and reviews it, the formal review cannot be recorded.
+
+<Warning>
+  **If you do not configure this App, review attribution falls back to the default Actions identity, `github-actions[bot]`.** An approval from `github-actions[bot]` does not satisfy a branch-protection rule that requires approving reviews. Configure the reviewer App if you rely on that rule.
+</Warning>
+
+Two details are easy to miss:
+
+- `/prflow:review-and-fix` and `/prflow:pr-description` do not use the reviewer App. They push or author content, so they stay on the primary App token.
+- Both halves of the pair matter, and they fail differently. If the **variable** is missing or misspelled, the reviewer step is skipped silently, exactly as if you had chosen not to configure it. If the variable resolves but the **secret** is wrong, the step fails loudly.
 
 ## Run a Smoke Test
 
-Open a throwaway pull request and add this standalone conversation comment:
+Open a throwaway pull request and add this as a comment of its own on the **Conversation** tab:
 
 ```text
 /prflow:review
 ```
 
-Confirm that the workflow starts, provisions the environment and posts a result. For implementation, use a low-risk issue and follow [Cloud Triggers](/docs/runs/cloud/triggers).
+You should see three things: a 🚀 reaction added to your own comment as an acknowledgement, a new workflow run under the **Actions** tab and a progress comment on the pull request that PRFlow rewrites as it works. The progress comment ends with the full report and an APPROVE or REJECT verdict.
+
+The reaction is best effort. Its absence is a weak signal on its own, so check the **Actions** tab before you conclude that nothing started.
+
+If nothing happens at all, the most common causes are an unauthorized commenter and a comment that is not on a line of its own. See [Cloud Triggers](/docs/runs/cloud/triggers) and [Cloud-Run Problems](/docs/troubleshooting/cloud-runs).
+
+For implementation, use a low-risk issue and follow [Cloud Triggers](/docs/runs/cloud/triggers).

--- a/docs/external/docs/runs/cloud/triggers.md
+++ b/docs/external/docs/runs/cloud/triggers.md
@@ -1,55 +1,109 @@
 ---
 title: "Cloud Triggers"
-description: "Use authorized standalone GitHub comments to start supported PRFlow workflows."
+description: "Start a PRFlow cloud workflow with an authorized standalone GitHub comment."
 ---
 
-Start an installed PRFlow cloud workflow from GitHub with an authorized comment or supported event.
+Start an installed PRFlow cloud workflow by posting the right comment, in the right place, as an authorized person.
 
-## Implement an Issue
+## The Four Comment Commands
 
-Add a comment to a regular issue:
+A fresh installation answers four commands. Each one works on one surface only.
+
+| **Command** | **Post It On** | **Who May Fire It** | **What It Does** |
+| --- | --- | --- | --- |
+| `/prflow:implement 123` | A comment on the issue itself. | An authorized collaborator or an allowed bot. | Creates a branch and opens a pull request for that issue. |
+| `/prflow:review` | A comment on the pull request's **Conversation** tab. | An authorized collaborator or an allowed bot. | Reviews the pull request and reports a verdict. It changes no code. |
+| `/prflow:review-and-fix` | A comment on the pull request's **Conversation** tab. | An authorized collaborator or an allowed bot. | Reviews the pull request, applies fixes and pushes them to its branch. |
+| `/prflow:pr-description` | A comment on the pull request's **Conversation** tab. | An authorized collaborator or an allowed bot. | Writes or updates the pull-request description. |
+
+### Implement an Issue
+
+Add this as a comment on a regular issue:
 
 ```text
 /prflow:implement 123
 ```
 
-The number is optional when the command is posted on the issue it targets. The implementation workflow does not run from a pull-request comment, issue title, issue description, label or `@claude` mention.
+The number is optional when you post the command on the issue it targets. The workflow starts, acknowledges your comment with a 🚀 reaction, creates a workpad comment on the issue and keeps it updated as it works.
 
-## Review a Pull Request
+<Warning>
+  `/prflow:implement` runs from an issue comment only. It does not run from a pull-request comment, an issue title, an issue description, a label or an `@claude` mention.
+</Warning>
 
-Add a comment on the pull request's **Conversation** tab:
+### Review, Fix or Describe a Pull Request
+
+Add one of these as a comment on the pull request's **Conversation** tab:
 
 ```text
 /prflow:review
 ```
 
-The shipped workflow listens to issue comments. Text entered in the review-submission box or an inline review comment does not trigger it. A repository collaborator must request review for an outside contributor's pull request.
+```text
+/prflow:review-and-fix
+```
 
-Fresh installs do not automatically review every pull request. The automatic review workflow is withdrawn from this release.
+```text
+/prflow:pr-description
+```
 
-## Format Commands Correctly
+`/prflow:review` and `/prflow:review-and-fix` post a single progress comment that PRFlow rewrites as it works, ending with the full report and an APPROVE or REJECT verdict. `/prflow:review-and-fix` also pushes its fixes to the pull-request branch. `/prflow:pr-description` updates the description in place and keeps content a person added.
 
-A command must be the only content on its line. Up to three leading spaces and an optional `#` before the number are accepted. Commands in prose, blockquotes, indented code or fenced code blocks are ignored.
+<Warning>
+  The shipped workflows listen to issue comments only. Text typed into GitHub's review-submission box, or into an inline comment on a diff, does not start a run. Post on the **Conversation** tab.
+</Warning>
 
-If one comment contains several standalone commands, the first recognized command wins. At most one cloud path dispatches from that comment.
+<Note>
+  These three commands always act on the thread they were posted on. A trailing number is ignored, and a warning names both numbers in the run log. A repository collaborator must post the comment for an outside contributor's pull request.
+</Note>
 
-Use the `/prflow:` spelling in new comments. The transitional `/devflow:` spelling is still accepted and normalized, but it should not be used in new documentation or automation.
+## Format the Comment Correctly
+
+<Steps>
+  <Step title="Put the Command on a Line of Its Own">
+    Nothing else may share the line, apart from an optional issue or pull-request number.
+  </Step>
+  <Step title="Keep the Indentation Small">
+    Up to three leading spaces are accepted. A tab, or four or more spaces, makes the line an indented code block and it is ignored.
+  </Step>
+  <Step title="Do Not Wrap It in Code or a Quote">
+    A command inside a fenced code block, a blockquote or ordinary prose is ignored on purpose. That is what lets you write about a command without starting one.
+  </Step>
+</Steps>
+
+An optional `#` before the number is accepted. If one comment contains several standalone commands, the first recognized command wins, and at most one cloud path starts from that comment.
+
+Use the `/prflow:` spelling in new comments. The older `/devflow:` spelling is still accepted and normalized to the current form, but do not use it in new documentation or automation.
 
 ## Understand Authorization
 
-Human requesters must satisfy both checks:
+A human requester must satisfy both checks:
 
 - Their login matches `prflow.allowed_users`, which defaults to `*`.
 - They have write, maintain or admin access to the repository.
 
-Bots do not use the collaborator check. Their login must appear in the comma-separated `prflow.allowed_bots` setting. Authorization fails closed when identity or permission cannot be established.
+A bot skips the collaborator check, but its login must appear in the comma-separated `prflow.allowed_bots` setting. The shipped default is `claude,dependabot`.
 
-An authorized command receives a best-effort 🚀 reaction as early acknowledgement. Unauthorized or unrecognized commands receive no reaction.
+Authorization fails closed. If identity or permission cannot be established, no run starts.
 
-## Understand Reuse and Dedupe
+An authorized command receives a best-effort 🚀 reaction. An unauthorized or unrecognized comment receives no reaction at all, so silence is the normal signal for both.
 
-Implementation uses one dedicated workpad comment per issue. A later run reuses that comment and records whether it resumed unfinished work or started from a terminal state. PRFlow's own workpad and review-progress comments carry hidden identifiers that prevent them from triggering new runs.
+## Understand Reuse and Deduplication
 
-Overlapping implementation requests on the same thread are deduplicated. The oldest visible active run proceeds. The duplicate posts a notice and does not start another agent job. The check fails open on a query error, so a rare duplicate is possible.
+<AccordionGroup>
+  <Accordion title="Implementation Reuses One Workpad per Issue">
+    Each issue has one dedicated workpad comment. A later run reuses that comment and records whether it resumed unfinished work or started from a terminal state. PRFlow's own workpad and progress comments carry hidden identifiers, so they can never start a new run themselves.
+  </Accordion>
+  <Accordion title="Overlapping Implementation Requests Are Deduplicated">
+    The oldest visible active run proceeds. The duplicate posts a notice and starts no second agent job. The check fails open on a query error, so a rare duplicate is still possible.
+  </Accordion>
+  <Accordion title="Overlapping Review Requests Are Deduplicated per Commit">
+    A second `/prflow:review` for the same pull-request head is suppressed while a fresh progress comment shows a review in flight. A request after the head changes proceeds for the new commit. That progress comment is the only in-flight signal, and it does not appear until the agent job begins, so a request in that short window is not deduplicated and a rare duplicate review is possible.
+  </Accordion>
+  <Accordion title="The Other Two Commands Are Not Deduplicated">
+    Only `/prflow:review` is deduplicated. `/prflow:review-and-fix` and `/prflow:pr-description` are not, so overlapping requests each start a run. Wait for one to finish before you post another.
+  </Accordion>
+</AccordionGroup>
 
-Overlapping `/prflow:review` requests for the same pull-request commit are also deduplicated while a fresh live progress comment shows a review in flight. A new request after the pull-request head changes proceeds for the new commit. That progress comment is the only in-flight signal, and an in-flight review does not publish it until its agent job begins, so a request arriving in the short window before it appears is not deduplicated and a rare duplicate review is possible.
+## What Is Not Included
+
+Fresh installations do not review every pull request automatically. That workflow is withdrawn from this release. To get a review without anyone typing a comment, add the workflow on [Request a Review Automatically on Green CI](/docs/runs/cloud/auto-review).

--- a/docs/external/docs/runs/cloud/updates.md
+++ b/docs/external/docs/runs/cloud/updates.md
@@ -1,51 +1,96 @@
 ---
 title: "Cloud Updates"
-description: "Preview, apply and review PRFlow cloud-tier updates with a review-first process."
+description: "Preview, apply and review a PRFlow cloud-tier update without losing your configuration."
 ---
 
-Move an existing cloud installation to a newer PRFlow release without losing repository-specific configuration.
+Move an existing cloud installation to a newer PRFlow release, and keep the settings you changed.
 
-## Preview an Update
+The installer is review-first on an update: it previews by default, and it never silently overwrites a file you edited.
 
-Download the newer installer and use the same new release tag for its payload:
+## Update in Three Steps
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/The01Geek/prflow/v2.34.50/install.sh -o devflow-install.sh
-# review devflow-install.sh, then:
-DEVFLOW_REF=v2.34.50 bash devflow-install.sh
-```
+<Note>
+  The examples below pin `v2.34.50`. Replace it with the tag you are moving to, from the [releases page](https://github.com/The01Geek/prflow/releases).
+</Note>
 
-An existing installation runs in dry-run mode by default. The installer does not intentionally change the target repository in this mode. It can create temporary files, and it still executes the downloaded installer. Inspect and verify the file before running it.
+<Steps>
+  <Step title="Preview the Update">
+    Download the newer installer and pass the same new tag as the payload.
 
-## Apply the Update
+    ```bash
+    curl -fsSL https://raw.githubusercontent.com/The01Geek/prflow/v2.34.50/install.sh -o devflow-install.sh
+    # read devflow-install.sh, then:
+    DEVFLOW_REF=v2.34.50 bash devflow-install.sh
+    ```
 
-After reviewing the preview, apply the same payload:
+    On an existing installation this runs in dry-run mode. It does not intentionally change your repository, though it can create temporary files, and it does execute the script you downloaded. Read that file before you run it.
+  </Step>
+  <Step title="Apply It">
+    ```bash
+    DEVFLOW_REF=v2.34.50 bash devflow-install.sh --apply
+    ```
 
-```bash
-DEVFLOW_REF=v2.34.50 bash devflow-install.sh --apply
-```
+    This refreshes the managed workflows, the composite actions and the configuration schema. It backfills newly added configuration keys and preserves the values and arrays you already set.
+  </Step>
+  <Step title="Review Before Committing">
+    ```bash
+    git status
+    git diff
+    ```
 
-Review `git status` and `git diff` before committing. Re-running the installer refreshes managed workflows, actions and the schema. It backfills newly scaffolded config keys while preserving existing values and arrays.
+    Look for two things: changes under `.github/` that you accept, and any file ending in `.prflow-new`. The next section explains those.
+  </Step>
+</Steps>
 
 ## Resolve Preserved Files
 
-The installer records managed-artifact digests in `.prflow/install-manifest.json`. On an update:
+The installer records a digest for each file it manages, in `.prflow/install-manifest.json`. On an update it decides file by file:
 
-- An unchanged managed file can be replaced with the new version.
-- A locally modified file is preserved.
-- A file with no verifiable recorded digest is preserved.
-- The proposed replacement is written beside a preserved file as `<path>.prflow-new`.
+| **State of the File** | **What the Installer Does** |
+| --- | --- |
+| Unchanged since it was installed | Replaces it with the new version. |
+| Modified locally | Preserves your version. |
+| No verifiable recorded digest | Preserves your version. |
 
-Compare each sidecar with the file you maintain. Merge the needed changes by hand, then remove the sidecar. Sidecars are ignored so a broad `git add -A` does not commit them accidentally.
+Whenever it preserves your version, it writes the proposed replacement beside it as `<path>.prflow-new`.
 
-If Python cannot run, the installer cannot compare managed files or write the provenance manifest. It preserves existing artifacts and writes sidecars rather than risk overwriting local work. Fix Python, then run the same update again.
+<Steps>
+  <Step title="Compare Each Sidecar">
+    ```bash
+    git status --porcelain --ignored | grep '.prflow-new'
+    diff .prflow/config.schema.json .prflow/config.schema.json.prflow-new
+    ```
 
-## Keep Runtime and Workflow Pins Together
+    An empty list from the first command means nothing was preserved and there is nothing to merge.
+  </Step>
+  <Step title="Merge What You Need by Hand">
+    Copy the changes you want into the file you maintain.
+  </Step>
+  <Step title="Delete the Sidecar">
+    Remove each `.prflow-new` file once you have merged it. Sidecars are ignored by Git, so a broad `git add -A` will not commit them by accident.
+  </Step>
+</Steps>
 
-In thin mode, `prflow_version` controls the plugin fetched by the installed workflows. The installer re-stamps an empty or SHA-shaped value to the commit it installed. It preserves a hand-set non-SHA value such as a tag or branch.
+<Warning>
+  If Python cannot run, the installer cannot compare managed files or write the provenance manifest. It preserves every existing artifact and writes sidecars instead of risking your work. That is safe but it means nothing was updated in place. Fix Python, then run the same update again.
+</Warning>
 
-Updating only the workflows or only `prflow_version` can leave two halves of a feature out of sync. Prefer running the installer with the new tag and reviewing the resulting pin in the same change.
+## Keep the Workflow and the Version Pin Together
 
-Prompt-extension delivery is a current example. The skills that consume `.prflow/prompt-extensions/` ship in the plugin, while the permission entries their delivery mechanisms need ship in the workflow files. Bumping only `prflow_version` leaves a mechanism unpermitted, and a refused delivery is not reported as a failure.
+In a thin install, `prflow_version` in `.prflow/config.json` decides which plugin the installed workflows fetch at run time. The installer re-stamps an empty or SHA-shaped value to the commit it installed, and preserves a value you set by hand, such as a tag or a branch name.
 
-In vendored mode, `prflow_version` is ignored because the committed `.prflow/vendor/prflow/` tree supplies the runtime.
+<Warning>
+  Updating only the workflow files, or only `prflow_version`, can leave two halves of one feature out of sync. Run the installer with the new tag and review the resulting pin in the same change.
+</Warning>
+
+A current example makes the risk concrete. The skills that read `.prflow/prompt-extensions/` ship inside the plugin, while the permission entries their delivery needs ship in the workflow files. Raising only `prflow_version` leaves that delivery unpermitted, and a refused delivery is not reported as a failure. The run looks normal and quietly applies less of your configuration.
+
+<Note>
+  In a vendored install, `prflow_version` is ignored. The committed `.prflow/vendor/prflow/` tree supplies the runtime, so update that tree instead.
+</Note>
+
+## After the Update
+
+Run `/prflow:init` locally in the repository. It backfills newly added settings into `.prflow/config.json` without replacing the values you set. Then try one low-stakes command, such as `/prflow:review` on a throwaway pull request, before you rely on the automation again.
+
+If something stops working after an update, see [Cloud-Run Problems](/docs/troubleshooting/cloud-runs) and [Cloud Recovery](/docs/runs/cloud/recovery).

--- a/docs/external/docs/runs/index.md
+++ b/docs/external/docs/runs/index.md
@@ -1,9 +1,11 @@
 ---
 title: "Runs"
-description: "Choose local interactive execution or optional GitHub Actions automation."
+description: "Choose between an interactive local run and an optional GitHub Actions cloud run."
 ---
 
-Choose local or cloud execution based on where your team wants PRFlow to run. Both modes follow a similar lifecycle, but their credentials, permission boundaries and interaction models differ.
+Decide where PRFlow does the work: inside your own Claude Code session, or inside GitHub Actions after an authorized comment.
+
+Both modes run the same workflows. They differ in who starts a run, which credentials it uses and how you approve what it does.
 
 ```mermaid
 flowchart TD
@@ -19,19 +21,55 @@ flowchart TD
     prepare --> cloud
 ```
 
-| **Run Type** | **Execution Environment** | **Best For** |
-| --- | --- | --- |
-| [Local runs](/docs/runs/local/index) | Your Claude Code, GitHub Copilot CLI or Codex CLI session. | First use, interactive decisions and access to an existing development environment. |
-| [Cloud runs](/docs/runs/cloud/index) | GitHub Actions after an authorized comment. | Headless, comment-driven implementation and review with repository-managed credentials. |
+## Compare the Two Modes
 
-Local runs inherit tools, authentication and permission prompts from your client session. They need no GitHub Actions workflows or cloud secret.
+| **Run Type** | **Where It Runs** | **How It Starts** | **Best For** |
+| --- | --- | --- | --- |
+| [Local runs](/docs/runs/local/index) | Your Claude Code session on your own machine. | You type a `/prflow:` command. | First use, interactive decisions and access to a development environment you already trust. |
+| [Cloud runs](/docs/runs/cloud/index) | GitHub Actions, using repository secrets and variables. | An authorized person comments on an issue or a pull request. | Hands-off work started from GitHub, with credentials the repository owns. |
 
-Cloud runs use committed workflows, explicit GitHub permissions, repository secrets and a declared setup process. Fresh cloud installations support issue-driven implementation and collaborator-triggered review. They require more maintenance than the local path.
+Local runs inherit tools, authentication and permission prompts from your Claude Code session. They need no GitHub Actions workflow and no repository secret.
 
-Begin locally. Add cloud automation after the workflow, verification commands and permission scopes are understood.
+Cloud runs use committed workflow files, explicit GitHub permissions, repository secrets and a declared setup process. They need more maintenance than the local path.
 
-## Related Documentation
+<Note>
+  PRFlow's documented command syntax describes Claude Code. The plugin has also been verified to work in GitHub Copilot CLI, Codex CLI, Codex Desktop and VS Code agent modes, but each of those clients names and invokes plugin commands its own way. Follow that client's own documentation for the exact prefix.
+</Note>
 
-- [Client Command Syntax](/docs/runs/local/client-commands)
-- [Local Permissions](/docs/runs/local/permissions)
-- [Cloud Setup](/docs/runs/cloud/setup)
+## What Each Mode Supports
+
+A local install exposes every public PRFlow workflow, including the ones that never run in the cloud: issue authoring, repository initialization, the documentation family and the weekly retrospective.
+
+A fresh cloud install ships two workflow files and answers four comment commands:
+
+| **Comment Command** | **Where You Post It** |
+| --- | --- |
+| `/prflow:implement 123` | A comment on the issue itself. |
+| `/prflow:review` | A comment on a pull request's **Conversation** tab. |
+| `/prflow:review-and-fix` | A comment on a pull request's **Conversation** tab. |
+| `/prflow:pr-description` | A comment on a pull request's **Conversation** tab. |
+
+Automatic pull-request-triggered review is not part of a fresh install. If you want a review requested without anyone typing a comment, see [Request a Review Automatically on Green CI](/docs/runs/cloud/auto-review).
+
+<Warning>
+  No PRFlow run merges a pull request. Every mode ends with a branch, a pull request, a workpad or a review for a person to read and act on.
+</Warning>
+
+## Start Here
+
+<CardGroup cols={2}>
+  <Card title="Local Runs" icon="terminal" href="/docs/runs/local/index">
+    Run PRFlow from a Claude Code session in your own checkout.
+  </Card>
+  <Card title="Cloud Runs" icon="cloud" href="/docs/runs/cloud/index">
+    Let authorized collaborators start PRFlow from a GitHub comment.
+  </Card>
+  <Card title="Commands and Arguments" icon="keyboard" href="/docs/runs/local/client-commands">
+    The command syntax, the arguments each workflow accepts and which ones are local-only.
+  </Card>
+  <Card title="Cloud Triggers" icon="comment" href="/docs/runs/cloud/triggers">
+    The exact comment format, the surface each command works on and who may fire it.
+  </Card>
+</CardGroup>
+
+Begin locally. Add cloud automation once you understand the workflows, the verification commands and the permission scopes they need.

--- a/docs/external/docs/runs/local/client-commands.md
+++ b/docs/external/docs/runs/local/client-commands.md
@@ -1,47 +1,80 @@
 ---
-title: "Client Command Syntax"
-description: "Use the correct PRFlow command syntax in Claude Code, GitHub Copilot CLI and Codex CLI."
+title: "Running PRFlow Locally: Commands and Arguments"
+description: "Learn the PRFlow command syntax, the arguments each workflow accepts and which workflows only run locally."
 ---
 
-Run the same PRFlow workflows from Claude Code, GitHub Copilot CLI or Codex CLI by using each client's namespace syntax.
+Use the right command syntax and the right arguments when you run PRFlow from Claude Code.
 
-## Syntax Table
+## One Syntax
 
-| **Client** | **Pattern** | **Implementation Example** |
+Every PRFlow command has the same shape:
+
+```text
+/prflow:<skill> [arguments]
+```
+
+Replace `<skill>` with a workflow name such as `implement`, `review` or `init`. A worked example:
+
+```text
+/prflow:implement 123
+```
+
+Claude Code shows the matching skill as you type `/prflow:`. If nothing appears, the session was started before the plugin finished installing. Start a new session and try again. See [Installation](/docs/getting-started/installation).
+
+<Warning>
+  Always include the `prflow` namespace. Names such as `review` and `init` can collide with commands built into a coding client, and a bare name can start a different tool with different behavior.
+</Warning>
+
+<Note>
+  PRFlow's documented syntax describes Claude Code. The plugin has also been verified to work in GitHub Copilot CLI, Codex CLI, Codex Desktop and VS Code agent modes. Those clients name and invoke plugin commands their own way, so follow each client's own documentation for its prefix.
+</Note>
+
+## Commands and Their Arguments
+
+Arguments follow the skill name, separated by spaces. Square brackets below mean the argument is optional.
+
+| **Command** | **Arguments** | **What It Does** |
 | --- | --- | --- |
-| Claude Code | `/prflow:<skill>` | `/prflow:implement 123` |
-| GitHub Copilot CLI | `/prflow/<skill>` | `/prflow/implement 123` |
-| Codex CLI | `$prflow:<skill>` | `$prflow:implement 123` |
+| `/prflow:create-issue` | `<user story>` | Turns a rough description into a written GitHub issue. |
+| `/prflow:implement` | `<issue-number>` | Turns an existing issue into a branch and a pull request. |
+| `/prflow:review` | `[pr-number] [--issue N]` | Reviews a pull request or the current branch and reports a verdict. |
+| `/prflow:review-and-fix` | `[pr-number] [--push-each-iteration] [--issue N]` | Reviews, applies fixes and repeats until the verdict is clean. |
+| `/prflow:pr-description` | `[issue-number]` | Writes or updates the pull-request description for the current branch. |
+| `/prflow:docs` | none | Updates internal docs, external docs and release notes together. |
+| `/prflow:docs-verify` | `<topic>` | Checks whether the documentation for one named topic is accurate. |
+| `/prflow:retrospective-weekly` | none | Runs the weekly self-improvement loop over recently merged pull requests. |
+| `/prflow:init` | none | Scaffolds or refreshes this repository's `.prflow/` configuration. |
 
-Replace `<skill>` with names such as `create-issue`, `implement`, `review`, `review-and-fix`, `docs` or `init`.
+The narrower documentation commands `docs-sync-internal`, `docs-sync-external`, `docs-bootstrap-internal`, `docs-bootstrap-external` and `docs-release-notes` take no arguments either. See [Workflow Guides](/docs/workflows/index) for what each one produces.
 
-## Always Use the Namespace
+<Accordion title="Argument Conventions in Detail">
+  - **A bare number is a pull-request or issue number.** In `/prflow:review` and `/prflow:review-and-fix`, only a bare number binds the pull-request number. A number that follows `--issue` is never read as the pull-request number.
+  - **Omit the number to work on the current branch.** `/prflow:review`, `/prflow:review-and-fix` and `/prflow:pr-description` fall back to the branch you have checked out, compared against the configured base branch.
+  - **`--issue N` names the issue whose acceptance criteria the review reads.** Use it when the pull request does not already point at the right issue.
+  - **`--push-each-iteration` pushes each completed fix cycle, and the final loop state, to the feature branch.** Without it a local fix run commits but never pushes, so the fixes stay on your machine.
+  - **`/prflow:implement` needs an issue number.** It reads that issue's body as the specification.
+</Accordion>
 
-Command names such as `review` and `init` can collide with commands built into a coding client. Always include the `prflow` namespace. A bare client command can invoke a different tool with different behavior.
+## Which Commands Run Only Locally
 
-Local commands use only the current `prflow` namespace. The former `/devflow:*` namespace survives only as a compatibility alias for supported GitHub cloud comment triggers. Do not use it for local commands.
+A fresh cloud installation answers four comment commands. Everything else in the table above is local-only.
 
-## Commands Available Locally
+<CardGroup cols={2}>
+  <Card title="Available Locally and in the Cloud" icon="cloud">
+    `implement`, `review`, `review-and-fix` and `pr-description`.
+  </Card>
+  <Card title="Local Only" icon="terminal">
+    `create-issue`, `init`, the whole `docs` family and `retrospective-weekly`.
+  </Card>
+</CardGroup>
 
-The installed plugin exposes its public workflows locally, including:
+Two differences matter when you move between the two:
 
-- `create-issue` and `implement` for issue-driven delivery.
-- `review` and `review-and-fix` for assessment and correction.
-- `pr-description` for pull-request descriptions.
-- `docs` and the focused documentation commands.
-- `retrospective-weekly` for the self-improvement loop.
-- `init` for repository setup and refresh.
+- **A cloud comment command ignores a trailing number.** `/prflow:review`, `/prflow:review-and-fix` and `/prflow:pr-description` always act on the thread they were posted on. Locally, a bare number selects a different pull request.
+- **`/prflow:implement` in the cloud runs only from a comment on an issue.** A comment on a pull request never starts one.
 
-The public cloud path is narrower. Fresh cloud installations support comment-driven `implement` and authorized `review`. Run configuration, issue authoring, direct `review-and-fix`, pull-request description, documentation and retrospective workflows locally.
+See [Cloud Triggers](/docs/runs/cloud/triggers) for the full comment rules.
 
-## Arguments Follow the Skill Name
+## Use the Current Namespace
 
-Arguments keep the same meaning across clients. Only the prefix and separator change:
-
-| **Action** | **Claude Code** | **GitHub Copilot CLI** | **Codex CLI** |
-| --- | --- | --- | --- |
-| Implement issue 123 | `/prflow:implement 123` | `/prflow/implement 123` | `$prflow:implement 123` |
-| Review pull request 456 | `/prflow:review 456` | `/prflow/review 456` | `$prflow:review 456` |
-| Initialize the repository | `/prflow:init` | `/prflow/init` | `$prflow:init` |
-
-See the [Workflow Guides](/docs/workflows/index) for each command's inputs and outcomes.
+Write new commands with the `/prflow:` spelling. The older `/devflow:` spelling is still accepted as a compatibility alias for GitHub comment triggers, where it is normalized to the current form. Do not use it in new documentation, scripts or automation.

--- a/docs/external/docs/runs/local/index.md
+++ b/docs/external/docs/runs/local/index.md
@@ -1,34 +1,75 @@
 ---
 title: "Local Runs"
-description: "Run PRFlow interactively from a supported coding client."
+description: "Run PRFlow interactively from a Claude Code session in your own checkout."
 ---
 
-Run PRFlow directly from Claude Code, GitHub Copilot CLI or Codex CLI. Local runs are the fastest way to start and require no GitHub Actions workflow or cloud secret.
+Run PRFlow directly from Claude Code. A local run is the fastest way to start, and it needs no GitHub Actions workflow and no repository secret.
 
-Open your coding client anywhere inside the target Git repository, then enter a namespaced command. For example, the implementation command is `/prflow:implement 123` in Claude Code, `/prflow/implement 123` in GitHub Copilot CLI and `$prflow:implement 123` in Codex CLI.
+## Run Your First Local Command
 
-The run uses:
+<Steps>
+  <Step title="Open Claude Code Inside the Repository">
+    Start the session from anywhere inside the target Git checkout.
+
+    ```bash
+    cd ~/code/acme-api
+    claude
+    ```
+  </Step>
+  <Step title="Enter a Namespaced Command">
+    Every PRFlow command starts with `/prflow:`.
+
+    ```text
+    /prflow:implement 123
+    ```
+  </Step>
+  <Step title="Answer the Permission Prompts">
+    Claude Code asks before it edits files, runs a command or calls `gh`. Approve only what the workflow needs. See [Local Permissions](/docs/runs/local/permissions).
+  </Step>
+  <Step title="Watch the Run Report Its Progress">
+    An implementation run leaves three things behind:
+
+    - A workpad comment on issue 123, which it keeps updated as it works.
+    - A feature branch named after the issue, such as `issue-123-add-retry-to-webhook-client`.
+    - A pull request that links back to the issue.
+
+    The workpad's `Status` line carries a glyph: 🚀 while the run is still working, then 🎉 Complete, 👎 Blocked, 💥 Failed or 🛑 Cancelled.
+  </Step>
+</Steps>
+
+<Warning>
+  🎉 Complete means PRFlow finished its own lifecycle. It does not mean the pull request was merged, and it is not a guarantee that the change is correct. Read the review and the diff before you merge.
+</Warning>
+
+## What a Local Run Uses
 
 - The repository and Git root discovered from the current directory.
 - Your authenticated GitHub CLI identity.
-- The tests, linters and development tools available on the machine.
-- The coding client's permission system and current interaction.
-- Built-in configuration defaults, with `.prflow/config.json` overrides when present.
+- The tests, linters and development tools already installed on the machine.
+- Claude Code's permission system and your answers to it.
+- Built-in configuration defaults, plus `.prflow/config.json` overrides when the file is present.
 
-Repository initialization is recommended for customization, but it is not required.
+Repository initialization with `/prflow:init` is recommended so you can customize behavior, but a local run works without it.
 
 ## When to Run Locally
 
-Use a local run when you want to:
-
-- Answer clarification questions while work proceeds.
-- Review tool requests before granting them.
-- Use services or development tools already configured on the workstation.
-- Create issues, configure PRFlow, update documentation or run retrospectives.
-- Inspect a run closely before enabling cloud automation.
+<CardGroup cols={2}>
+  <Card title="Interactive Decisions" icon="comments">
+    Answer clarification questions while the work is still in progress.
+  </Card>
+  <Card title="Tight Permission Control" icon="shield-check">
+    Approve each tool request as it happens instead of granting a standing allowlist.
+  </Card>
+  <Card title="Local-Only Workflows" icon="wrench">
+    Create issues, initialize configuration, update documentation and run the weekly retrospective. None of these has a cloud trigger.
+  </Card>
+  <Card title="A Trusted Environment" icon="laptop">
+    Use services, credentials and development tools that are already set up on your workstation.
+  </Card>
+</CardGroup>
 
 ## Next Steps
 
-- Check the complete [client syntax and local-only command guidance](/docs/runs/local/client-commands).
-- Review [local permission boundaries](/docs/runs/local/permissions).
-- Understand [working-directory and Git-root behavior](/docs/runs/local/working-directory).
+- Read the [commands and arguments](/docs/runs/local/client-commands) each workflow accepts.
+- Review the [local permission boundaries](/docs/runs/local/permissions).
+- Understand [working-directory and Git-root behavior](/docs/runs/local/working-directory) before you run from a subdirectory or a monorepo.

--- a/docs/external/docs/runs/local/permissions.md
+++ b/docs/external/docs/runs/local/permissions.md
@@ -1,41 +1,67 @@
 ---
 title: "Local Permissions"
-description: "Grant only the repository, Git and GitHub access a local PRFlow run needs."
+description: "Grant a local PRFlow run only the repository, Git and GitHub access it needs."
 ---
 
-Review and approve the tool access a local PRFlow run needs. The exact prompt and persistence options come from your coding client.
+Approve the tool access a local PRFlow run asks for, and keep each grant as narrow as the workflow allows.
 
-## Match Permission to the Workflow
+A local run has no allowlist of its own. It uses whatever Claude Code lets it use, so your answers to the permission prompts are the boundary. The exact prompt wording and the options for remembering an answer come from Claude Code, not from PRFlow.
 
-A read-only review usually needs repository reads, Git history, pull-request data and verification commands. An implementation or review-and-fix run also needs repository writes, Git commits and GitHub pull-request updates.
+## Match the Grant to the Workflow
 
-Typical permissions include:
+<Tabs>
+  <Tab title="Read-Only Review">
+    `/prflow:review` inspects but does not change your code. It normally needs:
 
-- Read files inside the target repository.
-- Edit files for workflows that are expected to change code or documentation.
-- Inspect Git status, history and diffs.
-- Create and push a scoped feature branch.
-- Run the repository's specific tests, linters and build commands.
-- Use authenticated `gh` commands for the relevant issue or pull request.
+    - Read access to files inside the target repository.
+    - Git history, status and diffs.
+    - Pull-request data through the GitHub CLI.
+    - The repository's own verification commands, such as its test and lint commands.
+
+    It does not need write access to your files.
+  </Tab>
+  <Tab title="Implementation and Fixing">
+    `/prflow:implement` and `/prflow:review-and-fix` change code. On top of the read-only set they need:
+
+    - Write access to files inside the target repository.
+    - Permission to create a branch, commit and push.
+    - Authenticated `gh` commands for the issue or pull request being worked on.
+  </Tab>
+</Tabs>
 
 ## Keep Grants Narrow
 
 - Prefer a specific command such as `make test`, `npm test` or `cargo test` over unrestricted shell access.
-- Limit filesystem access to the target repository unless a known dependency lives elsewhere.
-- Grant GitHub operations needed for the current issue or pull request instead of broad administrative access.
-- Treat `sudo`, raw shell evaluation and user-global file writes as separate, high-risk decisions.
-- Review persistent or project-wide grants more carefully than a one-time approval.
+- Limit filesystem access to the target repository unless a known dependency lives somewhere else.
+- Grant GitHub operations for the current issue or pull request rather than broad administrative access.
+- Treat `sudo`, raw shell evaluation and writes outside the repository as separate, high-risk decisions.
+- Review a persistent or project-wide grant more carefully than a one-time approval.
 
-Declining a required tool can leave verification incomplete or stop the lifecycle with a recorded blocker. That is safer than reporting unobserved work as validated.
+<Note>
+  Declining a tool the run needs is a safe outcome. The run reports the missing verification or stops with a recorded blocker instead of reporting unobserved work as validated.
+</Note>
 
-## Repository Configuration Is a Separate Boundary
+## Cloud Allowlists Are a Different Boundary
 
-Cloud tool profiles use `.prflow/config.json`. The `prflow.allowed_tools` and `prflow_implement.allowed_tools` lists are independent; one does not inherit the other.
+Cloud runs cannot ask a person anything, so they read their tool allowlist from `.prflow/config.json`:
 
-Those lists do not replace your local client's permission prompts. Review both boundaries when a repository supports local and cloud runs.
+```json
+{
+  "prflow": {
+    "allowed_tools": []
+  },
+  "prflow_implement": {
+    "allowed_tools": []
+  }
+}
+```
 
-## Inspect the Result
+`prflow.allowed_tools` applies to the comment commands, and `prflow_implement.allowed_tools` applies to issue implementation. The two lists are independent. Adding an entry to one does not add it to the other.
 
-Before merging, check that the workpad and pull request identify any command that was denied, skipped or unavailable. A review verdict narrows risk only when its stated evidence was actually observed.
+These lists never replace Claude Code's own prompts. A local run still asks you, whatever `.prflow/config.json` contains. Review both boundaries in a repository that supports local and cloud runs. See [Tool Permissions](/docs/configuration/tool-permissions).
 
-See [Human Control](/docs/concepts/human-control) for the wider approval and merge boundaries.
+## Check What Actually Ran
+
+Before you merge, read the workpad and the pull request for any command that was denied, skipped or unavailable. A review verdict narrows risk only to the extent that the evidence behind it was actually observed.
+
+See [Verification](/docs/concepts/verification) for how a run records its evidence, and [Human Control](/docs/concepts/human-control) for the wider approval and merge boundaries.

--- a/docs/external/docs/runs/local/working-directory.md
+++ b/docs/external/docs/runs/local/working-directory.md
@@ -1,38 +1,52 @@
 ---
 title: "Working Directory"
-description: "Understand how local PRFlow runs resolve the repository root and nested repositories."
+description: "Understand how a local PRFlow run resolves the repository root, and what changes in a monorepo or a nested checkout."
 ---
 
-Launch PRFlow safely from a repository subdirectory, monorepo package or nested Git checkout by confirming which repository and branch the run will use.
+Confirm which repository a local run will use before you start it, especially in a monorepo or a nested Git checkout.
 
-## Run From Any Repository Subdirectory
+## Check the Root First
 
-Local PRFlow skills can start from the Git repository root or a subdirectory. Core configuration and prompt-extension readers call `git rev-parse --show-toplevel` and anchor the default `.prflow/` path to that root.
+PRFlow anchors its configuration to the Git root, not to the directory you are standing in. Run this before you start a command:
 
-Shell helpers that need bundled sibling files resolve from their own script location. They do not depend on the current directory for those files.
+```bash
+git rev-parse --show-toplevel
+```
 
-As a result, a command run from `packages/web/` normally reads the same root `.prflow/config.json` and `.prflow/prompt-extensions/` files as a command run from the repository root.
+It prints one absolute path, such as `/Users/you/code/acme-api`. That path is the repository PRFlow will act on, and `.prflow/config.json` is read from it. If the printed path is not the repository you meant, move to the right directory before you start the command.
+
+## Run From Any Subdirectory
+
+PRFlow's configuration and prompt-extension readers resolve their default path from the Git root, so a command entered in `packages/web/` reads the same root `.prflow/config.json` and the same `.prflow/prompt-extensions/` files as a command entered at the top of the repository.
+
+Bundled helper files are found relative to the helper itself, not relative to your current directory, so they resolve the same way from anywhere in the tree.
 
 ## The Nearest Git Root Wins
 
-`git rev-parse --show-toplevel` returns the nearest containing Git root. This matters when:
+`git rev-parse --show-toplevel` returns the nearest enclosing Git root, which is not always the one you want. Watch for it in three layouts:
 
-- A monorepo contains a nested Git repository.
-- The current directory is inside a Git submodule.
-- A team deliberately stores `.prflow/` somewhere other than the Git root.
-
-In those layouts, PRFlow anchors to the inner or nearest repository. Move to the intended repository before starting the skill. Explicit configuration-path options, where a helper provides them, are honored as written.
+<AccordionGroup>
+  <Accordion title="A Nested Repository Inside a Monorepo">
+    A vendored or cloned repository inside your monorepo is its own Git root. A command started inside it anchors to that inner repository, and it will not see the monorepo's `.prflow/config.json`.
+  </Accordion>
+  <Accordion title="A Git Submodule">
+    A submodule is a separate Git root for the same reason. Change to the parent checkout first if the parent is the repository you mean to work on.
+  </Accordion>
+  <Accordion title="Configuration Stored Below the Git Root">
+    If your team stores `.prflow/` below the Git root, the default resolution will not find it. Where a helper offers an explicit configuration-path option, that option is honored exactly as written.
+  </Accordion>
+</AccordionGroup>
 
 ## Outside a Git Repository
 
-Some helpers fall back to the current directory when no Git root can be resolved. Issue, branch, workpad and pull-request workflows still depend on real Git and GitHub repository state.
-
-For predictable behavior, start those workflows from inside the intended Git checkout.
+Some helpers fall back to the current directory when no Git root can be found. That fallback is not enough for real work: issue, branch, workpad and pull-request workflows all depend on actual Git and GitHub state. Start those workflows from inside the intended checkout.
 
 ## Do Not Change Directory Mid-Run
 
-PRFlow's authored commands avoid a leading `cd`. Cloud helper paths are repository-relative, and the cloud Bash working directory persists across tool calls. A directory change can make later helpers resolve against the wrong path.
+<Warning>
+  Do not run `cd` while a PRFlow command is in progress. In a cloud run the Bash working directory persists between tool calls and helper paths are repository-relative, so a directory change makes later helpers resolve against the wrong path. Locally it can select a different Git root or break project-specific test commands.
+</Warning>
 
-Local readers re-anchor many paths, but keeping the session inside the same repository avoids selecting another Git root or confusing project-specific test commands.
+PRFlow's own commands are written to avoid a leading `cd` for this reason.
 
-See [Local Runs](/docs/runs/local/index) for the full local execution model.
+See [Local Runs](/docs/runs/local/index) for the rest of the local execution model.

--- a/docs/external/docs/troubleshooting/cloud-runs.md
+++ b/docs/external/docs/troubleshooting/cloud-runs.md
@@ -1,30 +1,42 @@
 ---
 title: "Cloud-Run Problems"
-description: "Diagnose comment authorization, authentication, runners, runtime setup, stale pins and interrupted workflows."
+description: "Diagnose a GitHub Actions run that failed, or an authorized comment that started no run."
 ---
 
-Diagnose a GitHub Actions run that failed or an authorized comment that did not start one. Each section opens with the signal to look for and a command you can run as-is; `gh` fills the `{owner}/{repo}` placeholders from the repository's git remote.
+Match the signal you can see to an entry below, run its command as-is, then apply its fix. `gh` fills the `{owner}/{repo}` placeholders from the repository's git remote.
 
-## A Comment Did Not Trigger
+<AccordionGroup>
+
+<Accordion title="A comment did not trigger a run">
 
 **Signal:** the comment received no 🚀 reaction. That usually means parsing or authorization declined before the agent job started.
 
-List the most recent gate runs to see whether the workflow fired at all:
+PRFlow's commands are split across two workflow files, so list the right one. The filenames deliberately keep the older `devflow` prefix.
+
+The implement command runs from `devflow-implement.yml`:
+
+```bash
+gh run list --workflow devflow-implement.yml --limit 5
+```
+
+The review, review-and-fix and pr-description commands run from `devflow.yml`:
 
 ```bash
 gh run list --workflow devflow.yml --limit 5
 ```
 
-Confirm all of these conditions:
+An empty list for the workflow you expected means the trigger never fired at all. Confirm all of these:
 
 - The command is the first recognized standalone command in the comment.
-- It is not quoted, fenced, indented as code or embedded in prose.
-- `/prflow:implement` is on a regular issue, not a pull request.
+- It is not quoted, fenced, indented as code or wrapped in prose.
+- `/prflow:implement` is on a regular issue, not on a pull request.
 - `/prflow:review` is on the pull request's **Conversation** tab.
 - The comment does not contain `@claude`.
-- `workflows.prflow` is true in committed config.
+- `workflows.prflow` is true in the committed configuration.
 
-## The Actor Is Unauthorized
+</Accordion>
+
+<Accordion title="The actor is unauthorized">
 
 **Signal:** the gate job's log records a decline reason such as `is not in the configured allowed_users allowlist` or `is not an allowed bot or write/admin/maintain collaborator`.
 
@@ -34,11 +46,13 @@ Check the exact permission GitHub reports for the commenting account:
 gh api repos/{owner}/{repo}/collaborators/<login>/permission --jq .permission
 ```
 
-Humans must match `prflow.allowed_users` and have write, maintain or admin repository permission. Bots must match `prflow.allowed_bots`. Check the exact login, including the configured bare bot name.
+A human must match `prflow.allowed_users` and hold write, maintain or admin permission on the repository. A bot must match `prflow.allowed_bots`. Check the exact login, including the bare bot name as configured.
 
-An API or permission lookup failure declines the run. Fix the gate job's token permissions or transient GitHub access, then retry.
+An API or permission lookup that fails declines the run. Fix the gate job's token permissions or the transient GitHub access problem, then try again.
 
-## Model Authentication Fails
+</Accordion>
+
+<Accordion title="Model authentication fails">
 
 **Signal:** on a provider route, the run stops with an error of the form `::error::.prflow/config.json section '<section>' selects provider '<name>' but the DEVFLOW_PROVIDER_API_KEY repository secret is empty.`
 
@@ -48,23 +62,27 @@ List the secrets the workflow can see:
 gh secret list
 ```
 
-On the default route, confirm `CLAUDE_CODE_OAUTH_TOKEN` is present in the workflow's repository or environment secrets. On a provider route, confirm the section names a valid provider and `DEVFLOW_PROVIDER_API_KEY` is present.
+On the default route, confirm `CLAUDE_CODE_OAUTH_TOKEN` is present in the repository or environment secrets. On a provider route, confirm the section names a valid provider and that `DEVFLOW_PROVIDER_API_KEY` is present.
 
-A partially routed installation can need both credentials. A fully provider-routed installation can omit OAuth only when every active model-running section is routed.
+A partly routed installation can need both credentials. A fully provider-routed installation can omit the OAuth token only when every section that runs a model is routed.
 
-## The Job Is Queued Indefinitely
+</Accordion>
 
-**Signal:** the run sits in **Queued** with no error. GitHub queues an unmatched runner label set without raising a configuration error; an invalid JSON array instead fails earlier with a visible `fromJSON` error.
+<Accordion title="The job is queued indefinitely">
 
-Compare `DEVFLOW_RUNNER`'s label array against the labels of your registered runners:
+**Signal:** the run sits in **Queued** with no error. GitHub queues an unmatched runner label set without raising a configuration error. An invalid JSON array fails earlier instead, with a visible `fromJSON` error.
+
+Compare the `DEVFLOW_RUNNER` label array against the labels of your registered runners:
 
 ```bash
 gh api repos/{owner}/{repo}/actions/runners --jq '.runners[] | {name, status, labels: [.labels[].name]}'
 ```
 
-The JSON label array must match all labels on an online self-hosted runner that is registered, online and eligible for the repository.
+Every label in the JSON array must appear on one self-hosted runner that is registered, online and eligible for this repository.
 
-## Setup Fails Before the Agent Starts
+</Accordion>
+
+<Accordion title="Setup fails before the agent starts">
 
 **Signal:** a provisioning step before the agent step is the first failure in the run.
 
@@ -74,27 +92,49 @@ Read only the failing steps' logs:
 gh run view <run-id> --log-failed
 ```
 
-Confirm the runner has bash, `git`, `gh`, `jq`, Python 3.11 or newer and Docker when services require it. Check `setup` values and commands in their documented order.
+Confirm the runner has bash, `git`, `gh`, `jq`, Python 3.11 or newer, and Docker when services need it. Check the `setup` values and commands in their documented order.
 
-On self-hosted Windows, preinstall Claude Code and set `setup.claude_code_executable`. If Python exists without the `python3` command, install the supported shim on the runner.
+On a self-hosted Windows runner, preinstall Claude Code and set `setup.claude_code_executable`. If Python exists without a `python3` command, install the supported shim on the runner — see [Installation Problems](/docs/troubleshooting/installation).
 
-## A Tool Is Installed but Denied
+</Accordion>
 
-**Signal:** the run's execution diagnostics (in the job log and run summary) report a nonzero permission-denial count, while the tool itself is present on the runner.
+<Accordion title="A tool is installed but denied">
 
-Provisioning and command authorization are separate. Add a narrow tool entry to the active workflow's allowlist. The general cloud-command and implementation allowlists do not inherit from each other. Merge the grant before expecting it in a new run.
+**Signal:** the run's execution diagnostics, in the job log and the run summary, report a nonzero permission-denial count while the tool itself is present on the runner.
 
-## Plugin Vendoring Fails
+Read the count and the denied names:
+
+```bash
+gh run view <run-id> --log | grep -i "denial"
+```
+
+Provisioning and command authorization are separate concerns. Installing a tool does not permit it. Add a narrow tool entry to the allowlist for the path that needs it: `prflow_implement.allowed_tools` for an implementation run, `prflow.allowed_tools` for the light command path. The two do not inherit from each other.
+
+<Warning>
+Merge the grant before you expect it in a run. The workflow reads these settings from the default branch at trigger time, so a grant added by a pull request does not apply to that pull request's own run.
+</Warning>
+
+</Accordion>
+
+<Accordion title="Plugin vendoring fails">
 
 **Signal:** the run stops with an error of the form `::error::incomplete vendor: missing after materialization: <files>`, or an earlier loud failure naming an empty `prflow_version`.
 
-In thin mode, confirm `prflow_version` is nonempty and resolves to a tag, branch or commit in `The01Geek/prflow`. An empty pin fails loudly to prevent mutable-main drift. A stale pin can also omit a helper required by newer workflow bytes.
+Read the pin the run used:
 
-Re-run the installer with a current release tag and apply the update so workflow files and the runtime pin move together. If a locally edited workflow was preserved, merge its `.prflow-new` sidecar by hand.
+```bash
+jq -r '.prflow_version' .prflow/config.json
+```
 
-## The Run Stopped Without Finishing
+In thin mode, `prflow_version` must be nonempty and must resolve to a tag, branch or commit in `The01Geek/prflow`. An empty pin fails loudly, to stop the installation drifting with a moving branch. A stale pin can also omit a helper that newer workflow bytes call.
 
-**Signal:** the workpad or review-progress comment shows a non-complete status, or the run ended with no verdict.
+Re-run the installer with a current release tag and apply the update, so the workflow files and the runtime pin move together. If a locally edited workflow was preserved, merge its `.prflow-new` sidecar by hand.
+
+</Accordion>
+
+<Accordion title="The run stopped without finishing">
+
+**Signal:** the workpad or the review-progress comment shows a status that is not Complete, or the run ended with no verdict.
 
 Read the failing steps and the execution diagnostics:
 
@@ -102,6 +142,17 @@ Read the failing steps and the execution diagnostics:
 gh run view <run-id> --log-failed
 ```
 
-Use the workpad or review-progress comment to distinguish Blocked, Failed, Cancelled and still-interim state. Inspect execution diagnostics for permission denials. Correct the cause before posting the command again.
+Use the workpad or the review-progress comment to tell Blocked, Failed, Cancelled and still-running apart. Look at the execution diagnostics for permission denials. Correct the cause before you post the command again.
 
-Implementation retries reuse the workpad and pushed branch checkpoints. Review retries target the current pushed head. See [Cloud Recovery](/docs/runs/cloud/recovery) for the recovery sequence.
+An implementation retry reuses the workpad and any pushed branch checkpoint. A review retry targets the current pushed head. See [Cloud Recovery](/docs/runs/cloud/recovery) for the full sequence.
+
+</Accordion>
+
+</AccordionGroup>
+
+## Related Articles
+
+- [Cloud Runs](/docs/runs/cloud/index)
+- [Triggers](/docs/runs/cloud/triggers)
+- [Runners](/docs/runs/cloud/runners)
+- [Cloud Recovery](/docs/runs/cloud/recovery)

--- a/docs/external/docs/troubleshooting/commands.md
+++ b/docs/external/docs/troubleshooting/commands.md
@@ -1,43 +1,116 @@
 ---
 title: "Command Problems"
-description: "Fix unknown commands, GitHub authentication, wrong context and blocked verification."
+description: "Fix an unknown command, failing GitHub calls, a command aimed at the wrong target and a denied verification command."
 ---
 
-Restore a local PRFlow command that is unavailable, resolves incorrectly or cannot complete its operation.
+Match the symptom to an entry below, run its diagnostic command, then apply its fix.
 
-## The Command Is Unknown
+<AccordionGroup>
 
-Use the syntax for your client:
+<Accordion title="The command is unknown">
 
-| **Client** | **Example** |
-| --- | --- |
-| Claude Code | `/prflow:implement 123` |
-| GitHub Copilot CLI | `/prflow/implement 123` |
-| Codex CLI | `$prflow:implement 123` |
+**Symptom:** the client answers that the command does not exist, or nothing happens when you send it.
 
-If the namespace is correct, reload the plugin and follow [Installation Problems](/docs/troubleshooting/installation).
+Claude Code is the documented client, and the only syntax PRFlow uses is `/prflow:<skill>`. For example:
 
-## GitHub Operations Fail
+```
+/prflow:implement 123
+```
 
-Check the active GitHub CLI account:
+Check that the plugin is loaded:
+
+```bash
+claude plugin list
+```
+
+If `prflow` is missing or disabled, follow [Installation Problems](/docs/troubleshooting/installation). If it is loaded, run `/reload-plugins` and try again.
+
+The older `/devflow:<skill>` spellings are still accepted, so an old habit or an old comment still works. They are permanent aliases, not a sign that something is out of date.
+
+</Accordion>
+
+<Accordion title="GitHub operations fail">
+
+**Symptom:** the run reports that it cannot read the issue, open the pull request or post the review.
+
+Check which account the GitHub CLI is using:
 
 ```bash
 gh auth status
 ```
 
-If needed, authenticate again with `gh auth login`. Confirm that the account can read the repository and perform the issue, pull-request or review operation PRFlow attempted. On Windows, also confirm that the same bash session resolves the intended `gh` or `gh.exe`.
+If no account is active, or the active one is the wrong account, sign in again:
 
-## The Command Is Running in the Wrong Context
+```bash
+gh auth login
+```
 
-Use implementation only with an existing GitHub issue. Use review with a pull-request number or a branch that has a resolvable pull request. Review-and-fix changes files and is a local workflow; use review when you want assessment only.
+Then confirm that account can reach the repository and do the specific thing PRFlow tried:
 
-## Verification Is Blocked
+```bash
+gh repo view
+gh issue view <number>
+gh pr view <number>
+```
 
-Read the blocked message for the exact command. Then do one of the following:
+On Windows, also confirm the same bash session resolves the `gh` you signed in with. Run `which -a gh` and compare it against `DEVFLOW_GH` if you set that override.
 
-- Install the missing repository dependency.
-- Correct the verification command.
-- Grant a narrow command pattern to the active execution path.
-- Resolve an external service that the verification depends on.
+</Accordion>
 
-Cloud implementation must observe command-based verification in its own environment. It does not substitute a CI result. A tool grant added by the same pull request is not active until after merge.
+<Accordion title="The command is running on the wrong target">
+
+**Symptom:** the run says the number is not an issue, not a pull request, or it works on something you did not mean.
+
+Confirm what the number actually is before you send the command again:
+
+```bash
+gh issue view <number> --json number,title,state
+gh pr view <number> --json number,title,state,headRefName
+```
+
+Then match the command to the target:
+
+- `/prflow:implement <number>` takes an existing GitHub **issue**. In the cloud it answers a comment on an issue, never on a pull request.
+- `/prflow:review <number>` takes a **pull request** and changes nothing. Use it when you want an assessment only.
+- `/prflow:review-and-fix <number>` also takes a **pull request**, and it both reviews and fixes. It is not local-only: it is one of the three commands a fresh cloud installation answers from a pull-request comment, alongside `/prflow:review` and `/prflow:pr-description`.
+
+In a comment on the pull request itself, send the review commands with no number. The run takes the pull request from the comment's own thread.
+
+<Warning>
+`/prflow:review-and-fix` edits files and pushes commits to the pull request's branch. `/prflow:review` never moves the working tree. If you wanted an opinion rather than a change, send `/prflow:review`.
+</Warning>
+
+</Accordion>
+
+<Accordion title="Verification is blocked">
+
+**Symptom:** the run stops and says a verification command it needed was not permitted. The command produced no output because it was refused before it ran.
+
+Read the message for the exact command, then check whether that command is granted for the path you are on:
+
+```bash
+jq '.prflow_implement.allowed_tools' .prflow/config.json
+```
+
+An implementation run reads its extra grants from `prflow_implement.allowed_tools` in `.prflow/config.json`. Add the command's leading token and arguments there, using the tool syntax the file already shows, such as `"Bash(make:*)"`. If the tool also has to be installed on the runner, add its install step to the `setup` block.
+
+`prflow_implement.allowed_tools` is the only setting that grants a verification command to an implementation run. `prflow.allowed_tools` grants commands to the light command path instead, and the two do not inherit from each other, so listing a tool in one does not make it available in the other.
+
+<Warning>
+A grant added by the same pull request does not apply to that pull request's own run. The workflow reads these settings from the default branch at the time the run is triggered, so the grant takes effect only after you merge it. Merge first, then start a new run.
+</Warning>
+
+If the command is granted and still fails, the cause is elsewhere. Install the missing repository dependency, correct the verification command in the issue, or fix the external service the command depends on.
+
+A cloud implementation run must observe a verification command in its own environment. It does not accept a CI result in place of running the command, so a green pull-request check does not discharge a verification the run itself could not perform.
+
+</Accordion>
+
+</AccordionGroup>
+
+## Related Articles
+
+- [Command Reference](/docs/reference/command-reference)
+- [Tool Permissions](/docs/configuration/tool-permissions)
+- [Verification](/docs/concepts/verification)
+- [Client Commands](/docs/runs/local/client-commands)

--- a/docs/external/docs/troubleshooting/configuration.md
+++ b/docs/external/docs/troubleshooting/configuration.md
@@ -1,43 +1,137 @@
 ---
 title: "Configuration Problems"
-description: "Fix missing, invalid, ignored or not-yet-effective PRFlow settings."
+description: "Fix a missing, invalid, ignored, dropped or not-yet-effective PRFlow setting."
 ---
 
-Diagnose `.prflow/config.json` when PRFlow cannot read it or a setting does not produce the expected behavior.
+Diagnose `.prflow/config.json` when PRFlow cannot read it, or when a setting does not change what a run does.
 
-## The Workflow Reports `config.json not found`
+<AccordionGroup>
 
-Confirm that `.prflow/config.json` exists on the repository's default branch and is committed. Run `/prflow:init` or the cloud installer to scaffold it. If your repository ignores the file broadly, add it explicitly and narrow the ignore rule.
+<Accordion title="The workflow reports config.json not found">
 
-## The Workflow Reports Invalid JSON
+**Symptom:** a cloud run stops early and says it could not find the configuration file.
 
-Validate syntax locally:
+Check that the file exists on the default branch and is committed:
+
+```bash
+git ls-files --error-unmatch .prflow/config.json
+git check-ignore -v .prflow/config.json
+```
+
+The first command fails if the file is untracked. The second names the ignore rule if one is hiding it. Run `/prflow:init`, or the cloud installer, to scaffold the file. If your repository ignores it broadly, add it explicitly and narrow the ignore rule.
+
+</Accordion>
+
+<Accordion title="The workflow reports invalid JSON">
+
+**Symptom:** a cloud run stops with a parse error naming the configuration file.
+
+Validate the syntax locally:
 
 ```bash
 python3 -m json.tool .prflow/config.json
 ```
 
-Fix the first parse error, then rerun the command. The cloud config reader fails on malformed JSON rather than silently using the full scaffold.
+Fix the first parse error it reports, then run the command again. The cloud config reader fails on malformed JSON rather than quietly falling back to a full scaffold, so a trailing comma stops the whole run.
 
-Use `.prflow/config.schema.json` for editor validation of types and accepted values. The runtime still applies setting-specific fallbacks for some missing or invalid leaves.
+Point your editor at `.prflow/config.schema.json` for validation of types and accepted values. The runtime still applies setting-specific fallbacks for some missing or invalid leaves.
 
-## A Setting Is Ignored
+</Accordion>
 
-Check the exact current key name and nesting. Current families begin with `prflow`, such as `prflow_implement` and `prflow_review`. Running `/prflow:init` migrates supported superseded family names and backfills new keys.
+<Accordion title="A setting is ignored">
 
-Then check the execution tier. Common mismatches include:
+**Symptom:** the setting is present and valid, and behavior does not change.
+
+Print the top-level key names to check the exact spelling and nesting:
+
+```bash
+jq 'keys' .prflow/config.json
+```
+
+Current families begin with `prflow`, such as `prflow_implement` and `prflow_review`. Running `/prflow:init` migrates supported older family names and backfills newly added keys.
+
+Then check the execution path. These are the common mismatches:
 
 - `prflow.allowed_tools` does not apply to implementation.
-- `prflow_implement.allowed_tools` does not apply to the general cloud command workflow.
-- `prflow_runner` and `workflows.prflow-review` have no effect in a fresh install because the automatic-review files are withdrawn.
-- Provider selection is per section.
+- `prflow_implement.allowed_tools` does not apply to the light cloud command path.
+- `prflow_runner` and `workflows.prflow-review` have no effect in a fresh installation, because the automatic-review files are not shipped.
+- Provider selection is set per section, not once for the whole file.
 
-## A Configuration Change Has Not Taken Effect
+</Accordion>
 
-Trigger-time security settings are read from a trusted default or base branch. Tool grants, provider routing, commit attribution, runner executable paths and git-environment pins added by a pull request are generally post-merge-only for that pull request's own run.
+<Accordion title="A per-agent model or effort override did nothing">
 
-Merge the configuration change, then start a new run. Do not use a same-pull-request result as evidence that a new permission took effect.
+**Symptom:** you set a model or an effort for one review agent, the run completes normally and the agent behaves exactly as before.
 
-## The Installer Backfilled Unexpected Keys
+Print the overrides block:
 
-Re-running the installer or `/prflow:init` adds newly scaffolded keys without replacing existing values or arrays. Review the diff. A new default can expose a feature for discovery without enabling every execution path. Consult [Settings](/docs/configuration/settings) before changing it.
+```bash
+jq '.prflow_review.agent_overrides' .prflow/config.json
+```
+
+A malformed override is dropped rather than raising an error. The run continues with the value it would have used anyway, so the only visible trace is a warning. On a cloud run, search the job log for it:
+
+```bash
+gh run view <run-id> --log | grep "resolve-review-overrides"
+```
+
+Check each value against what is accepted:
+
+| Field | Accepted values | What a bad value does |
+| --- | --- | --- |
+| `model` | `sonnet`, `opus`, `haiku`, `fable` | Dropped with a warning. The agent falls back to the top-level `claude_model`. |
+| `effort` | `low`, `medium`, `high`, `xhigh`, `max` | Dropped with a warning. The agent falls back to the session effort. |
+| `iterations` | `first-only` | Dropped with a warning. The agent runs on every iteration. |
+
+An empty string, a whitespace-only string and a nested object are all treated as bad values. A provider-specific model identifier belongs at the top-level `claude_model`, not here.
+
+Resolution is per entry. An agent that has its own entry uses only that entry, and the `default` entry does not fill in its missing fields. `default` supplies a model and effort only for agents that have no entry of their own.
+
+<Warning>
+An entry whose key is not one of the nine review agents is refused by the schema, so validate against `.prflow/config.schema.json` before you commit. An entry that is present but is not an object is ignored with a warning, and `default` then applies to that agent instead.
+</Warning>
+
+</Accordion>
+
+<Accordion title="A configuration change has not taken effect">
+
+**Symptom:** you changed a setting in a pull request, and that pull request's own run behaves as though you had not.
+
+Confirm what the default branch actually holds:
+
+```bash
+git show origin/<default-branch>:.prflow/config.json | jq '<your key path>'
+```
+
+Trigger-time security settings are read from the default branch, not from the pull request. Tool grants, provider routing, commit attribution, runner executable paths and git-environment pins added by a pull request are post-merge-only for that pull request's own run.
+
+Merge the configuration change, then start a new run.
+
+<Warning>
+Do not use a same-pull-request result as evidence that a new permission took effect. It cannot be, and reading it that way hides the real state of the grant.
+</Warning>
+
+</Accordion>
+
+<Accordion title="The installer backfilled unexpected keys">
+
+**Symptom:** re-running the installer or `/prflow:init` adds keys you did not write.
+
+Review the diff before you commit it:
+
+```bash
+git diff .prflow/config.json
+```
+
+Backfill adds newly scaffolded keys. It does not replace existing values or arrays. A new default can expose a feature for discovery without enabling every execution path. Read [Settings](/docs/configuration/settings) before you change one.
+
+</Accordion>
+
+</AccordionGroup>
+
+## Related Articles
+
+- [Settings](/docs/configuration/settings)
+- [Core Settings](/docs/configuration/core-settings)
+- [Review Agents](/docs/configuration/review-agents)
+- [Tool Permissions](/docs/configuration/tool-permissions)

--- a/docs/external/docs/troubleshooting/implementation.md
+++ b/docs/external/docs/troubleshooting/implementation.md
@@ -1,36 +1,213 @@
 ---
 title: "Implementation Problems"
-description: "Recover from issue blockers, branch-state refusals, capability limits and interrupted implementation."
+description: "Recover an implement run that stops before it produces a finished pull request."
 ---
 
-Recover an `/prflow:implement` run that stops before producing a complete pull request.
+Match the stop you are looking at to an entry below, run its diagnostic command, then apply its fix.
 
-## A Declared Issue Dependency Is Still Open
+<AccordionGroup>
 
-PRFlow reads dependency declarations such as `depends on #123`, `blocked by #123` and `must merge after #123`. An open declared prerequisite blocks implementation.
+<Accordion title="A declared issue dependency is still open">
 
-Confirm that the dependency direction in the issue is correct. Close or merge the prerequisite, or correct the issue text if it described the inverse relationship. Then rerun implementation.
+**Symptom:** the run stops as Blocked before it creates a branch, and names an issue number the issue body mentions.
 
-If PRFlow reports that a dependency could not be resolved, check GitHub authentication and repository access before retrying. An unreadable dependency does not count as closed.
+PRFlow reads the issue body for a declared prerequisite. Show every phrase it looks for:
 
-## The Branch-State Preflight Refuses to Continue
+```bash
+gh issue view <number> --json body --jq .body | grep -inE "depends on #|must merge after #|blocked by #|follow-up to #|^[ >*-]*after #"
+```
 
-Implementation checks commits on the feature branch that are not in the base branch before adopting it. A refusal means the run could not prove that the existing commits belong to the issue's prior work.
+These are all the phrases that declare a blocking dependency, each followed by one or more issue numbers:
 
-Check the workpad's branch and pull-request links. Confirm that the expected remote branch still exists and points at the intended commits. Do not bypass the guard by discarding unknown commits. Reconcile or publish the branch deliberately, then rerun.
+| Phrase | Example |
+| --- | --- |
+| `depends on` | `Depends on #123` |
+| `must merge after` | `Must merge after #123` |
+| `blocked by` | `Blocked by #123 — the schema has to land first` |
+| `follow-up to` | `Follow-up to #123` |
+| `after`, at the start of a line or bullet | `After #123 lands, do this` |
 
-## Every Required Change Is Under `.github/workflows/`
+One phrase can name several issues at once, as in `blocked by #10 and #11`.
 
-The built-in `GITHUB_TOKEN` cannot push workflow-file changes. When every acceptance criterion requires that capability, cloud implementation stops Blocked instead of opening an empty pull request.
+<Warning>
+`follow-up to #123` reads like ordinary prose. People write it to record where the work came from, not to say the work is blocked, and PRFlow still treats it as a blocking dependency. If you meant provenance rather than ordering, reword it, for example to `this continues the work in #123`.
+</Warning>
 
-Run the issue with a human credential or configure the optional GitHub App with both `Contents: write` and `Workflows: write`. If only some work is workflow-bound, PRFlow can defer that subset and continue with an independently shippable remainder.
+Check whether the named prerequisite is actually still open:
 
-## A Verification Command Is Blocked
+```bash
+gh issue view <prerequisite> --json state,title
+```
 
-Add the required leading command and arguments to `prflow_implement.allowed_tools` in a prior merged change. Provision the tool in `setup` as needed. Do not rely on `prflow.allowed_tools`; the two paths do not inherit from each other.
+Close or merge the prerequisite, or correct the issue text. Then start the run again. A phrase that points the other way, such as `Blocks #123` or `Required by #123`, is read as an outbound relation and does not block the run.
 
-## The Run Stopped Midway
+If the run says a dependency could not be resolved, that is not the same as closed. Fix GitHub authentication or repository access, then retry.
 
-Open the dedicated workpad and use its branch and pull-request links. Reissue the original implementation comment after correcting the cause. The new run reuses the workpad and adopts pushed checkpoints when available.
+</Accordion>
 
-A run interrupted before its first branch checkpoint can have no recoverable code. A cancelled run is terminal and is not automatically resumed. See [Cloud Recovery](/docs/runs/cloud/recovery).
+<Accordion title="PRFlow could not reproduce the bug">
+
+**Symptom:** the run stops as Blocked on a bug issue, and the workpad records a reflection beginning `cannot reproduce:` followed by the obstacle it hit.
+
+Reproduction is a hard gate for a bug issue. PRFlow will not plan a fix for a defect it has not seen happen, because a fix aimed at a guess is worse than no fix. It records the obstacle instead of inventing one.
+
+Read what it recorded:
+
+```bash
+gh issue view <number> --comments
+```
+
+The workpad comment holds the obstacle. Then give the run what it was missing by editing the issue's `Current Behavior` section: the exact steps, the input that triggers the defect, the environment it happens on and the output you actually see against the output you expect. If the defect only happens in one environment, say which. If a fact genuinely cannot be established, write that down rather than leaving it out.
+
+Start the run again once the issue carries reproduction steps a second person could follow.
+
+</Accordion>
+
+<Accordion title="The issue has no acceptance criteria">
+
+**Symptom:** nothing fails. The run finishes and reports Complete, and the workpad's acceptance-criteria section reads `_(none provided in issue body)_`.
+
+Check whether the issue has the section at all:
+
+```bash
+gh issue view <number> --json body --jq .body | grep -n "^## Acceptance Criteria"
+```
+
+<Warning>
+With no criteria, the acceptance-criteria gate has nothing to check and passes trivially. A Complete on such a run means the run finished, not that the requested outcome was verified. Do not read it as evidence.
+</Warning>
+
+Write acceptance criteria into the issue before you run it. Each one is a testable statement about observable behavior, written as a markdown checkbox:
+
+```markdown
+## Acceptance Criteria
+
+- [ ] Running `make check` on a repository with no config prints the missing-config remedy and exits 1
+- [ ] An existing config is left byte-identical
+```
+
+Then start the run again. [Create an issue](/docs/workflows/create-issue) writes this section for you.
+
+</Accordion>
+
+<Accordion title="Acceptance criteria are written as prose or a numbered list">
+
+**Symptom:** the issue clearly has criteria, but the run behaves as though it has none, and its workpad carries a reflection about the issue's accuracy that you did not cause.
+
+PRFlow reads a criterion only when it is a markdown checkbox list item: `- [ ]`, `- [x]`, `* [ ]` or `* [x]`. Bold paragraphs such as `**AC1 — ...**` and numbered lists such as `1. ...` parse to zero items, exactly as an absent section would.
+
+Count the checkbox rows in the issue:
+
+```bash
+gh issue view <number> --json body --jq .body | grep -cE "^[*-] \[[ xX]\]"
+```
+
+A count of 0 with a visible criteria section is this case. The run does not stop: it hand-extracts the criteria and records that it had to, which is the reflection you are reading. That reflection is about the issue's shape, not about your code.
+
+Rewrite each criterion as a checkbox row, then start the run again so the machine-readable path is used.
+
+</Accordion>
+
+<Accordion title="The feature branch is checked out in another worktree">
+
+**Symptom:** the run stops as Blocked and reports that the branch is checked out in another linked worktree. The underlying git error reads `fatal: '<branch>' is already used by worktree at '<path>'`. Older git versions word it `already checked out at`.
+
+List your worktrees and find the one holding the branch:
+
+```bash
+git worktree list
+```
+
+<Warning>
+This is a terminal stop, not a switch. PRFlow shares the working tree it was started in and cannot move into another one, so it refuses rather than continuing on the wrong branch. It makes no change to your history when it stops.
+</Warning>
+
+Resolve it yourself, then start the run again:
+
+```bash
+git worktree remove <path>
+```
+
+Finish and remove the other worktree, or move its work elsewhere. Use `git worktree remove --force` only when you are sure that worktree holds nothing you want.
+
+</Accordion>
+
+<Accordion title="The branch-state check refuses to adopt the branch">
+
+**Symptom:** the run stops before implementation and says it could not confirm that the existing commits on the feature branch belong to this issue's earlier work.
+
+The run compares the feature branch against the base branch. List the commits that are on the branch but not on the base:
+
+```bash
+git log --oneline origin/<base>..<branch>
+```
+
+A refusal means those commits could not be shown to be the run's own prior work. That usually happens when the branch was created from an unpushed local commit, so it carries unrelated history that every later step would treat as part of this change.
+
+Check the workpad's branch and pull-request links, and confirm the remote branch still exists and points where you expect:
+
+```bash
+git ls-remote origin <branch>
+```
+
+<Warning>
+Do not clear the refusal by deleting the commits you do not recognize. Reconcile or publish that history on purpose first. The check is read-only and has moved nothing.
+</Warning>
+
+</Accordion>
+
+<Accordion title="Every required change is under .github/workflows/">
+
+**Symptom:** a cloud run stops as Blocked rather than opening an empty pull request, and names workflow files.
+
+The built-in token cannot push a change to a workflow file. When every acceptance criterion needs that capability, the run has nothing it can ship.
+
+Check what the issue requires:
+
+```bash
+gh issue view <number> --json body --jq .body | grep -n ".github/workflows/"
+```
+
+Either run the issue with a human credential, or configure the optional GitHub App with both `Contents: write` and `Workflows: write`. See [Cloud Setup](/docs/runs/cloud/setup). If only part of the work is workflow-bound, PRFlow can defer that part and ship the rest.
+
+</Accordion>
+
+<Accordion title="A verification command was denied">
+
+**Symptom:** the run stops and names a command it needed but was not allowed to run.
+
+Check the grant list for the implementation path:
+
+```bash
+jq '.prflow_implement.allowed_tools' .prflow/config.json
+```
+
+The full fix, including why a grant added by the same pull request does not apply to that pull request's own run, is in [Command Problems](/docs/troubleshooting/commands).
+
+</Accordion>
+
+<Accordion title="The run stopped midway">
+
+**Symptom:** the workpad shows a status that is not Complete, and no finished pull request exists.
+
+Read the workpad and the run it came from:
+
+```bash
+gh issue view <number> --comments
+gh run view <run-id> --log-failed
+```
+
+The workpad holds the branch link, the pull-request link and the run's own record of where it stopped. Fix the cause it names, then post the original implement comment again. The new run reuses the same workpad and adopts any checkpoint that was already pushed.
+
+A run interrupted before its first branch checkpoint may have no recoverable code. A cancelled run is terminal and is never resumed for you. See [Cloud Recovery](/docs/runs/cloud/recovery).
+
+</Accordion>
+
+</AccordionGroup>
+
+## Related Articles
+
+- [Implement](/docs/workflows/implement)
+- [Workpads and Resume](/docs/concepts/workpads-and-resume)
+- [Verification](/docs/concepts/verification)
+- [Cloud Recovery](/docs/runs/cloud/recovery)

--- a/docs/external/docs/troubleshooting/index.md
+++ b/docs/external/docs/troubleshooting/index.md
@@ -1,15 +1,37 @@
 ---
 title: "Troubleshooting"
-description: "Resolve PRFlow installation, configuration, command and cloud-run problems by symptom."
+description: "Find the PRFlow error you are seeing and the command that fixes it."
 ---
 
-Start with the first visible symptom to identify why a PRFlow command, configuration or run failed.
+Start with the first symptom you can see, then open the page that covers it.
 
-- [Installation Problems](/docs/troubleshooting/installation) covers plugin loading, missing prerequisites, marketplace updates and installer sidecars.
-- [Command Problems](/docs/troubleshooting/commands) covers unknown commands, GitHub authentication and blocked verification.
-- [Implementation Problems](/docs/troubleshooting/implementation) covers issue blockers, branch state, capability limits and interrupted work.
-- [Review Problems](/docs/troubleshooting/review) covers unresolved pull requests, target branches, progress comments and missing verdicts.
-- [Configuration Problems](/docs/troubleshooting/configuration) covers invalid JSON, missing config, ignored settings and post-merge behavior.
-- [Cloud-Run Problems](/docs/troubleshooting/cloud-runs) covers authorization, secrets, queued runners, stale pins and workflow recovery.
+<CardGroup cols={2}>
+  <Card title="Installation Problems" icon="download" href="/docs/troubleshooting/installation">
+    PRFlow commands do not appear, a preflight tool is missing, Python is too old or the installer preserved a file.
+  </Card>
+  <Card title="Command Problems" icon="terminal" href="/docs/troubleshooting/commands">
+    The command is unknown, GitHub operations fail, the command runs on the wrong target or a verification command is denied.
+  </Card>
+  <Card title="Implementation Problems" icon="hammer" href="/docs/troubleshooting/implementation">
+    An implement run stops before it opens a pull request: a declared dependency, a bug it cannot reproduce, missing acceptance criteria or a branch it cannot adopt.
+  </Card>
+  <Card title="Review Problems" icon="magnifying-glass" href="/docs/troubleshooting/review">
+    A review cannot find the pull request, rejects over a documentation line, reports unverified coverage or delivers no verdict.
+  </Card>
+  <Card title="Configuration Problems" icon="gear" href="/docs/troubleshooting/configuration">
+    `.prflow/config.json` is missing or invalid, a setting is ignored, an override does nothing or a change is not yet in effect.
+  </Card>
+  <Card title="Cloud-Run Problems" icon="cloud" href="/docs/troubleshooting/cloud-runs">
+    A comment did not start a run, the actor was declined, model authentication failed, the job is queued or vendoring failed.
+  </Card>
+</CardGroup>
 
-When reporting a problem, include the PRFlow version, operating system or runner label, command, execution tier and smallest relevant error excerpt. Remove credentials, prompts and private repository content first.
+## Report a Problem
+
+When you report a problem, include the PRFlow version, the operating system or runner label, the command you ran, whether it ran locally or in the cloud and the smallest error excerpt that shows the failure. Remove credentials, prompt text and private repository content first.
+
+## Related Articles
+
+- [Command Reference](/docs/reference/command-reference)
+- [Glossary](/docs/reference/glossary)
+- [Cloud Recovery](/docs/runs/cloud/recovery)

--- a/docs/external/docs/troubleshooting/installation.md
+++ b/docs/external/docs/troubleshooting/installation.md
@@ -1,73 +1,182 @@
 ---
 title: "Installation Problems"
-description: "Fix plugin loading, missing prerequisites, Windows shims and cloud installer sidecars."
+description: "Fix missing PRFlow commands, an old Python, missing tools and preserved installer files."
 ---
 
-Restore missing plugin commands or resolve installer prerequisites that prevent PRFlow from starting.
+Match the message you see to an entry below, run its diagnostic command, then apply its fix.
 
-## PRFlow Commands Do Not Appear
+<AccordionGroup>
 
-Confirm that the plugin is `prflow` and the intentionally retained marketplace name is `devflow-marketplace`.
+<Accordion title="PRFlow commands do not appear in Claude Code">
 
-For Claude Code:
+**Symptom:** typing `/prflow:` offers no PRFlow commands, or the client answers that the command is unknown.
+
+Claude Code is the documented client. List what the client has loaded:
+
+```bash
+claude plugin list
+```
+
+The plugin is `prflow`. The marketplace keeps the older name `devflow-marketplace` on purpose, so that name is not a sign of a stale install. If the plugin is absent, add the marketplace and install it:
 
 ```bash
 claude plugin marketplace add The01Geek/prflow
 claude plugin install prflow@devflow-marketplace
 ```
 
-Then run `/reload-plugins` or restart Claude Code. If the marketplace is stale, run:
+Then run `/reload-plugins` or restart Claude Code. If the plugin is present but out of date, refresh both the marketplace and the plugin:
 
 ```bash
 claude plugin marketplace update devflow-marketplace
 claude plugin update prflow@devflow-marketplace
 ```
 
-For GitHub Copilot CLI, use `copilot plugin marketplace add`, `copilot plugin install`, `copilot plugin marketplace update` and `copilot plugin update`. For Codex CLI, use `codex plugin marketplace add`, `codex plugin add` and `codex plugin marketplace upgrade`.
+</Accordion>
 
-## Preflight Reports a Missing Tool
+<Accordion title="devflow preflight: Python 3.11+ required (found Python 3.9.6)">
 
-PRFlow requires working `git`, `gh`, `jq` and Python 3.11 or newer available as `python3`. Run the bundled preflight from a PRFlow source or vendored checkout:
+**Symptom:** on macOS the preflight prints a line of this form, even though you believe you installed a newer Python.
+
+macOS ships an older Python as `python3` at `/usr/bin/python3`. On current releases that interpreter is Python 3.9. PRFlow needs Python 3.11 or newer. When a newer Python is installed but the system one comes first on `PATH`, PRFlow still resolves the old one.
+
+Check which interpreter PRFlow will find, and every `python3` on your `PATH`:
 
 ```bash
-bash lib/preflight.sh
+python3 -VV
+which -a python3
 ```
 
-Install every dependency it reports. A local-only PyYAML gap is advisory, but install it to restore all helper behavior:
+If the first line reports 3.11 or newer, the gap is elsewhere. If it reports 3.9, install a newer Python and put it ahead of `/usr/bin` on your `PATH`. Homebrew installs it as:
+
+```bash
+brew install python@3.13
+```
+
+Open a new shell, run `python3 -VV` again and confirm the version changed. Then run `/prflow:init` to repeat the check.
+
+<Warning>
+Do not delete or replace `/usr/bin/python3`. macOS uses it, and removing it can break other software on the machine. Change the order of `PATH` instead.
+</Warning>
+
+</Accordion>
+
+<Accordion title="devflow preflight: missing required tool">
+
+**Symptom:** the preflight prints one or more `devflow preflight:` lines and exits non-zero.
+
+PRFlow requires working `git`, `gh`, `jq` and Python 3.11 or newer reachable as `python3`. Run the check the supported way:
+
+```
+/prflow:init
+```
+
+Initialization scaffolds the repository files and then runs the bundled preflight for you, reporting each gap with its remedy. The scaffold it already wrote stays in place even when the preflight reports a gap.
+
+On a GitHub Actions runner, or in a repository that commits the vendored plugin tree, the same check is available directly:
+
+```bash
+.prflow/vendor/prflow/lib/preflight.sh
+```
+
+Install every dependency the check reports. A missing PyYAML is advisory on a local run: the preflight prints `devflow preflight: required dependencies present; PyYAML advisory (see above).` and still exits 0, but one severity helper is degraded until you install it:
 
 ```bash
 python3 -m pip install PyYAML
 ```
 
-Cloud workflows provision PyYAML through their configured setup. Keep the scaffolded Python install line unless you replace it with an equivalent.
+Name the package. Do not install from a requirements file, because that path resolves against your own working directory and installs your project's dependencies instead.
 
-## Windows Has Python but Not `python3`
+</Accordion>
 
-If `python` or `py -3` reports Python 3.11 or newer, create the supported shim from a PRFlow checkout:
+<Accordion title="Windows has Python but no python3 command">
+
+**Symptom:** the preflight prints `devflow preflight: no working 'python3' on PATH, but a compatible Python (>=3.11) is available as ...`.
+
+Confirm which Python the shell can reach:
 
 ```bash
-bash scripts/provision-python3-shim.sh --apply
+py -3 -VV
+python -VV
 ```
 
-Run the preflight again. The provisioner refuses to create a shim when no compatible interpreter exists.
+If either reports 3.11 or newer, install the supported `python3` shim so PRFlow's helpers resolve it:
 
-## Windows Resolves the Wrong `gh` or `jq`
+```bash
+.prflow/vendor/prflow/scripts/provision-python3-shim.sh --apply
+```
 
-PRFlow probes `gh` and `gh.exe`, and likewise `jq` and `jq.exe`, for a runnable binary. Set an override when PATH still selects the wrong executable:
+Run the preflight again. The provisioner refuses to create a shim when no compatible interpreter exists, so a refusal means you still need a newer Python.
+
+</Accordion>
+
+<Accordion title="Windows resolves the wrong gh or jq">
+
+**Symptom:** the preflight reports no working `gh` or no working `jq`, and names a resolved path that does not execute. A non-executable shim shadowing the real tool causes this.
+
+Show every candidate the shell can see:
+
+```bash
+which -a gh
+which -a jq
+```
+
+PRFlow probes `gh` and `gh.exe`, and likewise `jq` and `jq.exe`, and picks the first one that actually runs. Set an override when `PATH` still selects the wrong executable:
 
 ```bash
 export DEVFLOW_GH=gh.exe
 export DEVFLOW_JQ=jq.exe
 ```
 
-If shell helpers are not running under a POSIX bash, install WSL bash, Git Bash or MSYS2 bash and set `DEVFLOW_BASH` at the invocation boundary.
+An override is used verbatim and is never probed, so point it at an executable you have confirmed. If the shell helpers are not running under a POSIX bash at all, install WSL bash, Git Bash or MSYS2 bash and set `DEVFLOW_BASH` where you invoke PRFlow.
 
-## A Windows Helper Crashed on an Em-dash or Emoji
+</Accordion>
 
-PRFlow's first-party Python helpers force their standard output and standard error to UTF-8 on their entry path, so non-ASCII output (an em-dash, an emoji) no longer raises an encoding error on a Windows host whose default codec is not UTF-8. If an older version crashes this way, update PRFlow. On Linux and macOS, where the default codec is already UTF-8, this is a no-op.
+<Accordion title="A Windows helper crashed on an em-dash or emoji">
 
-## The Cloud Installer Preserved a File
+**Symptom:** a PRFlow Python helper stops with a character-encoding error on a Windows host.
 
-A line naming `PRESERVED` means the installer could not prove that the existing file was untouched. It leaves the original in place and writes the new bytes to `<path>.prflow-new`.
+PRFlow's own Python helpers force their standard output and standard error to UTF-8 on their entry path, so non-ASCII output no longer raises an encoding error. If you see this, you are running an older version. Update the plugin:
 
-Compare the sidecar, merge the intended changes into your maintained file and remove the sidecar. Do not commit sidecars. If every file was preserved because Python could not run, fix Python and repeat the update for a real provenance comparison.
+```bash
+claude plugin update prflow@devflow-marketplace
+```
+
+On Linux and macOS the default codec is already UTF-8, so this never applies.
+
+</Accordion>
+
+<Accordion title="The installer preserved a file instead of updating it">
+
+**Symptom:** installer output names a file as `PRESERVED`, and a new file appears beside it with a `.prflow-new` suffix.
+
+The installer could not prove the existing file was untouched since it wrote it, so it left your copy in place and wrote the new bytes to the sidecar.
+
+<Steps>
+  <Step title="Compare the two files">
+    ```bash
+    diff <path> <path>.prflow-new
+    ```
+  </Step>
+  <Step title="Merge the changes you want into your maintained file">
+    Keep your local edits. Take the new behavior from the sidecar.
+  </Step>
+  <Step title="Delete the sidecar">
+    ```bash
+    rm <path>.prflow-new
+    ```
+    Never commit a sidecar. A committed sidecar is dead weight and confuses the next update.
+  </Step>
+</Steps>
+
+If every file was preserved, Python probably could not run during the update, so the installer could not compare anything. Fix Python, then run the update again for a real comparison.
+
+</Accordion>
+
+</AccordionGroup>
+
+## Related Articles
+
+- [Requirements](/docs/getting-started/requirements)
+- [Installation](/docs/getting-started/installation)
+- [Initialization](/docs/getting-started/initialization)
+- [Updates](/docs/getting-started/updates)

--- a/docs/external/docs/troubleshooting/review.md
+++ b/docs/external/docs/troubleshooting/review.md
@@ -1,73 +1,196 @@
 ---
 title: "Review Problems"
-description: "Fix unresolved pull-request targets, stale bases, missing progress and verdict problems."
+description: "Fix a review that cannot find the pull request, rejects unexpectedly, reports unverified coverage or delivers no verdict."
 ---
 
-Recover a review that cannot identify, inspect or finish the intended pull request.
+Match the symptom to an entry below, run its diagnostic command, then apply its fix.
 
-## The Pull Request Cannot Be Resolved
+<AccordionGroup>
 
-Pass a numeric pull-request number and confirm it exists in the current repository. Run:
+<Accordion title="The pull request cannot be resolved">
+
+**Symptom:** the run says it cannot find the pull request, or it never gets as far as reading a diff.
+
+Confirm the number exists in this repository and that you can read it:
 
 ```bash
 gh pr view <number>
 gh pr diff <number>
 ```
 
-If either command fails, fix GitHub authentication or repository access. Do not pass additional flags where the skill expects only a number.
+If either command fails, fix GitHub authentication or repository access first. Pass only the number. The skill expects a bare pull-request number and no extra flags.
 
-## The Review Targets the Wrong Branch or Commit
+</Accordion>
 
-Standalone review uses the pull request's pushed head and its current base. Confirm the pull request has the expected head commit and base branch in GitHub. Push local commits before requesting standalone review.
+<Accordion title="The review targets the wrong branch or commit">
 
-If a pull request was retargeted, fetch the new base and retry. A deleted or unreachable base can stop review because the diff cannot be established safely.
+**Symptom:** the findings describe code you already changed, or code you never wrote.
 
-## A Cloud Review Comment Does Nothing
+Check what GitHub thinks the pull request points at:
 
-Post `/prflow:review` as a standalone comment on the pull request's **Conversation** tab. Review-submission text and inline review comments are not subscribed trigger surfaces. The requester must be an authorized repository collaborator.
+```bash
+gh pr view <number> --json headRefOid,headRefName,baseRefName
+```
 
-## A Duplicate Review Was Suppressed
+A standalone review reads the pull request's pushed head and its current base. Push your local commits before you request a review, or the review reads the older head.
 
-PRFlow suppresses a second review request while a fresh progress comment shows a review of the same head commit in flight. Wait for that run. Push a new commit before requesting review again if the pull-request head has changed. Suppression depends on that progress comment being published: a request sent in the brief window before an in-flight review posts it is not suppressed, so two reviews of the same commit can occasionally run — this is harmless and self-heals as soon as the comment appears.
+If the pull request was retargeted, fetch the new base and try again. A deleted or unreachable base stops the review, because the diff cannot be established safely.
 
-## The Progress Comment Has No Verdict
+</Accordion>
 
-Check the last item of the comment's checklist first: **Run complete — everything this run owed**. On a standalone `/prflow:review` it is ticked only once the verdict has reached a durable channel — the formal GitHub review, or a marked comment when the review could not be posted. An unticked final item means the run ended without delivering, and the run states why. The comment's status field can read finished while that item is unticked; the item, not the status, is what tells you delivery happened.
+<Accordion title="My pull request was rejected over a documentation line, comment or test I touched">
 
-Note that a ticked item confirms a durable verdict exists, not that the pull request carries an approve or request-changes merge signal. When the verdict reached the comment channel instead of the reviews API, the run says so.
+**Symptom:** the verdict is REJECT, and the finding says that a documentation line, a release-note line, a code comment or a test that this change itself added or modified is untrue.
 
-Before it terminates, a standalone review re-reads its own checklist and makes one bounded attempt to complete a missing delivery. It does not retry beyond that one attempt.
+Read the finding and see the line it names:
 
-On `/prflow:review-and-fix`, which posts no verdict to GitHub at all, the same item is ticked when the fix loop reaches its terminal work. When that skill is driven inline by another run, its closing bookkeeping can be skipped and the item is left unticked; on that path this is a bookkeeping gap, not a missing verdict.
+```bash
+gh pr view <number> --json reviews --jq '.reviews[-1].body'
+gh pr diff <number>
+```
 
-If the item is still unticked, open the linked Actions run and inspect execution diagnostics for permission denials or an engine error. A failed run can flip the comment to `Review failed`. A configured backstop may post a bounded resume request, but it does not retry forever.
+This is a deliberate rule, not a severity judgment. When the change's own diff adds or modifies a line that is false — stale, contradicting the current code, or contradicting another part of the same change — that alone causes a REJECT.
 
-Fresh installs do not provide the old automatic `Devflow Review` status workflow. Do not add that status as a required check unless your repository deliberately retained and operates the legacy tier.
+<Warning>
+This REJECT cannot be lowered by configuration. It fires at every value of the severity threshold, including the most permissive one, and whatever severity the reviewing agent assigned it. Deferring the finding does not clear it either.
+</Warning>
 
-## The Run Stopped With `engine-root: incomplete`
+Only two things clear it:
 
-`/prflow:review-and-fix` reads PRFlow's review engine from your repository as a file, and confirms it received that file whole before it acts on it. When it cannot confirm that, it stops and reports `engine-root: incomplete` together with the path it read, rather than reviewing your pull request against a partly loaded engine. A run that stops this way has applied no fixes and reports no verdict, so nothing has been assessed.
+- Correct the untrue line so it matches the code.
+- Correct the code so the line becomes true.
+
+One narrow case is graded normally instead: prose that cannot change what the program does. A cosmetic wording problem in such prose is capped at Suggestion and drives no REJECT. Prose that a machine reads, or that instructs an agent, is not in that case.
+
+</Accordion>
+
+<Accordion title="The report says coverage could not be verified, or the verdict reads APPROVE WITH CAVEAT">
+
+**Symptom:** the pull request is approved, but the verdict line reads `APPROVE WITH CAVEAT`, or the summary contains a phrase beginning `shadow agreement not verified`.
+
+Read the verdict and the summary line together:
+
+```bash
+gh pr view <number> --json reviews --jq '.reviews[-1].body'
+```
+
+Both signals mean the same thing: the review found nothing that blocks the merge, and it could not confirm how much of its own checking actually happened. It says so rather than reporting a clean approval it cannot support.
+
+The common causes are:
+
+- The verification checklist could not be generated, so the phases that check each claim were skipped. That caps the verdict at `APPROVE WITH CAVEAT` and never lets it be a clean `APPROVE`.
+- Every finding sat below the fix loop's severity threshold, so the findings were parked as advisory rather than fixed.
+- The second, independent pass did not record that it ran with full coverage. The summary then reads `shadow agreement not verified`, sometimes with the reason in parentheses.
+
+Treat it as approved with unknown coverage. Read the report and decide as a human whether the gap matters. Requesting the review again is worth doing when the cause was transient. Nothing about this verdict means a defect was found and hidden.
+
+</Accordion>
+
+<Accordion title="I get too many findings, or too few">
+
+**Symptom:** every pull request comes back REJECT over small things, or obvious problems come back only as notes.
+
+Read the two settings that move those lines:
+
+```bash
+jq '{verdict: .prflow_review.verdict_severity_threshold, fix: .prflow_review_and_fix.fix_severity_threshold}' .prflow/config.json
+```
+
+| Setting | Default | What it does |
+| --- | --- | --- |
+| `prflow_review.verdict_severity_threshold` | `critical` | A finding at or above this severity causes REJECT. Set it to `important` to make Important findings block the merge too. Both `/prflow:review` and the review pass inside `/prflow:review-and-fix` use it. |
+| `prflow_review_and_fix.fix_severity_threshold` | `important` | The fix loop sends every finding at or above this severity to the fixer. Anything below it stays advisory. Set `suggestion` for a more aggressive fixer, or `critical` for a conservative one. |
+
+Severity runs `critical`, then `important`, then `suggestion`. An unknown or wrongly typed value falls back to the default with a note, and never stops the run. Any finding that would cause REJECT is always fixable, whatever the fix threshold says.
+
+Remember that the untrue-line rule above ignores both settings.
+
+</Accordion>
+
+<Accordion title="A cloud review comment does nothing">
+
+**Symptom:** you commented on the pull request and no run started.
+
+Post `/prflow:review` as a standalone comment on the pull request's **Conversation** tab. Review-submission text and inline review comments are not trigger surfaces, so a command typed into a code-review reply is never seen. The account that comments must be an authorized repository collaborator. See [Cloud-Run Problems](/docs/troubleshooting/cloud-runs) for the authorization check.
+
+</Accordion>
+
+<Accordion title="A duplicate review was suppressed">
+
+**Symptom:** you asked for a review and the run declined, saying one is already in flight for the same commit.
+
+PRFlow suppresses a second request while a fresh progress comment shows a review of the same head commit running. Wait for that run to finish. If the head has moved, push the new commit first and then ask again.
+
+Suppression depends on that progress comment already being published. A request sent in the short window before an in-flight review posts its comment is not suppressed, so two reviews of the same commit can occasionally run. That is harmless and clears itself once the comment appears.
+
+</Accordion>
+
+<Accordion title="The progress comment has no verdict">
+
+**Symptom:** the progress comment looks finished, but no verdict reached the pull request.
+
+Check the last item of the comment's checklist first: **Run complete — everything this run owed**. On a standalone `/prflow:review` that item is ticked only once the verdict has reached a durable channel — the formal GitHub review, or a marked comment when the review could not be posted. An unticked final item means the run ended without delivering, and the run states why. The comment's status field can read finished while that item is unticked. The item, not the status, is what tells you delivery happened.
+
+A ticked item confirms a durable verdict exists. It does not confirm the pull request carries an approve or request-changes merge signal. When the verdict reached the comment channel instead of the reviews API, the run says so.
+
+Before it ends, a standalone review re-reads its own checklist and makes one bounded attempt to complete a missing delivery. It does not retry beyond that one attempt.
+
+On `/prflow:review-and-fix`, which posts no verdict to GitHub at all, the same item is ticked when the fix loop reaches its terminal work. When that skill is driven by another run, its closing bookkeeping can be skipped and the item is left unticked. On that path this is a bookkeeping gap, not a missing verdict.
+
+If the item is still unticked, open the linked Actions run and look at the execution diagnostics for permission denials or an engine error:
+
+```bash
+gh run view <run-id> --log-failed
+```
+
+A failed run can flip the comment to `Review failed`. A configured backstop may post a bounded resume request, but it does not retry forever.
+
+Fresh installations do not include the old automatic `Devflow Review` status workflow. Do not add that status as a required check unless your repository deliberately kept and still operates that older tier.
+
+</Accordion>
+
+<Accordion title="The run stopped with engine-root: incomplete">
+
+**Symptom:** the run reports `engine-root: incomplete` together with the path it read, and applies no fixes.
+
+`/prflow:review-and-fix` reads PRFlow's review engine from your repository as a file, and confirms it received that file whole before acting on it. When it cannot confirm that, it stops rather than reviewing your pull request against a partly loaded engine. A run that stops this way has applied no fixes and reports no verdict, so nothing has been assessed.
 
 Check these in order:
 
 - **The engine file cannot be read.** Confirm the run can read `.prflow/vendor/prflow/skills/review/SKILL.md` in your repository. Fix file permissions, or re-run the installer with your current tag if the vendored copy is missing or incomplete — see [Cloud Updates](/docs/runs/cloud/updates).
 - **Your client cannot read a file in parts.** PRFlow confirms it reached the end of the engine file by reading past what it already holds. A client whose file reader does not accept a starting position cannot answer that question, so the run stops even when the file is intact. Run the workflow from a client whose file reader accepts a starting position.
 
-Note: When the run instead reports `engine-predicate: unread`, it is the rule it applies here that could not be read, and the named path is that rule's file. Check the same two causes against the named path.
+When the run instead reports `engine-predicate: unread`, it is the rule it applies here that could not be read, and the named path is that rule's file. Check the same two causes against the named path.
 
-The shadow pass reads the engine the same way. When the condition occurs there, the run does not stop — it reports a coverage gap for that pass and continues.
+The second, independent pass reads the engine the same way. When the condition occurs there, the run does not stop. It reports a coverage gap for that pass and continues.
 
-## The Review Did Not Apply My Prompt Extension
+</Accordion>
 
-`/prflow:review`, `/prflow:review-and-fix`, `/prflow:implement` and `/prflow:pr-description` read `.prflow/prompt-extensions/<skill>.md` through two independent channels, and both run on every applicable run. Where the client supports it, the extension is prepared as prompt text before the agent starts. Independently of that, the run also loads the extension through the bundled reader — unconditionally, whether or not the first channel delivered.
+<Accordion title="The review did not apply my prompt extension">
 
-Earlier releases made the second channel a fallback that applied only when the first had not delivered. On hosted runs the first channel is refused silently, and a run could skip the fallback and complete having applied none of your policy. That condition is gone: there is no longer a branch a run can decline to take. Where both channels deliver, they carry the same content and the run treats them as one set of instructions.
+**Symptom:** a run appears to ignore the policy you wrote in `.prflow/prompt-extensions/`.
+
+`/prflow:review`, `/prflow:review-and-fix`, `/prflow:implement` and `/prflow:pr-description` read `.prflow/prompt-extensions/<skill>.md` through two independent channels, and both run on every applicable run. Where the client supports it, the extension is prepared as prompt text before the agent starts. Independently of that, the run also loads the extension through the bundled reader, whether or not the first channel delivered.
+
+Earlier releases made the second channel a fallback that applied only when the first had not delivered. On hosted runs the first channel is refused silently, so a run could skip the fallback and finish having applied none of your policy. That condition is gone. Where both channels deliver, they carry the same content and the run treats them as one set of instructions.
 
 Check these when a run appears to ignore your policy:
 
-- **The extension is reported as `unestablished`.** The run states this rather than staying silent. It means the extension's state could not be established — an unreadable file, a broken symlink, something that is not a regular file, or a trusted-extension directory that did not materialize. Treat it as *not applied*, never as an empty extension. Fix the file and re-run.
+- **The extension is reported as `unestablished`.** The run states this rather than staying silent. It means the extension's state could not be established — an unreadable file, a broken symlink, something that is not a regular file, or a trusted-extension directory that did not materialize. Treat it as *not applied*, never as an empty extension. Fix the file and run again.
 - **The file name does not match the skill.** The name is the skill's own directory name: `review.md`, `review-and-fix.md`, `implement.md`, `pr-description.md`. `/prflow:review-and-fix` additionally reads `receiving-code-review.md`, because its fix loop applies that skill's principles without invoking it.
-- **An implement run left the row unticked.** A `/prflow:implement` workpad's Progress checklist carries one `prompt extension resolved: …` row per extension the run consumes. The row is written whether or not the run cooperates, so an unticked row is that run's own record that it did not establish that extension's state. On a run that finished `Complete`, that record is now deliberate rather than a bookkeeping miss: the finalize is refused while any such row is left both unticked and without an accompanying `state not established` note, so a completed workpad cannot silently carry a resolved-but-unrecorded row. It is still the run's report, not a verified fact — a ticked row is evidence the state was resolved, not proof the policy changed the outcome.
-- **A cloud installation is out of date.** The reader is invoked by the installed workflows' permission entries, while the skills themselves ship in the plugin. Updating only `prflow_version` can leave the two halves out of sync and the loader invocation unpermitted. Re-run the installer with the new tag — see [Cloud Updates](/docs/runs/cloud/updates).
+- **An implement run left the row unticked.** An implement workpad's Progress checklist carries one `prompt extension resolved: …` row per extension the run consumes. The row is written whether or not the run cooperates, so an unticked row is that run's own record that it did not establish that extension's state. On a run that finished Complete that record is deliberate: the finalize step is refused while any such row is left both unticked and without an accompanying `state not established` note. It is still the run's report, not a verified fact — a ticked row is evidence the state was resolved, not proof the policy changed the outcome.
+- **A cloud installation is out of date.** The reader is invoked by the installed workflows' permission entries, while the skills themselves ship in the plugin. Updating only `prflow_version` can leave the two halves out of sync and the loader unpermitted. Re-run the installer with the new tag — see [Cloud Updates](/docs/runs/cloud/updates).
 
 A file that is absent or empty is not an error. The run proceeds with PRFlow's own defaults.
+
+</Accordion>
+
+</AccordionGroup>
+
+## Related Articles
+
+- [Review](/docs/workflows/review)
+- [Review and Fix](/docs/workflows/review-and-fix)
+- [Review System](/docs/concepts/review-system)
+- [Review Settings](/docs/configuration/review)
+- [Prompt Extensions](/docs/configuration/prompt-extensions)

--- a/docs/external/docs/workflows/create-issue.md
+++ b/docs/external/docs/workflows/create-issue.md
@@ -1,51 +1,110 @@
 ---
 title: "Create an Issue"
-description: "Turn a rough request into an explicitly approved GitHub issue."
+description: "Turn a rough request into a GitHub issue you explicitly approved."
 ---
 
-Use this workflow when you want to record work in GitHub instead of implementing it now. It creates one issue only after you approve the final draft. The result is an approved issue or a visible unresolved blocker.
+Use this workflow when you want work recorded rather than built now.
 
-```text
-/prflow:create-issue Prevent duplicate release comments when a workflow retries
-```
+It creates one issue, and only after you approve the final draft. The result is an approved issue, or a draft that visibly names the decision nobody has made yet.
 
-The example uses Claude Code syntax. Use `/prflow/create-issue` in GitHub Copilot CLI or `$prflow:create-issue` in Codex CLI.
+## Run It
 
-## What to Provide
+<Steps>
+  <Step title="Describe the work in your own words">
+    ```text
+    /prflow:create-issue Prevent duplicate release comments when a workflow retries
+    ```
 
-A short feature idea, bug report or improvement is enough. Include the affected user, the desired outcome and any constraint that must not change when you know them.
+    A short feature idea, bug report or improvement is enough. Say who is affected, what outcome you want and anything that must not change, when you know them.
+  </Step>
+  <Step title="Answer the questions">
+    PRFlow reads the repository and its documentation before drafting, then asks focused questions until scope, behavior, dependencies, verification and the important edge cases are decided. For a bug report it collects what triggered the defect, what happened, what you expected instead and the environment.
 
-PRFlow inspects the repository and existing documentation before it drafts. It asks focused questions until scope, behavior, dependencies, verification and important edge cases are decided. When it reads your request as a bug report, it captures the facts needed to reproduce the defect — what triggered it, what happened, what you expected instead, and the environment — and records any fact nobody can establish as unestablished rather than guessing. If you explicitly decline to resolve a blocking decision, the draft records it in a visible Blocked section instead of inventing a default.
+    If nobody can establish a fact, PRFlow records it as unestablished rather than guessing.
+  </Step>
+  <Step title="Review the rendered draft">
+    PRFlow prints the complete title and body in chat, along with the supporting investigation as a separate, clearly labeled block.
+  </Step>
+  <Step title="Decide, then approve">
+    You choose whether to spend an audit round on the draft, then approve that exact draft or ask for changes, then choose whether to assign the issue to yourself. PRFlow creates nothing until those decisions are explicit.
+  </Step>
+</Steps>
+
+### What PRFlow Produces
+
+The issue body follows a fixed structure:
+
+| Section | Contents |
+| --- | --- |
+| `## Problem Statement` | Who is affected and what they cannot do today. |
+| `## Current Behavior` | What the code does now. |
+| `## Desired Behavior` | The intended outcome, stated as observable behavior. |
+| `## User Impact` | Who gains, and who is unaffected. |
+| `## Technical Context` | Known starting files, architecture fit, dependencies, data and cross-layer impact. |
+| `## Acceptance Criteria` | A checklist of independently testable outcomes. |
+| `## Implementation Notes` | Approach, relevant files and a testing strategy. |
+
+`## Dependencies` and `## 🚫 Blocked — resolve before implementation` are added when they apply.
+
+After creation you get the new issue's URL, and the `PRFlow` label is applied when repository permissions allow it.
+
+<Note>
+  The `## Technical Context` section opens with a scope note saying the listed files are starting points, not the full list. That is deliberate. The issue maps the work; it does not bound it.
+</Note>
+
+## The Second Comment Is Expected
+
+PRFlow splits its output into two artifacts, and you will see both.
+
+- **The issue body** is the implementer's brief. It holds only what a competent implementer cannot safely work out on their own: the problem, the desired behavior, non-obvious scope decisions, the acceptance criteria, real hazards and dependencies. It is the only channel an [implement](/docs/workflows/implement) run reads.
+- **The investigation record** is posted as the first comment on the created issue. It holds the narrative that produced those decisions: supporting evidence, audit history, lower-severity hazards, rejected alternatives and anything the repository would rediscover during implementation anyway.
+
+So a newly created issue normally has one comment on it already. That comment is PRFlow's, and nothing is missing from the body because of it.
+
+<Tip>
+  Set `create_issue.investigation_record_enabled` to `false` to stop that comment being posted. The default is `true`. The sorting between brief and record still happens on every draft — only publication is switched off, and the issue body is identical either way. PRFlow always shows you the investigation in chat, including when publication is disabled.
+</Tip>
+
+Splitting the two means an approver reviews the implementation contract rather than the whole investigation. It never drops a load-bearing detail to make the body shorter, and no length limit decides what stays.
 
 ## Approval Points
 
 PRFlow does not create an issue as soon as it has enough context.
 
-1. Review the complete title and body that PRFlow renders in chat.
-2. Choose whether to spend a fresh-context audit round on the draft. PRFlow offers one before it runs; a satisfied reviewer declines and the issue is filed unaudited. Each round you accept re-verifies the draft against the repository and takes time, so you pay only for the rounds you choose — the default is none.
-3. Approve that exact draft or request changes.
-4. Choose whether to assign the new issue to yourself.
-5. Let PRFlow create the issue after both decisions are explicit.
+1. Review the complete title and body rendered in chat.
+2. Choose whether to spend a fresh-context audit round on the draft. PRFlow offers one before it runs. Each round you accept re-verifies the draft against the repository and takes time, so you pay only for the rounds you choose. The default is none, and a satisfied reviewer declines.
+3. Approve that exact draft, or request changes.
+4. Choose whether to assign the new issue to yourself. Issues are created unassigned.
+5. PRFlow creates the issue once both decisions are explicit.
 
-An earlier instruction such as "just create it" does not replace approval of the final rendered draft. The `PRFlow` label is applied after creation when repository permissions allow it.
+<Warning>
+  An earlier "just create it" does not count as approval of the final rendered draft. PRFlow asks again against the actual text it is about to post.
+</Warning>
 
 ## Dependencies and Blockers
 
-Open prerequisite issues appear in a `Dependencies` section as `Blocked by #N`. The [implementation workflow](/docs/workflows/implement) reads these declarations and stops while a prerequisite remains open or cannot be resolved.
+These are two different sections and they mean different things.
 
-The Blocked section serves a different purpose. It contains unresolved product or implementation decisions. Resolve those decisions before starting implementation.
+`## Dependencies` lists open prerequisite issues as `Blocked by #N`. The [implement workflow](/docs/workflows/implement) reads those declarations and stops while a prerequisite is still open, or when it cannot establish whether it is open.
 
-## Expected Result
+`## 🚫 Blocked — resolve before implementation` lists unresolved product or implementation decisions. If you decline to settle a blocking decision, PRFlow records it here rather than inventing a default. Settle those before implementation starts.
 
-The issue contains a problem statement, current and desired behavior, user impact, technical context, acceptance criteria, implementation notes and a testing strategy. Desired behavior states the intended outcome. Acceptance criteria must represent every independently testable outcome in that section before PRFlow presents the draft for approval. Quantitative criteria include the command or counting rule that measures them.
+An issue is implementation-ready when its Blocked section holds no unresolved decision.
 
-The body is a minimum-sufficient implementation brief: it carries the decisions an implementer cannot safely derive on their own, and it keeps material only when removing it could change what gets built. The investigation that produced those decisions — supporting evidence, audit history and other detail the repository would rediscover during implementation — is recorded separately rather than mixed into the body, so an approver reviews the implementation contract instead of the whole investigation. This never drops a load-bearing detail to make the body shorter, and no length or size limit decides what stays.
+## Write Criteria You Want Checked
 
-The result is an approved issue. It is implementation-ready only when no unresolved decision remains in its Blocked section.
+Acceptance criteria must represent every independently testable outcome in Desired Behavior before PRFlow presents the draft. A quantitative criterion includes the command or counting rule that measures it.
 
-PRFlow offers implementation only when the issue has no unresolved blocking decision and the repository checks needed for the handoff succeeded. You can also run the [Implement workflow](/docs/workflows/implement) later with the new issue number.
+This matters beyond the draft: the acceptance criteria are what an implement run verifies at the end. An issue with no criteria gets a run with nothing to check at that gate. See [Implement an Issue](/docs/workflows/implement).
+
+## After Creation
+
+PRFlow offers to start implementation only when the issue has no unresolved blocking decision and the repository checks needed for the handoff succeeded. The offer posts the trigger comment on the new issue; it never starts implementing in the same session.
+
+You can also run [Implement](/docs/workflows/implement) later with the new issue number.
 
 ## Related Articles
 
 - [Implement an Issue](/docs/workflows/implement)
+- [The Lifecycle of a Change](/docs/concepts/lifecycle)
 - [Command Reference](/docs/reference/command-reference)

--- a/docs/external/docs/workflows/documentation.md
+++ b/docs/external/docs/workflows/documentation.md
@@ -1,50 +1,112 @@
 ---
 title: "Documentation"
-description: "Choose the PRFlow documentation workflow for branch changes, one topic or a new documentation set."
+description: "Keep developer docs, public docs and release notes in step with the code."
 ---
 
-Use this workflow guide when you want to verify or update documentation. The selected workflow can edit the documented files unless you choose report-only verification. A run returns updated documentation or a report that names the skipped work and any blocker.
+Use this guide to pick the PRFlow documentation command that matches what you need.
 
-## Choose a Documentation Workflow
+PRFlow has seven documentation commands. One is a router that runs three of the others in sequence; the rest do one job each. Every command except the report-only mode described below can edit files, and none of them commits.
 
-| **Need** | **Command** | **Behavior** |
-| --- | --- | --- |
-| Run a complete branch documentation pass | `docs` | Runs internal sync, external sync and release notes in sequence. Internal and external steps can be disabled by configuration. |
-| Update developer documentation for changed code | `docs-sync-internal` | Edits internal docs in proportion to functional changes on the current branch. |
-| Align existing public docs with internal docs or shipped behavior | `docs-sync-external` | Edits existing customer-facing docs and removes internal-only detail. Both internal and external documentation trees must already exist. |
-| Verify one named topic and fix its internal docs | `docs-verify <topic>` | Compares the topic's documentation with code and edits missing or inaccurate internal docs. |
-| Inspect one topic without changing files | `docs-verify --report-only <topic>` | Returns a structured code and documentation findings report with no edits, commits or pushes. |
-| Create or reorganize developer docs from scratch | `docs-bootstrap-internal` | Builds a domain-based internal documentation structure with substantive seed pages. |
-| Create or comprehensively rebuild public docs | `docs-bootstrap-external` | Generates customer-facing docs from existing internal documentation. Stops if the internal source is absent or empty. |
-| Add a customer-facing release note | `docs-release-notes` | Adds a note only for customer-visible changes and reconciles an applicable changelog entry. |
+## Pick a Command
+
+| Your need | Command |
+| --- | --- |
+| A general documentation pass before merge | `/prflow:docs` |
+| Update developer docs for code you changed | `/prflow:docs-sync-internal` |
+| Bring public docs in line with what shipped | `/prflow:docs-sync-external` |
+| Check and fix the docs for one topic | `/prflow:docs-verify <topic>` |
+| Understand one topic, with no file changes | `/prflow:docs-verify --report-only <topic>` |
+| Build developer docs from nothing | `/prflow:docs-bootstrap-internal` |
+| Build public docs from the developer docs | `/prflow:docs-bootstrap-external` |
+| Add a release note for a customer-visible change | `/prflow:docs-release-notes` |
+
+<Note>
+  Use a **sync** command when the documentation tree already exists. Use a **bootstrap** command when it is absent, empty or needs a full rebuild.
+</Note>
 
 ## Run the Complete Pass
 
-Use `docs` when a branch needs a general documentation check before merge:
+<Steps>
+  <Step title="Run it on the branch you are about to merge">
+    ```text
+    /prflow:docs
+    ```
+  </Step>
+  <Step title="Watch three steps run in order">
+    Internal developer docs first, then external docs aligned against them, then release notes. Steps one and two are each switched on or off by configuration; step three is always evaluated and does nothing when your repository has no release-notes artifacts.
+  </Step>
+  <Step title="Read the final summary and commit yourself">
+    `/prflow:docs` does not commit. That is left to you, or to the [implement](/docs/workflows/implement) run that called it.
+  </Step>
+</Steps>
 
-```text
-/prflow:docs
-```
+### What the Final Summary Says
 
-The router first updates internal developer docs, then aligns external docs and finally evaluates release notes. It does not commit its changes. A caller such as [Implement](/docs/workflows/implement) owns the commit.
+Each step ends in exactly one of four outcomes, and the summary names one per step:
 
-## Sync or Bootstrap
+| Outcome | Meaning |
+| --- | --- |
+| completed | The step ran to its own completion. |
+| skipped | Switched off by configuration. |
+| failed | The step errored. |
+| unestablished | Whether the step should run could not be determined. |
 
-Use a sync command when the relevant documentation tree already exists. Use a bootstrap command when the tree is absent, empty or needs a comprehensive rebuild.
+The summary also lists the internal files added or edited, the public-doc impact list carried forward from step one, the external files added or edited and whether a release note was added or skipped, with the reason.
 
-External documentation depends on an internal source of truth. Run `docs-bootstrap-internal` first when internal docs do not exist. `docs-bootstrap-external` refuses to fabricate public guidance without that source.
+<Warning>
+  A failed or unestablished step is reported as itself, never rolled up into a clean pass. If a configuration read was refused rather than answered, the summary says `unestablished` and the step still runs, because the switches default to on. Read the summary; do not assume a run that finished did everything.
+</Warning>
 
-## Verify Without Editing
+## The Two Switches
 
-The default `docs-verify` mode can change internal documentation. Add `--report-only` when you need analysis without file changes.
+| Setting | Default | Effect when `false` |
+| --- | --- | --- |
+| `docs.internal_enabled` | `true` | `/prflow:docs` skips the internal-docs step. |
+| `docs.external_enabled` | `true` | `/prflow:docs` skips the external-docs alignment step. |
 
-```text
-/prflow:docs-verify --report-only retry handling
-```
+Both affect the combined pass only. Running `/prflow:docs-sync-internal` or `/prflow:docs-sync-external` directly ignores them.
 
-Create Issue uses this report-only mode to inspect a topic before it drafts a ticket.
+The locations themselves come from `docs.internal` (default `docs/internal/`) and `docs.external` (default `docs/external/`). See [Documentation and Retrospectives](/docs/configuration/documentation-and-retrospectives).
+
+## External Docs Need an Internal Source
+
+`/prflow:docs-bootstrap-external` generates public documentation from your internal documentation. If the internal location is empty or absent, it stops and tells you to run `/prflow:docs-bootstrap-internal` first.
+
+<Note>
+  This refusal is deliberate. Without an internal source of truth, generated public guidance would be invented rather than derived, and a confidently wrong public doc is worse than a missing one.
+</Note>
+
+## Verify One Topic Without Changing Files
+
+<Steps>
+  <Step title="Name the topic">
+    ```text
+    /prflow:docs-verify --report-only retry handling
+    ```
+  </Step>
+  <Step title="Read the report">
+    Nothing is edited, committed or pushed. The working tree is unchanged when the run finishes.
+  </Step>
+</Steps>
+
+The report has a fixed shape:
+
+- **Doc reliability** — one of `RELIABLE`, `UNRELIABLE` or `ABSENT`. It describes the internal documentation only. A wrong default in a schema or a stale code comment is reported under current behavior instead and does not move this signal.
+- **Relevant code files** — the files that implement the topic, marked to show the minimum set someone must read, with file and line references for the entry points, guards and writers.
+- **Current behavior** — what the code actually does today, including the failure paths and non-obvious couplings you would otherwise find the hard way.
+- **Search space surveyed** — the file set this run looked at.
+- **Duty statuses** and **bearing observations** — what the run established and what it did not.
+
+<Tip>
+  `ABSENT` means no internal document covers the topic. If the documentation location itself could not be read, the run says so instead — an absence it could not establish is not an established absence.
+</Tip>
+
+[Create an Issue](/docs/workflows/create-issue) uses this same report-only mode to understand a topic before drafting a ticket.
+
+Drop `--report-only` and the same command fixes the internal documentation it found wrong.
 
 ## Related Articles
 
+- [Implement an Issue](/docs/workflows/implement)
+- [Documentation and Retrospectives](/docs/configuration/documentation-and-retrospectives)
 - [Command Reference](/docs/reference/command-reference)
-- [Configuration Settings](/docs/configuration/settings)

--- a/docs/external/docs/workflows/implement.md
+++ b/docs/external/docs/workflows/implement.md
@@ -1,78 +1,170 @@
 ---
 title: "Implement an Issue"
-description: "Turn an existing GitHub issue into a review-ready or draft pull request with recorded verification evidence."
+description: "Turn an open GitHub issue into a draft pull request with recorded verification evidence."
 ---
 
-Use this workflow when you have an open GitHub issue with actionable acceptance criteria. It can create a branch, commit and push changes and create or update a pull request. The result is a review-ready or draft pull request with recorded verification evidence, or a Blocked result naming the required human action.
+Use this workflow when an open GitHub issue describes work you want built.
 
-```text
-/prflow:implement 123
+It creates a branch, commits and pushes changes and opens a pull request. The result is a pull request with recorded verification evidence, or a Blocked result that names the human action needed to continue.
+
+## Run It
+
+<Steps>
+  <Step title="Pick an open issue">
+    You need the issue number. The issue does not have to be perfect, but the more precisely it states the outcome you want, the closer the result lands. See [Create an Issue](/docs/workflows/create-issue) for how PRFlow writes one.
+  </Step>
+  <Step title="Start the run">
+    In Claude Code:
+
+    ```text
+    /prflow:implement 123
+    ```
+
+    Or, if you installed the cloud tier, leave this as a comment on issue 123 itself:
+
+    ```text
+    /prflow:implement 123
+    ```
+
+    The comment form works on an issue only, not on a pull request. Only a comment body triggers a run, so a command written in the issue description starts nothing.
+  </Step>
+  <Step title="Watch the workpad">
+    Within a minute or two, a comment appears on the issue. This is the workpad: the single place the run records what it is doing. It is created before any code is written and updated in place for the rest of the run.
+  </Step>
+  <Step title="Read the result">
+    The run ends with the workpad at one of the terminal statuses below and, on success, a pull request linked from the workpad's `PR:` line.
+  </Step>
+</Steps>
+
+### What the Workpad Looks Like
+
+The freshly created workpad is a checklist of the whole run. For example:
+
+```markdown
+# PRFlow Workpad — Issue #123
+
+**Status:** 🚀 Setup
+**Branch:** `issue-123-prevent-duplicate-release-comments`
+**Run:** _(local run)_
+**PR:** _not yet created_
+**Last updated:** 2026-08-26 09:14 UTC
+
+## Progress
+- [ ] **Setup** — branch & workpad
+  - 09:14:22 — /prflow:implement run started
+- [ ] **Implement**
+  - [ ] code + sweeps
+- [ ] **Review**
+  - [ ] `/simplify`
+  - [ ] `review-and-fix`
+  - [ ] acceptance-criteria gate
+- [ ] **Documentation**
+- [ ] **PR marked ready**
+
+## Plan
+- [ ] _(planning in progress)_
+
+## Acceptance Criteria
+_(pending — mirrored from the issue when the run begins)_
 ```
 
-The example uses Claude Code syntax. Use `/prflow/implement 123` in GitHub Copilot CLI or `$prflow:implement 123` in Codex CLI.
+The `Status` line is the fastest way to read a run. It moves through Setup, Discovering, Reproducing, Planning, Implementing, Reviewing and Documenting, and ends at one of four terminal words:
+
+| Status | Glyph | Meaning |
+| --- | --- | --- |
+| Complete | 🎉 | The run finished everything it owed. |
+| Blocked | 👎 | The run stopped on purpose and recorded why. A human decides what happens next. |
+| Failed | 💥 | The run itself broke. |
+| Cancelled | 🛑 | The run was stopped before it finished. |
+
+The branch is named `issue-<number>-<title-slug>`, with a date suffix added when that name is already taken.
+
+<Tip>
+  A run you interrupt is resumable. Start it again with the same issue number and it adopts the same branch, the same workpad and the same pull request instead of creating a second set. See [Workpads and Resume](/docs/concepts/workpads-and-resume).
+</Tip>
 
 ## What PRFlow Does
 
-PRFlow runs all four implementation phases:
+The run has four phases:
 
 1. Fetch the issue, parse its acceptance criteria and create or resume its workpad.
-2. Create or adopt the issue branch, discover the affected code, plan the change, implement it and test it.
+2. Create or adopt the issue branch, explore the affected code, plan the change, write it and test it.
 3. Open a draft pull request, simplify the change and run the review-and-fix loop.
-4. File required follow-up issues, update documentation, refresh the pull request description and finalize the run.
+4. File any required follow-up issues, update documentation, refresh the pull request description and finish.
 
-The issue defines the intended outcome. Before implementation begins, PRFlow checks that its acceptance criteria represent every independently testable outcome in Desired Behavior. An uncovered outcome blocks the run for issue refinement instead of becoming an inferred criterion or being omitted from review. PRFlow also verifies the issue's repository claims against the current tree before using them as implementation instructions.
+The issue defines the intended outcome. Before implementation starts, PRFlow checks the issue's own claims about the repository against the current tree rather than trusting them, and it checks that the acceptance criteria cover every independently testable outcome the issue's Desired Behavior section states. An outcome no criterion covers stops the run for issue refinement. PRFlow never invents a criterion to fill the gap.
 
-## Branch and Workpad Behavior
+## Bug Reports Must Be Reproduced First
 
-The workpad is the single GitHub issue comment that records the run's branch, status, plan, progress, mirrored acceptance criteria and notable problems. The review phase records its classification, verification checklist, reviewer and verdict stages in that same workpad instead of creating a separate progress comment on the draft pull request. A resumed run updates the same workpad instead of creating another one.
+<Warning>
+  When PRFlow classifies an issue as a bug report, reproducing the defect is a hard gate, not a best effort. If it cannot reproduce the bug, the run stops at Blocked and records the obstacle. It does not proceed to write a fix for a defect it never observed.
+</Warning>
 
-PRFlow checks for an existing open pull request before it creates a branch. It can adopt a validated issue branch or resume the pull request head.
+PRFlow decides "is this a bug report?" from what the issue's title and body describe, not from the `bug` label and not from a sentence in the issue telling it how to classify. A reproduction is one of three things: a failing test, a quoted error log or a recorded shell command. Whichever it captures is written into a `## Reproduction` section of the workpad, and planning cannot start until that section has content.
 
-PRFlow stops before changing existing branch history when:
+If the reproduction was not a failing test, PRFlow writes one before it writes the fix, and confirms it fails for the right reason first.
 
-- It finds commits on the feature branch that are not in the base branch and cannot link them to the issue.
-- It cannot establish evidence linking the workpad to this issue and pull request.
+## Acceptance Criteria Decide What Gets Checked
+
+Before the documentation stage, every in-scope acceptance criterion must be supported by a passing test, a documented manual check or a code reference. Two independent checkers run in a fresh context and have to agree; if they disagree, the criterion counts as unestablished and blocks, exactly as a failing one would.
+
+A criterion that can only be confirmed in a real deployed environment stays unticked and moves to the pull request's Post-Merge Verification section.
+
+<Warning>
+  An issue with no acceptance criteria does not fail this gate — it passes it, because there is nothing to check. A prose-only issue therefore gets a run with no criteria gate at the end of it. If you want that gate to mean something, write acceptance criteria in the issue. PRFlow still stops when the issue's Desired Behavior section states a testable outcome no criterion covers, but an issue that states no such outcomes leaves nothing to compare against.
+</Warning>
+
+When a large issue deliberately defers some criteria to a later pull request, PRFlow files follow-up issues before it finishes and discloses them in the pull request description. Deferral never marks the work complete quietly.
+
+## When a Run Stops
+
+A Blocked result is a normal outcome, not a crash. The workpad's status becomes `👎 Blocked` and the reason is recorded in the workpad. No pull request is published, so nothing half-finished reaches your reviewers.
+
+PRFlow stops before touching existing history when:
+
+- The feature branch has commits that are not in the base branch and cannot be linked to the issue.
+- It cannot establish that the workpad belongs to this issue and pull request.
 - It cannot resolve the base reference.
 - A merge is already in progress.
 
-If a previous workpad is Blocked, a local run surfaces the reason and waits for confirmation before it proceeds.
+It stops early when the issue declares an open `Blocked by #N` dependency, or when it cannot establish whether that dependency is still open.
 
-## Dependencies and Other Blockers
+Later stopping points include a bug it could not reproduce, an acceptance criterion that fails or cannot be established, a verification command the run is not permitted to execute and an unresolved Critical review finding. Before publishing, PRFlow also confirms the branch tip reached the remote; if a commit was made but never landed there, the run stops rather than publish a pull request whose description cites a commit the remote does not have.
 
-PRFlow stops early when an issue declares an open `Blocked by #N` dependency. It also stops when the dependency state cannot be established.
+<Accordion title="What to do about a Blocked run">
+  Read the reason on the workpad first — it names the specific obstacle.
 
-Later blockers include a failing in-scope acceptance criterion, an ungranted verification command and an unresolved Critical review finding. Final-tree verification that does not produce a clean result in the run environment also blocks completion. Before publishing, PRFlow also confirms the local branch tip has reached the remote; if a commit was made but not pushed and a push does not land it, the run stops with a Blocked result rather than publishing a pull request whose description cites a commit the remote does not have.
+  - **Cannot reproduce.** Add the missing detail to the issue: the exact trigger, the environment, the observed and expected behavior. Then run the command again.
+  - **An uncovered outcome in Desired Behavior.** The workpad quotes the exact sentence no criterion covers. Add a criterion for it, or narrow the Desired Behavior section.
+  - **An open dependency.** Close or unblock the prerequisite issue, then run again.
+  - **A verification command that is not permitted.** Grant it in your tool-permission settings. See [Tool Permissions](/docs/configuration/tool-permissions).
 
-Continuous integration remains a post-pull-request merge gate. It does not replace verification inside the implementation run.
+  Running the command again after the fix resumes the same workpad and the same branch. It does not start over.
+</Accordion>
+
+Continuous integration is a post-pull-request merge gate. It never stands in for the verification the run does inside its own environment.
 
 ## Draft Pull Request and Review
 
-The pull request is created as a draft before the review phase. PRFlow runs a simplification pass and the review-and-fix loop while the pull request is still a draft.
+The pull request is opened as a draft, titled with the issue title, before the review phase begins. PRFlow runs a simplification pass and then the review-and-fix loop while the pull request is still a draft, so your reviewers see the converged state rather than every intermediate one.
 
-Non-Critical residual findings can be surfaced for human review after bounded re-review. A genuine unresolved Critical finding blocks the run.
+Non-Critical findings that survive bounded re-review are surfaced for human judgment. A genuine unresolved Critical finding blocks the run.
 
-PRFlow never merges the pull request.
+## Ready or Draft
 
-## Acceptance Criteria and Deferred Work
+The `prflow_implement.implement_pr_state` setting decides the final state:
 
-Every in-scope acceptance criterion must be supported by a passing test, a documented manual check or a code reference. A criterion that requires a real deployed environment stays unticked and appears in the pull request's Post-Merge Verification section.
+- `ready_for_review` — the default. PRFlow marks the pull request ready after final verification.
+- `draft` — the pull request stays a draft for a human to publish.
 
-When a multi-pull-request issue deliberately defers criteria, Phase 4 files follow-up issues before finalization. Review findings that are intentionally deferred also receive follow-up issues and are disclosed in the pull request description. Deferral does not silently mark the work complete.
+The workpad can reach Complete either way. If publication was requested and failed, the workpad records the failure and the pull request stays a draft until a human resolves it.
 
-## Ready or Draft Outcome
-
-The `prflow_implement.implement_pr_state` setting controls the final pull request state:
-
-- `ready_for_review` is the default. PRFlow runs `gh pr ready` after final verification.
-- `draft` leaves the pull request as a draft for a human to publish later.
-
-The workpad can reach Complete in either case. If publication was requested but failed, the workpad records the failure and the pull request stays unpublished until a human resolves it.
-
-Human reviewers and repository protections own the merge decision. PRFlow prepares the branch and evidence, but it does not approve or merge its own work.
+Human reviewers and your branch protection rules own the merge decision. PRFlow prepares the branch and the evidence. It does not approve or merge its own work.
 
 ## Related Articles
 
 - [Review](/docs/workflows/review)
 - [Review and Fix](/docs/workflows/review-and-fix)
-- [Cloud Runs](/docs/runs/cloud/index)
-- [Configuration Settings](/docs/configuration/settings)
+- [Workpads and Resume](/docs/concepts/workpads-and-resume)
+- [Verification](/docs/concepts/verification)
+- [Implementation Settings](/docs/configuration/implementation)

--- a/docs/external/docs/workflows/index.md
+++ b/docs/external/docs/workflows/index.md
@@ -1,42 +1,72 @@
 ---
 title: "Workflows"
-description: "Choose the PRFlow workflow that matches the outcome and edit authority you want."
+description: "Pick the PRFlow workflow that matches the outcome you want and the edit authority you are willing to grant."
 ---
 
-Choose the smallest PRFlow workflow that can produce the outcome you need with the appropriate edit authority.
+Pick the smallest PRFlow workflow that produces the outcome you need with the least edit authority.
 
-The diagram uses PRFlow skill names without a client-specific command prefix. The command examples below show how to invoke them in each supported client.
+PRFlow commands are Claude Code skills. You run them as `/prflow:<skill>` in Claude Code, and you run four of them by leaving a comment on a GitHub issue or pull request. See [Local Runs](/docs/runs/local/index) and [Cloud Runs](/docs/runs/cloud/index) for the difference.
 
 ![A map of PRFlow skills grouped by outcome. The core delivery skills are prflow:create-issue, prflow:implement, prflow:review and prflow:review-and-fix. Supporting skills are prflow:pr-description, prflow:docs and prflow:retrospective-weekly.](/images/workflow-skill-map.svg)
 
+## The Delivery Path
+
+These four workflows carry a piece of work from an idea to a pull request a human can merge.
+
+<CardGroup cols={2}>
+  <Card title="Create an Issue" icon="circle-plus" href="/docs/workflows/create-issue">
+    Turn a rough idea or bug report into one approved GitHub issue. Creates nothing until you approve the final draft.
+  </Card>
+  <Card title="Implement an Issue" icon="code" href="/docs/workflows/implement">
+    Turn an open issue into a pull request. Creates a branch, commits code and docs, pushes and opens a pull request.
+  </Card>
+  <Card title="Review" icon="magnifying-glass" href="/docs/workflows/review">
+    Assess a pull request or branch and return a verdict. Never edits the reviewed tree.
+  </Card>
+  <Card title="Review and Fix" icon="wrench" href="/docs/workflows/review-and-fix">
+    Assess the same way, then correct what it finds. Commits to the active branch.
+  </Card>
+</CardGroup>
+
+## Supporting Workflows
+
+<CardGroup cols={2}>
+  <Card title="Pull Request Description" icon="file-lines" href="/docs/workflows/pr-description">
+    Write or refresh a pull request body from the current branch.
+  </Card>
+  <Card title="Documentation" icon="book" href="/docs/workflows/documentation">
+    Keep developer docs, public docs and release notes in step with the code.
+  </Card>
+  <Card title="Weekly Retrospective" icon="arrows-rotate" href="/docs/workflows/retrospective-weekly">
+    Learn from recently merged pull requests and file the findings for human triage.
+  </Card>
+</CardGroup>
+
 ## Choose a Workflow
 
-| **Goal** | **Workflow** | **What It Can Change** | **Expected Result** |
-| --- | --- | --- | --- |
-| Turn an idea or bug report into a ticket | [Create an Issue](/docs/workflows/create-issue) | Creates one approved GitHub issue | An approved issue. It is implementation-ready only when its Blocked section has no unresolved decision. |
-| Complete an existing issue | [Implement](/docs/workflows/implement) | Creates a branch, commits code and docs, pushes and opens a pull request | A review-ready or draft pull request with recorded verification evidence, or a Blocked result naming the required human action |
-| Assess a pull request or branch | [Review](/docs/workflows/review) | Does not edit the reviewed tree | Findings and an APPROVE or REJECT verdict |
-| Assess changes and authorize corrections | [Review and Fix](/docs/workflows/review-and-fix) | Commits corrections to the target branch | Corrections followed by recorded verification, or a report naming unresolved findings |
-| Generate or refresh a pull request body | [Pull Request Description](/docs/workflows/pr-description) | Updates the current branch's pull request body when one exists | A structured, current description |
-| Maintain developer docs, public docs or release notes | [Documentation](/docs/workflows/documentation) | Edits the selected documentation files | Documentation aligned with the current change |
-| Learn from recently merged pull requests | [Weekly Retrospective](/docs/workflows/retrospective-weekly) | Updates learning records, opens or updates a state pull request and files selected GitHub issues | A state pull request, human-triage issues and a report |
+Read down the "Your goal" column until you find your case.
 
-Use `review` for an assessment with no code edits. Use `review-and-fix` only when you explicitly authorize PRFlow to make and commit corrections.
+| Your goal | Use | What it may change |
+| --- | --- | --- |
+| Record work instead of building it now | [Create an Issue](/docs/workflows/create-issue) | Creates one GitHub issue, after you approve the draft |
+| Complete an issue that already exists | [Implement](/docs/workflows/implement) | Branch, commits, push, one draft pull request |
+| Get an opinion on a pull request or branch | [Review](/docs/workflows/review) | Nothing in the reviewed tree |
+| Get the problems found and corrected | [Review and Fix](/docs/workflows/review-and-fix) | Commits on the active branch |
+| Make a pull request body match the code | [Pull Request Description](/docs/workflows/pr-description) | The pull request body only |
+| Catch documentation up with a change | [Documentation](/docs/workflows/documentation) | The documentation files you select |
+| Find recurring delivery problems | [Weekly Retrospective](/docs/workflows/retrospective-weekly) | Learning records, one state pull request, new issues |
 
-## Command Syntax
+<Note>
+  `review` and `review-and-fix` share the same review engine and produce the same findings. The difference is authority: `review` reports, `review-and-fix` edits. Use `review-and-fix` only when you want PRFlow to change your branch.
+</Note>
 
-PRFlow commands use different prefixes in supported local clients:
+## What No Workflow Does
 
-| **Client** | **Example** |
-| --- | --- |
-| Claude Code | `/prflow:review 123` |
-| GitHub Copilot CLI | `/prflow/review 123` |
-| Codex CLI | `$prflow:review 123` |
-
-Supported GitHub comment commands always use the Claude-style `/prflow:` prefix. See the [command reference](/docs/reference/command-reference) for arguments, availability and mutation authority.
+No PRFlow workflow merges a pull request, and none of them approves its own work. Merge stays with your reviewers and your branch protection rules. See [Human Control](/docs/concepts/human-control).
 
 ## Related Articles
 
 - [Command Reference](/docs/reference/command-reference)
+- [The Lifecycle of a Change](/docs/concepts/lifecycle)
 - [Local Runs](/docs/runs/local/index)
 - [Cloud Runs](/docs/runs/cloud/index)

--- a/docs/external/docs/workflows/pr-description.md
+++ b/docs/external/docs/workflows/pr-description.md
@@ -1,43 +1,90 @@
 ---
 title: "Pull Request Description"
-description: "Generate or update a structured pull request description from the current branch."
+description: "Write or refresh a structured pull request body from the current branch."
 ---
 
-Use this workflow when you want the current branch's pull request body to match the current code. It can update an existing pull request body but does not edit branch files. The result is an updated pull request body or a complete description in chat when no pull request exists.
+Use this workflow when a pull request body no longer matches the code it describes.
 
-```text
-/prflow:pr-description 123
-```
+It updates an existing pull request body and never edits branch files. When no pull request exists yet, it prints the finished description instead of creating one.
 
-The issue number is optional. When provided, PRFlow adds `Resolves #123` and reads the issue for context.
+## Run It
+
+<Steps>
+  <Step title="Start from the branch you want described">
+    In Claude Code, with the branch checked out:
+
+    ```text
+    /prflow:pr-description 123
+    ```
+
+    The issue number is optional. When you supply one, PRFlow adds `Resolves #123` and reads that issue for context.
+
+    On the cloud tier, comment on the pull request's Conversation tab with the bare command:
+
+    ```text
+    /prflow:pr-description
+    ```
+
+    This is one of the four commands a cloud install answers from a GitHub comment. A comment-triggered run describes the pull request it was posted on, so it takes no number.
+  </Step>
+  <Step title="Check the result">
+    If the branch already has a pull request, its body is updated in place. If it does not, the full description is printed for you to paste when you open one.
+  </Step>
+</Steps>
+
+### What Gets Written
+
+The generated body uses a fixed set of sections:
+
+| Section | Contents |
+| --- | --- |
+| `## Summary` | One to three bullets saying what changed and why. |
+| `## Changes` | The changes grouped by area or concern, one line per area. |
+| `## Resolves` | `Resolves #N`. Omitted when no issue number is known. |
+| `## Test Plan` | Concrete verification steps as a checklist. |
+| `## Post-Merge Verification` | Items that can only be checked after merge or deploy. Omitted when there are none. |
+| `## Deferred Findings` | Review findings deliberately left for later. Omitted when there are none. |
+
+`## Visual Changes` and `## Breaking Changes` are added when the diff calls for them.
 
 ## What PRFlow Reads
 
-PRFlow compares the current branch with the base branch. It reads the commit history, diff summary and detailed diff. When a related implementation workpad exists, it also carries post-merge verification items into the pull request body.
+PRFlow compares the current branch against the base branch and reads the commit history, the diff summary and the detailed diff. When the branch came from an [implement](/docs/workflows/implement) run, it also carries that run's post-merge verification items into the body.
 
-Deferred review findings filed by the implementation workflow appear in a Scope-Acknowledged Findings section. This keeps the human disclosure with the information PRFlow uses to recognize the finding later.
+## Refreshing an Existing Body
 
-## Existing Pull Request
+Regenerated every run, from the current diff: Summary, Changes, Visual Changes, Breaking Changes, Post-Merge Verification and Deferred Findings.
 
-When the current branch already has a pull request, PRFlow updates its body directly. Generated sections such as Summary, Changes, Visual Changes and Breaking Changes are refreshed from the current diff.
+Your own content survives:
 
-Human content is preserved:
+- Test Plan items you added stay, as long as they still apply. Items for changes that no longer exist are removed.
+- Existing issue links stay alongside a newly supplied issue number.
+- Custom sections such as Reviewer Notes or Deploy Steps keep their position.
+- Anything outside PRFlow's body markers stays outside them.
+- A body with no markers at all is preserved above the newly generated section rather than replaced.
 
-- Human-added Test Plan items remain when they are still relevant.
-- Existing issue links remain alongside a newly supplied issue number.
-- Custom sections such as Reviewer Notes or Deploy Steps retain their position.
-- Content outside the PRFlow body markers remains outside those markers.
-- An unmarked existing body is preserved above the newly generated marked section.
+## Scope-Acknowledged Findings
 
-## No Existing Pull Request
+A scope-acknowledged finding is a real review finding the team decided not to fix in this pull request. It appears in the `## Deferred Findings` section as a table: the severity, the file, a one-line summary and the follow-up issue that now owns it.
 
-When no pull request exists, PRFlow does not create one. It outputs the complete description as plain text so a caller or user can supply it when creating the pull request.
+This is a disclosure, not a dismissal. It exists so a reviewer reading the pull request can see what was consciously left undone, and so a later [review](/docs/workflows/review) recognizes the finding instead of raising it again as new.
 
-## Expected Result
+<Warning>
+  A deferral holds only while its follow-up issue is open and linked to the finding in both directions. Close that issue, unlink it or delete the disclosure and the deferral stops applying — the next review raises the finding again and it blocks as it originally would have. A deferral parks a finding. It does not resolve it.
+</Warning>
 
-The generated body contains a concise summary, grouped changes, issue links, a concrete test plan and applicable post-merge, deferred, visual and breaking-change sections.
+One kind of deferral has no follow-up issue: a finding settled by disclosure, where writing the caveat down *is* the deliverable. Those rows cite the document that carries the disclosure instead of an issue number, and a later review re-checks that the document still says it.
+
+<Note>
+  Because a settled-by-disclosure entry has no follow-up issue, the pull request body is its only durable record. PRFlow therefore never wipes an existing Deferred Findings block when it regenerates a body — it merges rather than overwrites.
+</Note>
+
+## When There Is No Pull Request
+
+PRFlow does not create one. It outputs the complete description as plain text so you, or whatever opens the pull request, can supply it.
 
 ## Related Articles
 
 - [Implement an Issue](/docs/workflows/implement)
+- [Review](/docs/workflows/review)
 - [Command Reference](/docs/reference/command-reference)

--- a/docs/external/docs/workflows/retrospective-weekly.md
+++ b/docs/external/docs/workflows/retrospective-weekly.md
@@ -1,58 +1,107 @@
 ---
 title: "Weekly Retrospective"
-description: "Run PRFlow's local, human-governed learning loop over recently merged pull requests."
+description: "Turn recurring delivery problems from merged pull requests into a small number of issues for human triage."
 ---
 
-Use this workflow when you want to turn recurring delivery problems into bounded issues for human triage. It changes the local checkout and writes learning records. It can also create GitHub issues and a state pull request. The result is a report with those records or explicit blockers.
+Use this workflow when you want PRFlow to learn from what it already shipped.
 
-This is a mutating local workflow. It requires a clean working tree and can switch the checkout to `main`. It writes learning records, opens or updates a state pull request and files selected findings as GitHub issues. It never edits product code or merges a pull request.
+It reads recently merged pull requests, records what went well or badly, looks for patterns that repeat and proposes a bounded number of GitHub issues for a human to triage. It never edits product code and never merges anything.
 
-```text
-/prflow:retrospective-weekly
+## Run It
+
+<Steps>
+  <Step title="Start from a clean tree on main">
+    ```text
+    /prflow:retrospective-weekly
+    ```
+
+    This is a local command. It is not available as a GitHub comment command and it is not scheduled for you.
+  </Step>
+  <Step title="Let the preflight checks pass">
+    The run confirms the working tree is clean, that the GitHub CLI is authenticated and that `main` is checked out. It switches to `main` itself when needed.
+  </Step>
+  <Step title="Read the report and triage">
+    The run prints a report, links the state pull request and lists every issue it filed. Everything after that is yours to decide.
+  </Step>
+</Steps>
+
+<Warning>
+  This workflow changes your local checkout. It requires a clean working tree, may switch you to `main`, writes learning records, opens or updates a pull request and creates GitHub issues. Commit or stash your work before running it. A non-empty `git status` stops the run rather than proceeding.
+</Warning>
+
+### What You Get Back
+
+The report opens with a summary of the scan. For example:
+
+```markdown
+# DevFlow Weekly Report
+
+**Run finished:** 2026-08-26T09:41:07Z
+
+## Summary
+PRs scanned: 12
+clean (no analysis): 8
+analyzed: 4
+skipped: 0
 ```
 
-This workflow runs locally. It is not a scheduled cloud command.
+Below that, sections appear only when they have content: the patterns found this run, patterns that regressed after being fixed, the filing queue, patterns a cap withheld, issues filed, patterns skipped by cooldown and any blockers.
 
-## Prerequisites
+<Note>
+  The report still carries the product's former name in its heading. It is the same report. See [Migrate From DevFlow](/docs/getting-started/migrate-from-devflow).
+</Note>
 
-Before it starts, PRFlow requires:
+When there is nothing new, the run says so and stops:
 
-- A clean working tree.
-- An authenticated GitHub CLI session. Run `gh auth login` if authentication fails.
-- The repository's `main` branch checked out. PRFlow switches to `main` when needed.
-
-The clean-tree requirement prevents unrelated changes from entering the retrospective state pull request.
+```text
+Nothing to process — no unprocessed watched-author PRs in the last 7 days.
+```
 
 ## What It Scans
 
-The normal weekly scan finds watched-author pull requests that were merged in the last seven days and are not already recorded as processed. Pull requests with no signal that warrants further analysis receive a compact clean entry. Other eligible pull requests receive a bounded retrospective analysis.
+The weekly scan finds pull requests by the watched authors that merged in the last seven days and are not already recorded as processed. A pull request with no signal worth analyzing gets a short clean entry. The rest get a bounded analysis.
 
-PRFlow writes the results to `.prflow/learnings/` and derives recurring actionable patterns. It limits how many pull request records are used to reassess each pattern.
+PRFlow then writes the results to its learning records and derives the patterns that recur across them.
 
-## Bounded Proposals
+<Tip>
+  To re-run the loop over a specific set of pull requests — backfilling old ones, or re-checking after a fix — pass `--prs` with a comma-separated list instead of using the rolling seven-day window. Everything downstream behaves identically.
+</Tip>
 
-Filing controls limit the number of issues created in one run, the total number of open retrospective issues and the number open in one category. A pattern with missing evidence or an invalid cap is withheld instead of filed speculatively.
+## Filing Is Deliberately Bounded
 
-Each selected finding becomes one GitHub issue for human triage. The issue proposes the smallest change that could prevent another occurrence.
+A learning loop that files freely produces a backlog nobody reads. Five settings keep the volume down:
 
-## State Pull Request
+| Setting | Default | Limits |
+| --- | --- | --- |
+| `prflow_retrospective.min_occurrences` | 2 | How often a pattern must recur before it can be filed at all. |
+| `prflow_retrospective.max_issues_per_run` | 3 | Issues filed in one run. |
+| `prflow_retrospective.max_open_issues` | 10 | Open retrospective issues in total. |
+| `prflow_retrospective.max_open_per_category` | 2 | Open retrospective issues in one category. |
+| `prflow_retrospective.cooldown_days` | 3 | How long before the same pattern can be filed again. |
 
-PRFlow opens or updates a separate state pull request containing the retrospective records. It returns to `main` before it files proposed issues.
+A pattern with missing evidence is withheld rather than filed on a guess, and the report names which cap withheld what, so a withheld pattern is visible rather than silently dropped.
 
-Review the state pull request and merge it manually after continuous integration passes. PRFlow never merges it.
+Each filed issue proposes the smallest change that could stop the problem happening again.
 
-## Human Governance Boundary
+## The State Pull Request
 
-The retrospective loop does not edit product code. It does not implement its proposed issues and does not merge any pull request.
+PRFlow opens or updates a separate pull request holding the retrospective records, then returns to `main` before it files any issues.
 
-Humans decide which findings are worth pursuing. Selected issues then move through the normal [Implement](/docs/workflows/implement) and [Review](/docs/workflows/review) workflows.
+Review that pull request and merge it yourself once continuous integration passes. PRFlow never merges it.
 
-## Expected Result
+## Where Humans Decide
 
-The run returns a report, a state pull request, any filed issues and explicit blockers. A later run processes only newly eligible pull requests and avoids refiling an already tracked pattern.
+<Note>
+  The retrospective loop does not edit product code, does not implement the issues it proposes and does not merge any pull request. It proposes; you triage.
+</Note>
+
+Pick the findings worth acting on and run them through the normal [Implement](/docs/workflows/implement) and [Review](/docs/workflows/review) workflows. The loop never starts that for you.
+
+Re-running is safe. The next run processes only pull requests it has not already recorded, and it does not refile a pattern it already filed this cycle.
 
 ## Related Articles
 
 - [Create an Issue](/docs/workflows/create-issue)
 - [Implement an Issue](/docs/workflows/implement)
+- [Documentation and Retrospectives](/docs/configuration/documentation-and-retrospectives)
 - [Glossary](/docs/reference/glossary)

--- a/docs/external/docs/workflows/review-and-fix.md
+++ b/docs/external/docs/workflows/review-and-fix.md
@@ -1,62 +1,123 @@
 ---
 title: "Review and Fix"
-description: "Review a pull request or branch, apply authorized corrections and record verification."
+description: "Review a pull request or branch, correct what the review finds and record the verification."
 ---
 
-Use this workflow when you explicitly authorize PRFlow to assess changes and commit corrections. It changes the active branch and can push when requested. The result is corrections followed by recorded verification, or a report naming unresolved findings.
+Use this workflow when you want the problems found and corrected in one pass.
 
-```text
-/prflow:review-and-fix 123
-```
+It runs the same review engine as [Review](/docs/workflows/review), then fixes what it finds and commits as it goes. The result is a converged branch with recorded verification, or a report naming the findings it could not resolve.
 
-The optional arguments are `[pull request number] [--push-each-iteration] [--issue N]`. Omit the pull request number to use the current branch. Use `--issue N` when the review should verify a specific issue's acceptance criteria.
+## Run It
 
-## Edit Authority and Target Boundaries
+<Steps>
+  <Step title="Start the loop">
+    In Claude Code, on a pull request:
 
-This workflow applies fixes directly in the active session. It creates commits as it converges.
+    ```text
+    /prflow:review-and-fix 123
+    ```
 
-In pull request mode, PRFlow checks out the pull request head and verifies both the branch name and head commit before it reviews or edits. A dirty working tree that prevents checkout stops the run. In current-branch mode, commits land on the checked-out branch.
+    Omit the number to work on the current branch. The full argument list is `[pull request number] [--push-each-iteration] [--issue N]`, and you can pass any, all or none of them.
 
-Use assessment-only [Review](/docs/workflows/review) when you do not want branch changes.
+    On the cloud tier, comment on the pull request's Conversation tab with the bare command:
 
-## Iterations and Severity Routing
+    ```text
+    /prflow:review-and-fix
+    ```
 
-The loop runs the full review engine, verifies each finding, fixes the actionable set and reviews the new commit again. The default cap is five iterations. Configure `prflow_review_and_fix.max_iterations` to change it.
+    This is one of the four commands a cloud install answers from a GitHub comment. A comment-triggered run acts on the thread it was posted on, so it takes no number.
+  </Step>
+  <Step title="Let it iterate">
+    Each iteration runs the full review engine, verifies each finding before acting on it, fixes the ones that qualify, commits and reviews the new commit. The default cap is five iterations.
+  </Step>
+  <Step title="Read the loop result">
+    The loop ends with a verdict, the list of reviewers that completed and any known coverage gaps, all in chat.
+  </Step>
+</Steps>
 
-The default fix threshold is `important`:
+### What You Get Back
 
-- Critical and Important findings route to the fixer.
-- Suggestion findings stay advisory unless the threshold is changed to `suggestion`.
-- A threshold of `critical` routes only Critical findings to the fixer.
+The final chat report opens with a one-line result. On an approval-side outcome it names how many iterations ran and whether the independent shadow pass agreed, in the shape "Review passed after *N* iteration(s) (*shadow status*)". On an approval with parked findings it also states how many advisory findings were left for human review. A REJECT says so and the findings stay in the report below it.
 
-PRFlow can push back on a finding when the code disproves it. It can also defer a real finding when the documented deferral rules apply. Test failures introduced by a fix must be corrected before the loop continues.
+Underneath the headline is the same report structure as a standalone review: the verdict, issue compliance, the verification-checklist tally and the findings grouped by severity. Each finding also carries what the loop decided about it — applied, pushed back, deferred, advisory or severity-calibrated.
+
+The commits it made are on your branch, one per fix iteration.
+
+<Note>
+  This workflow does not post a formal GitHub review. Its verdict goes to chat. To get a merge signal on the pull request, run [Review](/docs/workflows/review) afterward — a separate, independent pass over the fixed head.
+</Note>
+
+## Edit Authority
+
+This workflow applies fixes directly in the session that runs it, and commits as it converges.
+
+In pull request mode it checks out the pull request head and confirms both the branch name and the head commit before it reviews or edits anything. A working tree too dirty to check out stops the run. In current-branch mode the commits land on the branch you already have checked out.
+
+Use [Review](/docs/workflows/review) when you do not want your branch changed.
+
+## Iterations and What Gets Fixed
+
+The default iteration cap is five. Change it with `prflow_review_and_fix.max_iterations`. The loop also exits early when it converges.
+
+Which findings reach the fixer is set by `prflow_review_and_fix.fix_severity_threshold`, which defaults to `important`:
+
+| Threshold | Fixed | Left advisory |
+| --- | --- | --- |
+| `critical` | Critical only | Important, Major, Suggestion, Minor |
+| `important` (default) | Critical, Important, Major | Suggestion, Minor |
+| `suggestion` | Everything | Nothing |
+
+Anything that drives a REJECT is always fixable, whatever this threshold says. That is deliberate: it means no combination of settings can produce a blocking finding the fixer is configured to ignore.
+
+PRFlow can push back on a finding when the code disproves it, rather than "fixing" something that was never wrong. It can also defer a genuine finding when the deferral rules apply. A test broken by one of its own fixes must be repaired before the loop continues.
 
 ## Push Behavior
 
-Fix commits stay local by default. Add `--push-each-iteration` to push each completed fix iteration and the final loop state to the feature branch.
+Where the fix commits end up depends on how you started the run.
 
-The flag does not post a formal verdict. It only keeps the remote branch and its continuous integration runs current.
+**Locally**, they stay on your branch and are not pushed. Add `--push-each-iteration` to push each completed iteration and the final loop state to the feature branch, which keeps the remote branch and its continuous integration runs current.
+
+**From a pull request comment**, the run pushes its fix commits to the pull request branch, so the fixes are on the pull request when the run finishes. You do not pass the flag, and could not — the workflow builds the command from the command word and the thread number alone, so any extra argument in a comment is ignored.
+
+<Note>
+  Pushing never posts a verdict. It only moves commits. To get a merge signal, run [Review](/docs/workflows/review) afterward.
+</Note>
 
 ## Shadow Review
 
-Before an approval-side conclusion, PRFlow runs a separate shadow review over the candidate. The shadow pass reports which planned reviewers completed and any known coverage gaps. A run with no reported gap still does not prove that the review found every defect.
+Before it concludes on the approval side, PRFlow runs a separate shadow review over the candidate. The shadow pass reports which planned reviewers completed and any coverage gaps it knows about.
 
-Shadow agreement narrows the chance of a false clean result. It does not replace a human review or create a formal merge signal.
+<Note>
+  Shadow agreement narrows the chance of a false clean result. It does not close it. A run reporting no gap has not proved that the review found every defect, and it is not a substitute for a human review or a formal merge signal.
+</Note>
 
-## Formal Review Boundary
+When the shadow pass cannot confirm its own coverage, the report says agreement was not verified rather than claiming agreement.
 
-Review-and-fix skips the standalone review workflow's attempt to post a formal verdict. Its final verdict, completed-reviewer list and known gaps go to chat. A standalone pull-request run can maintain its own progress comment, but that comment is not a substitute for a formal GitHub review. When implementation runs this loop inline, the review stages appear in the issue workpad instead of a separate pull-request progress comment.
+### When the Shadow Pass Finds Something Too Late
 
-Run an independent assessment after the fixes converge:
+The shadow pass can surface a new finding after the loop has already used its iterations. Rather than quietly approving or silently dropping it, the run reports a distinct result:
+
+```text
+Review converged after 5 iteration(s) but a final shadow pass surfaced 2 new
+Important finding(s) that the loop could not address within the iteration cap.
+See report.
+```
+
+Read this as an approval with known, unaddressed findings, listed in the report below the headline. Treat those findings as work still to do. Raise `prflow_review_and_fix.max_iterations` and run the loop again, or fix them yourself, before you merge.
+
+## Getting a Merge Signal Afterward
+
+Once the loop converges, run an independent assessment:
 
 ```text
 /prflow:review 123
 ```
 
-That standalone run reviews the resulting pull request head and attempts to post the formal merge signal. If GitHub refuses it, PRFlow reports the fallback channel and that the merge signal is missing. Neither workflow merges the pull request.
+That run reviews the resulting pull request head from scratch and attempts to post the formal GitHub review. If GitHub refuses the post, PRFlow reports which fallback channel it used and that the merge signal is missing. Neither workflow merges the pull request.
 
 ## Related Articles
 
 - [Review](/docs/workflows/review)
 - [Implement an Issue](/docs/workflows/implement)
-- [Configuration Settings](/docs/configuration/settings)
+- [How the Review System Works](/docs/concepts/review-system)
+- [Review Settings](/docs/configuration/review)

--- a/docs/external/docs/workflows/review.md
+++ b/docs/external/docs/workflows/review.md
@@ -1,48 +1,111 @@
 ---
 title: "Review"
-description: "Assess a pull request or branch without changing the reviewed tree."
+description: "Assess a pull request or branch and get a verdict, without changing the reviewed code."
 ---
 
-Use this workflow when you want findings, verification results and a review verdict for human evaluation without authorizing code edits. It does not change the reviewed tree. The result is a report and verdict, or a report naming incomplete checks and any missing GitHub review signal.
+Use this workflow when you want findings and a verdict, and no edits.
 
-```text
-/prflow:review 123
-```
+It never changes the reviewed tree. The result is a report with a verdict, or a report naming the checks it could not complete.
 
-Omit the pull request number to review the current branch against the configured base branch. Add `--issue N` to use a specific issue's acceptance criteria.
+## Run It
 
-## Review Targets
+<Steps>
+  <Step title="Start the review">
+    In Claude Code, review a pull request by number:
 
-In pull request mode, PRFlow reviews the pushed pull request head and uses the pull request's base. Local uncommitted changes are not included.
+    ```text
+    /prflow:review 123
+    ```
 
-In current-branch mode, PRFlow reviews committed changes between `HEAD` and the configured `base_branch`. Commit the changes you want assessed before starting.
+    Omit the number to review the current branch against the configured base branch. Add `--issue N` to check the change against a specific issue's acceptance criteria.
 
-## What the Review Covers
+    On the cloud tier, comment on the pull request's Conversation tab with the bare command:
 
-The review engine classifies the diff, builds and verifies a change-specific checklist, runs specialized review agents and aggregates the results. It evaluates correctness, silent failures, tests, type design, issue compliance and relevant review comments.
+    ```text
+    /prflow:review
+    ```
 
-A failed or inconclusive verification checklist item causes REJECT. Code findings cause REJECT when they meet the configured verdict severity threshold. Lower-severity findings remain visible as notes.
+    A comment-triggered run always reviews the thread it was posted on, so it takes no number. A number typed after the command is ignored.
+  </Step>
+  <Step title="Wait for the phases to finish">
+    The engine classifies the diff, builds a verification checklist specific to that change, verifies each item, dispatches its review agents and aggregates the results into one verdict.
+  </Step>
+  <Step title="Read the report">
+    A current-branch run returns the report in chat. A pull request run also posts a formal GitHub review, and maintains a progress comment on the pull request while it works.
+  </Step>
+</Steps>
 
-## Mutation Boundary
+### What You Get Back
 
-Review does not edit, commit, check out or push the reviewed tree. It can write ephemeral review scratch data and, in pull request mode, maintain a progress comment and post the final GitHub review.
+The report is one Markdown document with a fixed set of sections, in this order:
 
-Use [Review and Fix](/docs/workflows/review-and-fix) only when you explicitly want PRFlow to correct verified findings.
+- **`## Verdict:`** — one of the five verdicts below, followed by a short summary in parentheses. This is the first line, so it is what a reader sees first.
+- **`## Issue Compliance`** — which issue the change was checked against, where the acceptance criteria came from, and whether this run narrowed the scope. When no issue was found, it says compliance was not checked rather than implying it passed.
+- **`## Verification Checklist Results`** — a single tally line in the form "*N* passed, *N* failed, *N* inconclusive", then one line per failing or inconclusive item, each quoting the claim and the file and line it came from. Passing items are collapsed behind an expandable block.
+- **`## Code Review Findings`** — findings grouped under `### 🔴 Critical`, `### 🟠 Important / Major`, `### 🟡 Suggestion / Minor` and `### ℹ️ Informational — Deferred`. Empty groups are omitted. Each finding says how many of the dispatched agents raised it, so you can tell a corroborated finding from a single-source one.
+- **`## Verdict Criteria`** — the rules that produced the verdict, so the decision is auditable rather than asserted.
 
-## Expected Result
+Failing and inconclusive items are never collapsed. Everything that blocks is visible without expanding anything.
 
-Current-branch mode returns the full report and verdict in chat.
+## What Gets Reviewed
 
-Pull request mode also attempts to post a formal GitHub review:
+In pull request mode, PRFlow reviews the pushed pull request head against the pull request's base. Uncommitted local changes are not included.
 
-- A clean APPROVE posts an approval.
-- REJECT posts a request for changes.
-- An approval-side verdict with notes or a caveat posts a comment review.
+In current-branch mode, it reviews committed changes between `HEAD` and the configured base branch. Commit what you want assessed before you start.
 
-If the formal review cannot be posted, PRFlow records the report through the available fallback channel and reports that the merge signal is missing. PRFlow never merges the pull request.
+Four review agents always run: a general code reviewer, a silent-failure hunter, a comment-accuracy analyzer and a final-pass independent reviewer. Two more run only when the diff calls for them — a type-design analyzer when the change adds new types, and a test analyzer when the change touches test files or adds new testable logic. See [Review Agents](/docs/configuration/review-agents).
+
+## The Verdicts
+
+The engine emits one of five verdicts.
+
+| Verdict | Meaning |
+| --- | --- |
+| APPROVE | No findings, and every checklist item passed. |
+| APPROVE with notes | Findings exist, but all of them are below the configured severity threshold. |
+| APPROVE WITH ADVISORY NOTES | Approved, with findings deliberately parked for a human to judge. |
+| APPROVE WITH CAVEAT | Approved, but verification coverage was incomplete — for example, the verification checklist could not be generated. |
+| REJECT | At least one blocking problem. On a pull request this posts a request for changes. |
+
+<Note>
+  An APPROVE from PRFlow is a machine verdict on one diff. It is not a human approval and it does not merge anything. Treat it as evidence for your reviewers, not as a substitute for them.
+</Note>
+
+## What Causes a REJECT
+
+Three things drive a REJECT.
+
+1. **A failed verification-checklist item.** A claim the change depends on was checked and found untrue.
+2. **An inconclusive verification-checklist item.** The claim could not be established either way, so it needs a manual check. Unknown is not treated as fine.
+3. **A finding at or above the configured severity threshold.** The default threshold is `critical`, so by default only Critical findings block. Set `prflow_review.verdict_severity_threshold` to `important` or `suggestion` to make the line stricter. Findings below the line stay visible as notes.
+
+### The Rule That Surprises People
+
+<Warning>
+  If the change's own diff added or modified a documentation line, a code comment or a test that is **untrue**, that alone causes a REJECT — at every threshold setting, and whatever severity the finding was graded. Severity settings cannot lower it, deferring it does not clear it, and one agent raising it is enough. Only correcting the untrue claim, or the code it describes, clears the REJECT.
+</Warning>
+
+"Untrue" means the claim is stale, contradicts the code as it now stands, or contradicts another part of the same change. The rule covers the change's own additions and edits, not prose that was already there.
+
+The narrow exception is wording that cannot affect behavior in either direction — a purely cosmetic phrasing problem in a message or a comment with no wrong output, no corrupted state and no skipped guard. That is capped as a Suggestion and does not block at the default threshold. A false claim is never treated as a wording problem.
+
+<Accordion title="Why this rule exists">
+  A change that ships a comment or a doc line describing behavior it does not have is worse than one that ships no comment at all: the next reader trusts it. The same applies to a test whose assertion does not match what the change claims to guarantee.
+
+  Because the cost lands on a future reader rather than on today's run, a severity grade would let it be tuned away. So the rule sits outside severity entirely.
+</Accordion>
+
+## What Review Never Touches
+
+Review does not edit, commit, check out or push the reviewed tree. It writes temporary scratch data, and in pull request mode it maintains a progress comment and posts the final GitHub review.
+
+If the formal review cannot be posted, PRFlow records the report through whatever channel remains available and tells you the merge signal is missing. It never merges the pull request.
+
+Use [Review and Fix](/docs/workflows/review-and-fix) when you want the findings corrected as well as reported.
 
 ## Related Articles
 
 - [Review and Fix](/docs/workflows/review-and-fix)
+- [How the Review System Works](/docs/concepts/review-system)
 - [Review Agents](/docs/configuration/review-agents)
-- [Command Reference](/docs/reference/command-reference)
+- [Review Settings](/docs/configuration/review)

--- a/docs/external/index.mdx
+++ b/docs/external/index.mdx
@@ -37,7 +37,7 @@ mode: "custom"
     <div className="mt-9 flex flex-col items-center justify-center gap-3 sm:flex-row">
       <a
         data-home-primary-cta
-        href="/docs/getting-started/installation"
+        href="/docs/quickstart"
         className="inline-flex min-h-12 items-center justify-center rounded-full border border-[#593e2e] bg-[#593e2e] px-6 py-3 font-semibold text-[#F2E6D8] no-underline shadow-[0_8px_24px_rgba(89,62,46,0.24)] transition hover:-translate-y-0.5 hover:shadow-[0_12px_30px_rgba(89,62,46,0.3)]"
       >
         Get started <span aria-hidden="true" className="ml-2">→</span>

--- a/lib/test/brand-devflow-buckets.json
+++ b/lib/test/brand-devflow-buckets.json
@@ -166,6 +166,9 @@
       "path": "agents/deferral-drafter.md"
     },
     {
+      "path": "docs/external/docs/getting-started/index.md"
+    },
+    {
       "path": "docs/external/docs/getting-started/initialization.md"
     },
     {
@@ -173,6 +176,15 @@
     },
     {
       "path": "docs/external/docs/getting-started/migrate-from-devflow.md"
+    },
+    {
+      "path": "docs/external/docs/getting-started/updates.md"
+    },
+    {
+      "path": "docs/external/docs/reference/glossary.md"
+    },
+    {
+      "path": "docs/external/docs/workflows/retrospective-weekly.md"
     },
     {
       "path": "docs/internal/DEVFLOW_SYSTEM_OVERVIEW.md"

--- a/lib/test/run.sh
+++ b/lib/test/run.sh
@@ -18830,7 +18830,6 @@ _936_EXPECTED="$(cat <<'EOF'
 CLAUDE.md
 README.md
 docs/external/docs/reference/release-notes-archive-2026.md
-docs/external/docs/runs/cloud/installation.md
 docs/internal/DEVFLOW_SYSTEM_OVERVIEW.md
 docs/internal/cloud-allowlist.md
 docs/internal/cloud-setup.md


### PR DESCRIPTION
## Summary

A full audit and rebuild of the public documentation at `docs/external/`, ahead of introducing PRFlow to a large developer audience. **57 → 62 pages: 55 rewritten, 5 new.** Every user-visible claim was verified against the code rather than copied from the internal docs.

## The critical fix

The docs presented PRFlow as a three-client product and printed install, update and init commands for GitHub Copilot CLI and Codex CLI — `copilot plugin marketplace add …`, `codex plugin add …`, `/prflow/implement`, `$prflow:implement`. **None of those commands exist anywhere in this repository.** They were invented, inconsistent between pages, and spread across 17 pages. A developer following the Copilot tab would have hit a command that fails.

Claude Code is now the single documented client. One honest `<Note>` on the installation page — the only place the site mentions other clients — records that Claude Code plugins are largely compatible and that PRFlow has been verified in Copilot CLI, Codex CLI, Codex Desktop and VS Code agent modes, and points readers at each client's own plugin instructions. No commands are printed for them.

## Other corrections, each proved against a file

| Was | Is |
| --- | --- |
| "Two public cloud commands" | Four — `implement` on an issue comment; `review`, `review-and-fix` and `pr-description` on a pull request comment |
| `review-and-fix` and `pr-description` marked local only | Both are cloud comment commands |
| Reviewer roster listed five focus areas as always-on | Four always-on, including the final-pass reviewer the docs omitted; type-design and test analyzers are conditional |
| Verdict labels documented nowhere | All five defined, plus the sixth the fix loop emits at its iteration cap |
| A surprising REJECT rule undocumented | A doc line, comment or test the diff itself made untrue blocks at every severity threshold, non-demotably; only a fix clears it |
| Bug reproduction "when possible" | A hard gate — unreproducible means Blocked |
| Test suite described as running twice | Once, before the draft pull request opens |
| Implementation and reviewer effort fallback unstated | Absent resolves to `high`, so removing the key raises effort |
| Dependency phrases incomplete | Five, including `follow-up to #N`, which reads as prose and silently blocks |
| Cloud trigger debugging pointed at one workflow | Both workflow files, with which command each serves |
| Cloud setup omitted the reviewer App | Documented, with the consequence for required-approving-review protection |
| Fix-commit push behavior hedged | A local run pushes only with `--push-each-iteration`; a comment-triggered run pushes to the pull request branch |

Also added, as an honesty item: an issue with no acceptance criteria passes that gate trivially, so `Complete` on such a run does not mean the outcome was verified.

## New pages

- **Quickstart** — install to pull request on one page, with the real workpad and status glyphs.
- **Security and Trust** — what PRFlow can write, who can trigger a cloud run, the base-branch trust boundary (with a diagram), untrusted content treated as data, the read-only reviewer path. States plainly that prompt-injection defenses are a mitigation, not a proof.
- **How PRFlow Verifies a Change** — what "recorded verification evidence" means, and that an unknown result is never a pass.
- **Prompt Extensions** — the supported customization channel, previously documented only inside a troubleshooting entry, so users found it only when it broke.
- **Request a Review Automatically on Green CI** — the supported replacement for the withheld auto-review tier, with its `pull_request_target` warning carried alongside the snippet.

`docs/index.md` is now an introduction that states the problem PRFlow solves, compares it with a raw coding agent, and says what PRFlow does not do.

## Quality

- Mintlify components: **1 page → 58**.
- Glossary: **18 terms → 39**, covering every term a user meets in PRFlow's own output.
- Diagrams: four SVGs preserved, mermaid 2 → 4.
- Configuration's two overlapping hub pages became a hub plus an A-to-Z index of all settings.
- Every procedure page carries a worked example, with output quoted from the code rather than invented.

## Verification

A tree-wide check confirms all pages are registered in `docs.json`, every internal link resolves, frontmatter is present on every page, no fabricated client commands remain, and no internal phase numbers or issue numbers leaked. Release notes, styles and images are untouched. The landing page changed by one line: its primary call to action now points at the new Quickstart.

Two navigation warnings are pre-existing and deliberate — `index` and `release-notes` are reached from the site root and the header anchor rather than the sidebar.

No changeset: the versioning policy scopes to the engine surface (`skills/`, `agents/`, `lib/`, `scripts/`, workflows, config schema), and this change touches only the published documentation site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
