### PR TITLE
fix: name the vendored literal first in prompt-surface-growth.py's invocation contract

### DIFF
--- a/.changeset/prompt-surface-growth-vendored-literal-first.md
+++ b/.changeset/prompt-surface-growth-vendored-literal-first.md
@@ -10,9 +10,4 @@ and the vendored literal as a parenthetical alternative, which is inverted for t
 tier: only the vendored literal is granted in the `implement` and `command` profiles, so a
 cloud run following the docstring order spends a permission denial before reaching the form
 that works. Ordering matches the ladder `.prflow/prompt-extensions/pr-description.md`
-already prescribes. The same docstring's claim that the `python3 <path>` interpreter-head
-form "is denied by the cloud permission matcher" is also corrected: two cloud implement runs
-ran `python3 scripts/prompt-surface-growth.py` to a result under the granted `Bash(python3:*)`
-head, so the claim steered runs away from a form that works. The correction is scoped to this
-helper and asserts nothing about the interpreter head in general. Docstring only — no
-behaviour change.
+already prescribes. Docstring only — no behaviour change.

--- a/.changeset/prompt-surface-growth-vendored-literal-first.md
+++ b/.changeset/prompt-surface-growth-vendored-literal-first.md
@@ -10,4 +10,9 @@ and the vendored literal as a parenthetical alternative, which is inverted for t
 tier: only the vendored literal is granted in the `implement` and `command` profiles, so a
 cloud run following the docstring order spends a permission denial before reaching the form
 that works. Ordering matches the ladder `.prflow/prompt-extensions/pr-description.md`
-already prescribes. Docstring only — no behaviour change.
+already prescribes. The same docstring's claim that the `python3 <path>` interpreter-head
+form "is denied by the cloud permission matcher" is also corrected: two cloud implement runs
+ran `python3 scripts/prompt-surface-growth.py` to a result under the granted `Bash(python3:*)`
+head, so the claim steered runs away from a form that works. The correction is scoped to this
+helper and asserts nothing about the interpreter head in general. Docstring only — no
+behaviour change.

--- a/.changeset/prompt-surface-growth-vendored-literal-first.md
+++ b/.changeset/prompt-surface-growth-vendored-literal-first.md
@@ -1,0 +1,13 @@
+---
+bump: patch
+---
+
+`scripts/prompt-surface-growth.py`'s invocation contract now names the vendored literal
+`.prflow/vendor/prflow/scripts/prompt-surface-growth.py` as the form to try FIRST, with the
+repo-relative `scripts/prompt-surface-growth.py` as the fallback for a checkout where the
+vendored path does not resolve. The previous wording named the repo-relative spelling first
+and the vendored literal as a parenthetical alternative, which is inverted for the cloud
+tier: only the vendored literal is granted in the `implement` and `command` profiles, so a
+cloud run following the docstring order spends a permission denial before reaching the form
+that works. Ordering matches the ladder `.prflow/prompt-extensions/pr-description.md`
+already prescribes. Docstring only — no behaviour change.

--- a/scripts/prompt-surface-growth.py
+++ b/scripts/prompt-surface-growth.py
@@ -29,9 +29,12 @@ and a checkout with nothing to measure — exits 0 with a stated breadcrumb
 instead of a table. A table of zeros is deliberately never printed: a reader would
 misread it as "this PR added nothing", which is worse than no table at all.
 
-Invoke it as a direct leading token (`scripts/prompt-surface-growth.py`, or the
-vendored `.prflow/vendor/prflow/scripts/…` literal on the cloud tier) — the
-`python3 <path>` interpreter-head shape is denied by the cloud permission matcher.
+Invoke it as a direct leading token, the vendored literal
+(`.prflow/vendor/prflow/scripts/prompt-surface-growth.py`) FIRST, falling back to the
+repo-relative `scripts/prompt-surface-growth.py` only where that path does not resolve:
+the repo-relative spelling is granted in no cloud profile, so leading with it spends a
+denial before the working form is reached. The `python3 <path>` interpreter-head shape
+is denied by the cloud permission matcher.
 
 stdlib-only; shells out to `git` alone, honoring a non-probing `DEVFLOW_GIT` override
 in the same shape `scripts/checkout-fingerprint.py` uses (`git` is a hard preflight

--- a/scripts/prompt-surface-growth.py
+++ b/scripts/prompt-surface-growth.py
@@ -33,12 +33,7 @@ Invoke it as a direct leading token, the vendored literal
 (`.prflow/vendor/prflow/scripts/prompt-surface-growth.py`) FIRST, falling back to the
 repo-relative `scripts/prompt-surface-growth.py` only where that path does not resolve:
 the repo-relative spelling is granted in no cloud profile, so leading with it spends a
-denial before the working form is reached. Do not re-add a claim that the interpreter-head
-`python3 <path>` form is denied for this helper: cloud implement runs 32957163134 and
-32936014504 each ran `python3 scripts/prompt-surface-growth.py` to a result under the
-granted `Bash(python3:*)` head, so steering away from it costs a denial for nothing. That
-measurement scopes this helper alone and settles nothing about the interpreter head in
-general, which only `.github/workflows/matcher-probe.yml` can.
+denial before the working form is reached.
 
 stdlib-only; shells out to `git` alone, honoring a non-probing `DEVFLOW_GIT` override
 in the same shape `scripts/checkout-fingerprint.py` uses (`git` is a hard preflight

--- a/scripts/prompt-surface-growth.py
+++ b/scripts/prompt-surface-growth.py
@@ -33,8 +33,12 @@ Invoke it as a direct leading token, the vendored literal
 (`.prflow/vendor/prflow/scripts/prompt-surface-growth.py`) FIRST, falling back to the
 repo-relative `scripts/prompt-surface-growth.py` only where that path does not resolve:
 the repo-relative spelling is granted in no cloud profile, so leading with it spends a
-denial before the working form is reached. The `python3 <path>` interpreter-head shape
-is denied by the cloud permission matcher.
+denial before the working form is reached. Do not re-add a claim that the interpreter-head
+`python3 <path>` form is denied for this helper: cloud implement runs 32957163134 and
+32936014504 each ran `python3 scripts/prompt-surface-growth.py` to a result under the
+granted `Bash(python3:*)` head, so steering away from it costs a denial for nothing. That
+measurement scopes this helper alone and settles nothing about the interpreter head in
+general, which only `.github/workflows/matcher-probe.yml` can.
 
 stdlib-only; shells out to `git` alone, honoring a non-probing `DEVFLOW_GIT` override
 in the same shape `scripts/checkout-fingerprint.py` uses (`git` is a hard preflight


### PR DESCRIPTION
## What this fixes

`scripts/prompt-surface-growth.py`'s docstring named the repo-relative spelling as the
invocation form and the vendored literal as a parenthetical alternative. That ordering is
inverted for the cloud tier, where only `Bash(.prflow/vendor/prflow/scripts/prompt-surface-growth.py:*)`
is granted (in the `implement` and `command` profiles). A run following the docstring order
leads with a form no profile grants and spends a permission denial before reaching one that works.

This PR reorders the docstring to the ladder `.prflow/prompt-extensions/pr-description.md`
already prescribes: vendored literal first, repo-relative fallback only where that path does
not resolve. **Docstring only — no behaviour change, no grant change, no generated artifact touched.**

### Evidence

Across the five uninterrupted cloud implement runs, every one led with the ungranted rung and
was denied; each then reached a working form afterwards. Per-run first attempt, from the
`claude-execution-transcript` artifacts:

| Run | First attempt | Result |
|---|---|---|
| 32957163134 | `cd …; scripts/prompt-surface-growth.py` | denied |
| 32947740578 | `scripts/prompt-surface-growth.py 2>&1; echo …` | denied (×3) |
| 32936014504 | `cd …; scripts/prompt-surface-growth.py` | denied (×2) |
| 32929107360 | `cd …; scripts/prompt-surface-growth.py \| head` | denied (×3) |
| 32914809551 | `(scripts/prompt-surface-growth.py …)` | denied (×2) |

## Scope

**No grant was added.** The repo-relative spelling stays ungranted by design — it is the
anchor-fallback ladder's second rung, kept ungranted so the vendored literal is the cloud
path. The `review` profile literal and `lib/review-profile.tokens` are untouched.

**No claim is made about the `python3 <path>` interpreter-head shape.** An earlier revision of
this PR replaced the docstring's "is denied by the cloud permission matcher" sentence with an
affirmative correction, on the strength of two runs that had executed
`python3 scripts/prompt-surface-growth.py` to a result. Review 5032077983 raised that as
Critical and it is **accepted and actioned**: two successful observations do not establish the
shape's behaviour, and the original denial claim is equally unestablished from that evidence.
The sentence is therefore **removed rather than replaced** — the docstring now asserts nothing
in either direction, and the question is being settled empirically via
`.github/workflows/matcher-probe.yml` before anything is written down. Nothing outside this
file was swept: the repo-wide #401/#789 interpreter-head rule in `CLAUDE.md` and
`docs/internal/cloud-allowlist.md` is untouched.

**The redirect finding is already documented, so nothing was added for it.** The same denial
analysis showed `>` refused to in-repo paths (`Output redirection to '…/.prflow/tmp/…' was
blocked … may only write to files in the allowed working directories:
'/home/runner/work/prflow/prflow'` — a target inside the directory named as allowed).
`docs/internal/cloud-allowlist.md` already records this under *"The redirect-into-`.prflow/tmp/**`
rows are QUALIFIED by field evidence (issue #1721)"*, including the counter-intuitive part
("the guard is on the construct, not the destination"). These runs corroborate that section
rather than changing it.

## Verification

- `ruff check scripts/prompt-surface-growth.py` — All checks passed
- `lib/test/test_python_scripts.py` (the coverage-map `focused_test` for this file) — 6100 passed,
  29 failed; all 29 carry `#1655` and are the known environment-only local set, green on CI at
  the same commit. A docstring edit touches no assertion in that set.
- CI green on both earlier heads of this branch: `618e89271` (run 32982051406) and `5e96b209f`
  (run 32983214480), each with `lib + python tests` and `lint (shellcheck + actionlint + ruff)`
  passing plus all five shards.

Writing-skills evidence: skill-loaded=no (no `skills/**` file is touched — the change is a
docstring in `scripts/`, outside the skill prose surface the mandate governs);
guidance-applied=no (same reason); pressure-scenario=no (same reason); micro-tests=no (the
covering focused test was run instead, as the change is to a Python helper, not skill prose).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
