### PR TITLE
fix: name the monolith shard runner at the mid-iteration decision point

### DIFF
--- a/.changeset/monolith-iteration-selection-name.md
+++ b/.changeset/monolith-iteration-selection-name.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Name the `monolith` shard runner in the implement extension's repo-specific command table, so a `run.sh`-resident surface iterating mid-run selects `lib/test/run-shard.sh monolith` instead of the whole-suite coordinator.

--- a/.prflow/prompt-extensions/implement.md
+++ b/.prflow/prompt-extensions/implement.md
@@ -100,7 +100,10 @@ extension was lost to compaction still reads a phase-file sentence sufficient to
 shape.
 
 - **The project's own test command** is `lib/test/run.sh` (the serial primitive) and, for the whole
-  suite, `lib/test/run-parallel.sh`; a focused surface uses `lib/test/run-module.sh <module-id>`.
+  suite, `lib/test/run-parallel.sh`; a focused surface uses `lib/test/run-module.sh <module-id>`, and
+  the `monolith` result named above is `lib/test/run-shard.sh monolith`. Select the whole-suite
+  coordinator only for the Phase 4.3 obligation — selecting it to iterate pays the whole-suite cost
+  twice in one run.
 - **The project's own relocation check** is `lib/test/pin-corpus-lint.py --reloc`, which turns a
   bare `ABSENT` pin into `relocated to <file>` and fails closed on a genuine deletion or an
   unresolvable search set. It has no direct-token grant on the cloud implement tier and


### PR DESCRIPTION
## What

Names `lib/test/run-shard.sh monolith` in the implement extension's repo-specific command table, and marks the whole-suite coordinator as the Phase 4.3 instrument rather than an iteration one.

## Why

Measured across five uninterrupted cloud implement runs:

| Run | Issue | Mid-iteration launch | Cost |
|---|---|---|---|
| 32947740578 | #1993 | `run-parallel.sh` in P2 **and** at the P4 gate | 16.4 m + 16.6 m of a 79 m run |
| 32936014504 | #1985 | `run-parallel.sh` in P2 **and** at the P4 gate | 16.5 m + 16.8 m of a 79 m run |
| 32957163134 | #742 | 3x `run-shard.sh monolith` | 6.7 m each — correct |

This is a compliance gap, not a design change. The policy already exists in two places:

- `CLAUDE.md`'s issue-#1253 bullet authorizes the `monolith` instrument for a `run.sh`-resident surface and carries its four limits.
- This extension already states that "A focused or `monolith` result iterates".

What was missing is **name resolution**. The extension's repo-specific command table (the issue-#1072 relocation destination, where the phase files' deliberately generic "the project's own test command" wording resolves) listed only `run.sh`, `run-parallel.sh` and `run-module.sh`. An agent iterating on a `run.sh`-resident surface — which by definition has no focused module — read that table, found the coordinator as the only whole-file option, and launched it. It knew `monolith` iterates; it had no command to map that to.

## Placement

Per the issue-#1352 placement rule: these command names are this repository's own test harness (`lib/test/**` is pruned from the vendored plugin), so they must never ship into a consumer `skills/**` body. The rule itself is tier-scoped and stays in `CLAUDE.md` in one copy; this table supplies only the command name, consistent with its stated purpose. Nothing is duplicated across the two surfaces.

## Not changed: moving `--with-floors` off the P4 critical path

I was asked to also move `lib/test/regenerate-artifacts.py --with-floors` (2.0–2.7 m, run immediately before the completion gate) off the critical path, and to decline if the in-run catch is load-bearing. **It is load-bearing — declining.**

- 14 modules carry `assertion_floor_policy: "exact"`, several large and frequently touched (`efficiency-trace-telemetry` 994, `review-trigger-helpers` 844, `create-issue-contract` 397, `installer-wiring` 305).
- `test_module_runner.py` on CI executes the full exact-policy population and enforces **equality**, not `>=`. Any run that adds an assertion to one of those modules goes CI-RED unless the floor was raised.
- So the "saving" is 2.5 minutes traded for a full CI round-trip whenever a floor actually needs raising — and per the helper's own exit-2 semantics the recovery is a coupled two-site hand-edit (`scripts/workflow-flight-recorder-registry.json` plus its `lib/test/run.sh` operands, which move as one unit).
- It also cannot simply move: the extension explicitly rejects running it per-batch ("spends most of an iteration re-measuring a tree that keeps changing"), and it cannot run concurrently with the gate because it **writes** to the tree the suite reads.

The existing prose already states this tradeoff honestly. Net loss; no change made.

## Verification

- `lib/test/lint-reference-size.py` — green (rc 0, 82 of 325 files audited). The extension is not boundary-gated and sits at 29 KB against the 61,750-byte ceiling.
- `lib/test/run-shard.sh monolith` — the covering surface, since the extension's content is pinned by `run.sh`-resident blocks (`$WSR_IMPL`). **9984 passed, 1 failed, 1 skipped.**
  - The one failure is `#1621 ruff Python-lint gate` (54 errors) and is **environmental, not from this change**: local ruff is 0.15.21 while the repo pins `ruff==0.16.*` (adopted in the top commit, #742). This diff touches zero `.py` files.
  - The one skip is the `#434` stale-prose `blocking-gate` on a dirty tree — expected mid-iteration; the tree is now committed.
- No pin asserts the edited sentence (checked `$WSR_IMPL` pins and the `run-module.sh <module-id>` literal across `lib/test/`); the `#810` corpus is untouched.
- CI is the completion gate for this local-tier change — status below.

Writing-skills evidence: skill-loaded=no (no `skills/**` file is touched — the change is confined to the repo-local prompt extension and a changeset, so the prompt-surface edit routing that mandates the skill does not arm); guidance-applied=yes (applied the instruction-plus-consequence prose rule — one instruction, one consequence clause — and the issue-#1352 placement rule, which is what kept this out of a shipped skill body); pressure-scenario=no (not a shipped skill body; the gate asks for a stated disposition, not the cycle); micro-tests=no (prose with no executable behavior of its own — the asserting surface is the existing `$WSR_IMPL` pin set, which was checked and is unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
