### PR TITLE
ci: keep the judge changeable, and let ordinary pull requests merge

### DIFF
--- a/.github/workflows/distribution-verify.yml
+++ b/.github/workflows/distribution-verify.yml
@@ -70,6 +70,18 @@ jobs:
             exit 1
           fi
 
+          # A policy-update/* branch exists to CHANGE the judge, so a diff is its
+          # purpose, not a violation. Without this arm the judge becomes permanently
+          # unchangeable the moment it is required: every pull request that touches
+          # it fails, including the ceremony documented for changing it. The control
+          # here is that such a branch is judged by the PREVIOUS base verifier and
+          # reviewed by a human - not that the diff is forbidden.
+          case "$HEAD_REF" in
+            policy-update/*)
+              echo "::notice::policy-update branch: a judge change is this branch's purpose. It is evaluated by the base verifier and requires human review."
+              exit 0 ;;
+          esac
+
           status=0
           for f in $judge; do
             if ! git diff --quiet "${BASE_SHA}" HEAD -- "${f}"; then
@@ -82,6 +94,7 @@ jobs:
       - name: Verify the release artifact
         env:
           HEAD_REF: ${{ github.event.pull_request.head.ref || github.ref_name }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
         run: |
           set -euo pipefail
           # A tree carrying no .release/ metadata is not a release candidate. That
@@ -99,6 +112,17 @@ jobs:
                 exit 0 ;;
             esac
           fi
+          # Once a release has landed, main carries .release/files.sha256 and EVERY
+          # edited file is a digest mismatch. Full artifact verification therefore
+          # belongs to what is actually being published - a release branch, or main
+          # itself - and not to an ordinary pull request, which would otherwise be
+          # unmergeable for changing so much as a typo.
+          case "${GITHUB_EVENT_NAME}:${HEAD_REF}" in
+            pull_request:release/*|push:*) : ;;
+            pull_request:*)
+              echo "::notice::not a release branch: the digest manifest describes the published release, so an ordinary pull request is not verified against it."
+              exit 0 ;;
+          esac
           # The candidate is DATA. Copy the tree without its .git directory and
           # verify that copy, so no candidate code is imported or executed.
           candidate="$(mktemp -d)/candidate"


### PR DESCRIPTION
A **policy-update** change: it modifies the verification workflow itself, so it lands on
its own, judged by the verifier currently on `main` rather than by the one it installs.

An adversarial audit of the cutover plan found two defects, both of which would have
taken effect the moment `distribution-verify` became the required status check.

### 1. The judge could never be changed again

The `policy-update/*` ceremony documented for changing the verifier **existed only in
prose**. In code, the branch exemption fired solely when *no part* of the judge was on
base. Once installed, every pull request touching it would fail — including the ceremony
meant to change it. The repository would have been permanently unable to update its own
verification logic except by an admin bypass or by removing the required check, i.e. the
exact controls this design exists to tighten.

There is now an arm for it. The control is that such a branch is judged by the
**previous** base verifier and requires human review — not that the diff is forbidden.

### 2. Any ordinary pull request would have been unmergeable

Once a release lands, `main` carries `.release/files.sha256`, and the verifier reports a
digest mismatch for **every edited file**. A README typo or a community patch would have
failed the required check with no way to pass it.

Full artifact verification is now scoped to what is actually being published — a
`release/*` branch, or a push to `main`. An ordinary pull request is exempted with a
stated notice rather than silently skipped.

### Why now

The pending release candidate carried these fixes, and the base-equality rule correctly
refused it: a release must not change its own judge. Landing them here first means the
release can then carry judge bytes **identical to base**, which is precisely what lets it
be judged by a verifier it cannot modify.