### PR TITLE
ci: a fork can no longer take the judge-change exemption

### DIFF
--- a/.github/verify-release.py
+++ b/.github/verify-release.py
@@ -106,7 +106,11 @@ LEAK_PATTERNS = (
      "private key block"),
     (re.compile(r"\bgh[pousr]_[A-Za-z0-9]{16,}"), "GitHub token"),
     (re.compile(r"\bsk-ant-[A-Za-z0-9-]{16,}"), "Anthropic API key"),
-    (re.compile(r"\bRadman-LLC/prflow-dev\b"), "private repository reference"),
+    # Assembled from fragments for the same reason the allowlist keys are: spelling
+    # the private repository as one literal publishes the very name this pattern
+    # exists to keep out of the release.
+    (re.compile(r"\b" + "Radman" + "-LLC/prflow" + "-dev" + r"\b"),
+     "private repository reference"),
 )
 
 # Reviewed, benign matches. Each entry is (path, matched text, reason) and

--- a/.github/workflows/distribution-verify.yml
+++ b/.github/workflows/distribution-verify.yml
@@ -43,6 +43,10 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          # A fork chooses its own branch name, so a branch-name test is NOT an
+          # identity test. Every exemption below is gated on the pull request
+          # coming from this repository; a fork always takes the strict path.
+          IS_SAME_REPO: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         run: |
           set -euo pipefail
           judge=".github/verify-release.py .github/workflows/distribution-verify.yml"
@@ -56,8 +60,8 @@ jobs:
             if git cat-file -e "${BASE_SHA}:${f}" 2>/dev/null; then present=$((present+1)); else absent=$((absent+1)); fi
           done
           if [ "$present" -eq 0 ]; then
-            case "$HEAD_REF" in
-              policy-update/*)
+            case "${IS_SAME_REPO}:${HEAD_REF}" in
+              true:policy-update/*)
                 echo "::notice::bootstrap: the judge is absent from the protected base and this is a policy-update branch introducing it. Comparison skipped for this pull request only."
                 exit 0 ;;
               *)
@@ -76,9 +80,9 @@ jobs:
           # it fails, including the ceremony documented for changing it. The control
           # here is that such a branch is judged by the PREVIOUS base verifier and
           # reviewed by a human - not that the diff is forbidden.
-          case "$HEAD_REF" in
-            policy-update/*)
-              echo "::notice::policy-update branch: a judge change is this branch's purpose. It is evaluated by the base verifier and requires human review."
+          case "${IS_SAME_REPO}:${HEAD_REF}" in
+            true:policy-update/*)
+              echo "::notice::policy-update branch in this repository: a judge change is this branch's purpose. It is evaluated by the base verifier and requires human review."
               exit 0 ;;
           esac
 
@@ -95,6 +99,7 @@ jobs:
         env:
           HEAD_REF: ${{ github.event.pull_request.head.ref || github.ref_name }}
           GITHUB_EVENT_NAME: ${{ github.event_name }}
+          IS_SAME_REPO: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         run: |
           set -euo pipefail
           # A tree carrying no .release/ metadata is not a release candidate. That
@@ -117,9 +122,9 @@ jobs:
           # belongs to what is actually being published - a release branch, or main
           # itself - and not to an ordinary pull request, which would otherwise be
           # unmergeable for changing so much as a typo.
-          case "${GITHUB_EVENT_NAME}:${HEAD_REF}" in
-            pull_request:release/*|push:*) : ;;
-            pull_request:*)
+          case "${GITHUB_EVENT_NAME}:${IS_SAME_REPO}:${HEAD_REF}" in
+            pull_request:*:release/*|push:*:*) : ;;
+            pull_request:true:*)
               echo "::notice::not a release branch: the digest manifest describes the published release, so an ordinary pull request is not verified against it."
               exit 0 ;;
           esac


### PR DESCRIPTION
A **policy-update** change: it modifies the release verifier and its workflow, so it lands on its own and is judged by the verifier currently on `main`.

## The bug

The exemption that lets a maintainer change the verifier keyed on the **branch name**:

```
case "$HEAD_REF" in
  policy-update/*) exit 0 ;;
esac
```

`HEAD_REF` is `github.event.pull_request.head.ref` — and **a fork chooses its own branch names**. A pull request from a fork on a branch called `policy-update/anything` skipped the judge comparison *and* then skipped artifact verification, reporting the required check **green on a tree that was never verified**.

With `required_approving_review_count: 0`, nothing automated stood between such a pull request and a merge. The workflow's own header comment — "a PR cannot edit the judge that evaluates it" — was not true as written.

## The fix

Every exemption is now gated on an identity the head cannot forge:

```
IS_SAME_REPO: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
```

A fork always takes the strict path — judge comparison enforced, artifact verification enforced.

## Also

The private repository's name was published verbatim in the verifier's own leak pattern — the single control built to keep that string out of the release. It did not self-trip only because the character preceding it is the `b` of `\b`. It is now assembled from fragments, as the allowlist keys already were, and still detects a real occurrence.