### PR TITLE
policy-update: sync release verifier for v2.39.48

### DIFF
--- a/.github/verify-release.py
+++ b/.github/verify-release.py
@@ -70,7 +70,8 @@ FORBIDDEN_EXACT = frozenset({
 FORBIDDEN_PREFIXES = (
     ".git/", ".claude/", ".codex/", ".changeset/",
     "lib/test/", "docs/internal/", "docs/site/",
-    ".prflow/learnings/", ".prflow/logs/", ".prflow/prompt-extensions/",
+    ".prflow/learnings/", ".prflow/logs/",
+    ".prflow/skill-extensions/", ".prflow/prompt-extensions/",
 )
 # Development workflows that must never reach the distribution repo. The two
 # consumer workflows (devflow.yml, devflow-implement.yml) are distribution assets
@@ -79,7 +80,7 @@ FORBIDDEN_WORKFLOWS = frozenset({
     "ci.yml", "matcher-probe.yml", "version-consolidate.yml",
     "mintlify-check.yml", "agents-seam-probe.yml",
     "devflow-runner.yml", "telemetry-push.yml", "devflow-review.yml",
-    "internal-larger-runner-canary.yml",
+    "internal-larger-runner-canary.yml", "rotate-claude-token.yml",
 })
 
 # Windows reserved device names: a checkout carrying one of these cannot be


### PR DESCRIPTION
Two-path `policy-update/*` PR that syncs the public release verifier ahead of the **v2.39.48** release, per the distribution-verify ceremony (judged by the *previous* base verifier + human review).

**Change** (`.github/verify-release.py`, a byte-projection of private `tools/carry-on/verify_public_release.py`):
- Add `.prflow/skill-extensions/` to the private-path prefix set (the shipped rename; `.prflow/prompt-extensions/` retained during transition).
- Add `rotate-claude-token.yml` to the internal-only workflow set.

`.github/workflows/distribution-verify.yml` is unchanged from base.

Expected: after merge, `main` is red on `distribution-verify` until the v2.39.48 release republishes `.release/` (§19.16) — the tagged release is unaffected.
